### PR TITLE
Seanw/value dashboard

### DIFF
--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -232,6 +232,56 @@ document.getElementById('nav-reset-onboarding').addEventListener('click', (e) =>
 });
 
 // ================================================================
+// Historical enrichment wiring
+// ================================================================
+function getSelectedLookback() {
+    const sel = document.getElementById('lookback-select');
+    if (!sel) return 3;
+    const val = parseInt(sel.value, 10);
+    return Number.isFinite(val) ? val : 3;
+}
+
+function onEnrichmentProgress(state) {
+    const banner = document.getElementById('enrichment-banner');
+    if (banner && state.state === 'loading') {
+        const bar = banner.querySelector('.enrichment-progress-bar');
+        const text = banner.querySelector('.enrichment-text');
+        if (bar) bar.style.width = state.progress + '%';
+        if (text) text.innerHTML = `Loading historical data&hellip; ${(state.tasksFetched || 0).toLocaleString()} tasks`;
+    }
+
+    if (state.state === 'complete' || state.state === 'error') {
+        const view = Router.getCurrentView();
+        if (view === 'overview' || view === 'trends' || view === 'velocity') {
+            Router.refresh();
+            if (view === 'overview' && _lastSummary) {
+                renderValueImpact(_lastSummary);
+            }
+        }
+    }
+}
+
+function startEnrichment() {
+    const months = getSelectedLookback();
+    debug('Starting historical enrichment', { lookbackMonths: months });
+    DashboardData.startHistoricalEnrichment(months, onEnrichmentProgress);
+}
+
+// Wire lookback dropdown
+document.getElementById('lookback-select').addEventListener('change', () => {
+    const months = getSelectedLookback();
+    if (months > 12 || months === 0) {
+        const label = months === 0 ? 'all time' : `${months / 12} years`;
+        if (!confirm(`Fetching ${label} of data may take a while and could be heavy on large Octopus instances.\n\nContinue?`)) {
+            document.getElementById('lookback-select').value = '12';
+            return;
+        }
+    }
+    DashboardData.clearHistoryCache();
+    startEnrichment();
+});
+
+// ================================================================
 // Override DashboardUI.loadDashboard to also render value impact
 // and refresh the current view after data loads
 // ================================================================
@@ -247,6 +297,8 @@ DashboardUI.loadDashboard = async function() {
     } else {
         Router.refresh();
     }
+
+    startEnrichment();
 };
 
 // ================================================================
@@ -295,6 +347,8 @@ updateRefreshTime();
 
 document.getElementById('btn-refresh').addEventListener('click', () => {
     updateRefreshTime();
+    DashboardData.cancelEnrichment();
+    DashboardData.clearHistoryCache();
     DashboardUI.loadDashboard();
 });
 

--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -267,18 +267,23 @@ function startEnrichment() {
     DashboardData.startHistoricalEnrichment(months, onEnrichmentProgress);
 }
 
+// Track last confirmed lookback so we can restore it on cancel
+let lastConfirmedLookbackMonths = getSelectedLookback();
+
 // Wire lookback dropdown
 document.getElementById('lookback-select').addEventListener('change', () => {
+    const previousMonths = lastConfirmedLookbackMonths;
     const months = getSelectedLookback();
     if (months > 12 || months === 0) {
         const label = months === 0 ? 'all time' : `${months / 12} years`;
         if (!confirm(`Fetching ${label} of data may take a while and could be heavy on large Octopus instances.\n\nContinue?`)) {
-            document.getElementById('lookback-select').value = '12';
+            document.getElementById('lookback-select').value = String(previousMonths);
             return;
         }
     }
     DashboardData.clearHistoryCache();
     startEnrichment();
+    lastConfirmedLookbackMonths = months;
 });
 
 // ================================================================

--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -271,6 +271,10 @@ function startEnrichment() {
 let lastConfirmedLookbackMonths = getSelectedLookback();
 
 // Wire lookback dropdown
+// Track last confirmed lookback so we can restore it on cancel
+let lastConfirmedLookbackMonths = getSelectedLookback();
+
+// Wire lookback dropdown
 document.getElementById('lookback-select').addEventListener('change', () => {
     const previousMonths = lastConfirmedLookbackMonths;
     const months = getSelectedLookback();
@@ -283,6 +287,7 @@ document.getElementById('lookback-select').addEventListener('change', () => {
     }
     DashboardData.clearHistoryCache();
     startEnrichment();
+    lastConfirmedLookbackMonths = months;
     lastConfirmedLookbackMonths = months;
 });
 

--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -404,7 +404,6 @@ function formatCSV(data) {
     row('Total Targets', data.kpi.totalTargets);
     row('Healthy Targets', data.kpi.healthyTargetsPct + '%');
     row('Total Releases', data.kpi.totalReleases);
-    row('Time Saved (est. hrs)', data.kpi.timeSavedHours);
     lines.push('');
 
     if (data.valueImpact) {

--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -242,12 +242,25 @@ function getSelectedLookback() {
 }
 
 function onEnrichmentProgress(state) {
-    const banner = document.getElementById('enrichment-banner');
-    if (banner && state.state === 'loading') {
-        const bar = banner.querySelector('.enrichment-progress-bar');
-        const text = banner.querySelector('.enrichment-text');
-        if (bar) bar.style.width = state.progress + '%';
-        if (text) text.innerHTML = `Loading historical data&hellip; ${(state.tasksFetched || 0).toLocaleString()} tasks`;
+    // Ensure the enrichment banner exists when we first enter "loading"
+    if (state.state === 'loading') {
+        const view = Router.getCurrentView();
+        const shouldShowBanner = (view === 'overview' || view === 'trends' || view === 'velocity');
+        let banner = document.getElementById('enrichment-banner');
+
+        // On first load the banner may not yet be in the DOM; force a refresh so
+        // the view re-renders with the banner, then rely on subsequent progress events.
+        if (shouldShowBanner && !banner) {
+            Router.refresh();
+            return;
+        }
+
+        if (banner) {
+            const bar = banner.querySelector('.enrichment-progress-bar');
+            const text = banner.querySelector('.enrichment-text');
+            if (bar) bar.style.width = state.progress + '%';
+            if (text) text.innerHTML = `Loading historical data&hellip; ${(state.tasksFetched || 0).toLocaleString()} tasks`;
+        }
     }
 
     if (state.state === 'complete' || state.state === 'error') {

--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -371,6 +371,7 @@ function assembleExportData() {
             spaces: e.spaces,
         })),
         weeklyTrend: summary.weeklyTrend,
+        dailyTrend: summary.dailyTrend,
         licenseInfo: summary.licenseInfo,
     };
 }
@@ -449,6 +450,13 @@ function formatCSV(data) {
     row('Environment', 'Success', 'Failed', 'Total', 'Success Rate', 'Spaces');
     for (const e of data.envHealth) {
         row(e.environment, e.success, e.failed, e.total, e.successRate, e.spaces.join('; '));
+    }
+    lines.push('');
+
+    lines.push('# Daily Deployment Trend (last 30 UTC days)');
+    row('Date (UTC)', 'Total', 'Success', 'Failed');
+    for (const d of (data.dailyTrend || [])) {
+        row(d.dateKey, d.total, d.success, d.failed);
     }
     lines.push('');
 

--- a/dashboards/valuemetrics/dashboard.js
+++ b/dashboards/valuemetrics/dashboard.js
@@ -271,10 +271,6 @@ function startEnrichment() {
 let lastConfirmedLookbackMonths = getSelectedLookback();
 
 // Wire lookback dropdown
-// Track last confirmed lookback so we can restore it on cancel
-let lastConfirmedLookbackMonths = getSelectedLookback();
-
-// Wire lookback dropdown
 document.getElementById('lookback-select').addEventListener('change', () => {
     const previousMonths = lastConfirmedLookbackMonths;
     const months = getSelectedLookback();

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -8,6 +8,7 @@
      GET /api                                        → Server info & version
      GET /api/spaces?take=100                        → All spaces
      GET /api/licenses/licenses-current-usage        → Per-space project/tenant/machine counts
+     GET /api/{spaceId}/teams/all                    → Teams (membership & scoping; needs TeamView)
      GET /api/{spaceId}/projects?take=1000           → Projects per space
      GET /api/{spaceId}/environments?take=100        → Environments per space
      GET /api/{spaceId}/environments/summary         → Machine / target health summary
@@ -179,6 +180,21 @@ const DashboardData = (() => {
       safeGet(`/api/${sid}/runbooks?take=0`),
     ]);
 
+    // Teams: use real errors (not safeGet) so we can tell 403 from “no teams”
+    let teams = [];
+    let teamsAccess = 'ok';
+    try {
+      const teamsRaw = await OctopusApi.get(`/api/${sid}/teams/all`);
+      teams = normalizeTeamsList(teamsRaw);
+    } catch (err) {
+      const st = err && err.status;
+      if (st === 401 || st === 403) teamsAccess = 'denied';
+      else {
+        teamsAccess = 'error';
+        log(`${space.Name}: teams fetch failed`, err.message || err);
+      }
+    }
+
     // Build project name lookup
     const projectNames = {};
     for (const p of (projects?.Items || [])) {
@@ -210,6 +226,8 @@ const DashboardData = (() => {
       machineHealth,
       releaseCount: releasesResp?.TotalResults || 0,
       runbookCount: runbooksResp?.TotalResults || 0,
+      teams,
+      teamsAccess,
     };
   }
 
@@ -223,6 +241,14 @@ const DashboardData = (() => {
       if (err.message && err.message.includes('deprecated')) return null;
       throw err;
     }
+  }
+
+  /** Normalize Octopus list responses (some `/all` routes return a raw array, others `{ Items }`). */
+  function normalizeTeamsList(raw) {
+    if (raw == null) return [];
+    if (Array.isArray(raw)) return raw;
+    if (Array.isArray(raw.Items)) return raw.Items;
+    return [];
   }
 
   // ---- Aggregation / Summary ----
@@ -407,6 +433,53 @@ const DashboardData = (() => {
       hostingEnv: _licenseStatus?.HostingEnvironment,
     };
 
+    // Teams (per-space fetch in fetchSpaceData)
+    const teamRows = [];
+    let teamsAnyDenied = false;
+    let teamsAnyOkFetch = false;
+    let teamsAnyError = false;
+    for (const [spaceId, data] of Object.entries(_spaceData)) {
+      const acc = data.teamsAccess || 'ok';
+      if (acc === 'denied') teamsAnyDenied = true;
+      else if (acc === 'error') teamsAnyError = true;
+      else teamsAnyOkFetch = true;
+
+      const spaceName = data.space?.Name || spaceId;
+      for (const t of (data.teams || [])) {
+        const unrestricted = !t.ProjectIds || t.ProjectIds.length === 0;
+        const projSet = unrestricted ? null : new Set(t.ProjectIds);
+        let recentDeploysInScope = 0;
+        for (const d of (data.deployments || [])) {
+          if (unrestricted || projSet.has(d.ProjectId)) recentDeploysInScope++;
+        }
+        const scopedRoles = t.SpaceTeamScopedUserRoles || t.spaceTeamScopedUserRoles || [];
+        const roleN = Array.isArray(scopedRoles) ? scopedRoles.length : 0;
+        teamRows.push({
+          spaceId,
+          spaceName,
+          id: t.Id,
+          name: t.Name || '—',
+          memberCount: (t.MemberUserIds || []).length,
+          projectsLabel: unrestricted ? 'All projects' : String(t.ProjectIds.length),
+          envScopeLabel: (t.EnvironmentIds && t.EnvironmentIds.length) ? String(t.EnvironmentIds.length) : '—',
+          scopedRoles: roleN,
+          recentDeploysInScope,
+        });
+      }
+    }
+    teamRows.sort((a, b) => {
+      const s = (a.spaceName || '').localeCompare(b.spaceName || '');
+      if (s !== 0) return s;
+      return (a.name || '').localeCompare(b.name || '');
+    });
+    const teamsInsight = {
+      rows: teamRows,
+      totalTeams: teamRows.length,
+      anyDenied: teamsAnyDenied,
+      anyOkFetch: teamsAnyOkFetch,
+      anyError: teamsAnyError,
+    };
+
     return {
       serverInfo: _serverInfo,
       lastFetch: _lastFetch,
@@ -451,6 +524,8 @@ const DashboardData = (() => {
       successCount: totalSuccessful,
       failedCount: totalFailed,
       cancelledCount: totalCancelled,
+
+      teamsInsight,
     };
   }
 

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -884,6 +884,55 @@ const DashboardUI = (() => {
       .slice(-12);
   }
 
+  const _ISO_WEEK_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  /** Monday 00:00 UTC of ISO week `isoWeek` in ISO week-year `isoYear`. */
+  function getIsoWeekMondayUTC(isoYear, isoWeek) {
+    const jan4 = new Date(Date.UTC(isoYear, 0, 4));
+    const dow = jan4.getUTCDay() || 7;
+    const monday = new Date(jan4);
+    monday.setUTCDate(jan4.getUTCDate() - dow + 1 + (isoWeek - 1) * 7);
+    return monday;
+  }
+
+  /** e.g. 129 → "129", 12_400 → "12.4K" (exact value stays in tooltip). */
+  function formatCompactCount(n) {
+    const x = Number(n);
+    if (!Number.isFinite(x)) return '0';
+    return new Intl.NumberFormat('en-AU', { notation: 'compact', maximumFractionDigits: 2 }).format(x);
+  }
+
+  /** Max stacked bar height in px (sqrt-scaled; cap keeps charts readable). */
+  const TREND_BAR_MAX_PX = 168;
+
+  /**
+   * Pixel height for one column’s stacked bar (sqrt scale vs max in view).
+   */
+  function trendBarPixelHeight(total, maxTotal, maxPx = TREND_BAR_MAX_PX) {
+    const t = Math.max(0, Number(total) || 0);
+    const mx = Math.max(1, Number(maxTotal) || 0);
+    if (t <= 0) return 0;
+    const h = (Math.sqrt(t) / Math.sqrt(mx)) * maxPx;
+    return Math.max(4, Math.round(h));
+  }
+
+  /** Calendar span for chart copy, e.g. "3–9 Mar 2026" (Mon–Sun of that ISO week, UTC). */
+  function formatIsoWeekDateRange(isoYear, isoWeek) {
+    const monday = getIsoWeekMondayUTC(isoYear, isoWeek);
+    const sunday = new Date(monday);
+    sunday.setUTCDate(monday.getUTCDate() + 6);
+    const d1 = monday.getUTCDate();
+    const d2 = sunday.getUTCDate();
+    const m1 = monday.getUTCMonth();
+    const m2 = sunday.getUTCMonth();
+    const y1 = monday.getUTCFullYear();
+    const y2 = sunday.getUTCFullYear();
+    const M = _ISO_WEEK_MONTHS;
+    if (y1 === y2 && m1 === m2) return `${d1}–${d2} ${M[m1]} ${y1}`;
+    if (y1 === y2) return `${d1} ${M[m1]} – ${d2} ${M[m2]} ${y2}`;
+    return `${d1} ${M[m1]} ${y1} – ${d2} ${M[m2]} ${y2}`;
+  }
+
   function renderWeeklyTrend(weeklyTrend, range) {
     if (weeklyTrend) _fullWeeklyTrend = weeklyTrend;
     if (range) _currentRange = range;
@@ -900,19 +949,22 @@ const DashboardUI = (() => {
         success: m.success,
         failed: m.failed,
         label: MONTH_NAMES[m.month] + (m.month === 0 ? '<br>' + m.year : ''),
-        tooltip: `${MONTH_NAMES[m.month]} ${m.year}: ${m.total} deployments (${m.success} success, ${m.failed} failed, ${m.total - m.success - m.failed} other)`,
+        tooltip: _tooltipAttr(`${MONTH_NAMES[m.month]} ${m.year}: ${m.total} deployments (${m.success} success, ${m.failed} failed, ${m.total - m.success - m.failed} other)`),
       }));
     } else {
       const weeksToShow = _currentRange === '90d' ? 13 : 5;
       const sliced = _fullWeeklyTrend.slice(-weeksToShow);
       bars = sliced.map((w, i) => {
         const showYear = (i === 0) || (sliced[i - 1] && sliced[i - 1].year !== w.year);
+        const rangeStr = formatIsoWeekDateRange(w.year, w.week);
+        const counts = `${w.total} deployments (${w.success} success, ${w.failed} failed, ${w.total - w.success - w.failed} other)`;
+        const tip = `${rangeStr} · ISO week ${w.week}, ${w.year} (Mon–Sun, UTC). ${counts}`;
         return {
           total: w.total,
           success: w.success,
           failed: w.failed,
           label: `W${w.week}${showYear ? '<br>' + w.year : ''}`,
-          tooltip: `Week ${w.week}, ${w.year}: ${w.total} deployments (${w.success} success, ${w.failed} failed, ${w.total - w.success - w.failed} other)`,
+          tooltip: _tooltipAttr(tip),
         };
       });
     }
@@ -929,23 +981,31 @@ const DashboardUI = (() => {
     const maxTotal = Math.max(...bars.map(b => b.total), 1);
 
     el.innerHTML = `
-      <div style="width:100%;overflow-x:auto;">
-        <div style="display:flex;align-items:flex-end;gap:6px;height:200px;padding:0 var(--space-xs);">
+      <div class="deployment-trend-chart">
+        <div class="deployment-trend-bars" style="gap:6px;padding:0 var(--space-xs);">
           ${bars.map(b => {
-            const h = Math.max(4, (b.total / maxTotal) * 180);
-            const successH = b.total > 0 ? (b.success / b.total * h) : 0;
-            const failH = b.total > 0 ? (b.failed / b.total * h) : 0;
-            const otherH = h - successH - failH;
+            const t = b.total;
+            const hPx = trendBarPixelHeight(t, maxTotal);
+            let failH = 0;
+            let otherH = 0;
+            let succH = 0;
+            if (t > 0 && hPx > 0) {
+              failH = Math.round((b.failed / t) * hPx);
+              succH = Math.round((b.success / t) * hPx);
+              otherH = Math.max(0, hPx - failH - succH);
+            }
             const topSegment = failH > 0 ? 'fail' : (otherH > 0 ? 'other' : 'success');
             return `
-              <div style="display:flex;flex-direction:column;align-items:center;flex:1;min-width:28px;cursor:default;" title="${b.tooltip}">
-                <div style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);margin-bottom:4px;">${b.total}</div>
-                <div style="width:100%;max-width:40px;display:flex;flex-direction:column;">
-                  ${failH > 0 ? `<div style="height:${failH}px;background:var(--colorDanger);border-radius:${topSegment === 'fail' ? '3px 3px' : '0 0'} 0 0;"></div>` : ''}
-                  ${otherH > 0 ? `<div style="height:${otherH}px;background:var(--colorBackgroundTertiary);border-radius:${topSegment === 'other' ? '3px 3px' : '0 0'} ${successH > 0 ? '0 0' : '3px 3px'};"></div>` : ''}
-                  ${successH > 0 ? `<div style="height:${successH}px;background:var(--colorSuccess);border-radius:0 0 3px 3px;"></div>` : ''}
+              <div class="deployment-trend-col" data-tooltip="${b.tooltip}">
+                <div class="deployment-trend-value">${formatCompactCount(t)}</div>
+                <div class="deployment-trend-bar-area">
+                  <div class="deployment-trend-bar-stack" style="height:${t > 0 ? hPx : 0}px;">
+                    ${failH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--fail" style="height:${failH}px;border-radius:${topSegment === 'fail' ? '3px 3px' : '0 0'} 0 0;"></div>` : ''}
+                    ${otherH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--other" style="height:${otherH}px;border-radius:${topSegment === 'other' ? '3px 3px' : '0 0'} ${succH > 0 ? '0 0' : '3px 3px'};"></div>` : ''}
+                    ${succH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--success" style="height:${succH}px;border-radius:0 0 3px 3px;"></div>` : ''}
+                  </div>
                 </div>
-                <div style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);margin-top:4px;white-space:nowrap;text-align:center;height:2.5em;line-height:1.25em;">${b.label}</div>
+                <div class="deployment-trend-axis-label">${b.label}</div>
               </div>`;
           }).join('')}
         </div>
@@ -1014,6 +1074,10 @@ const DashboardUI = (() => {
     setTrendRange,
     // Expose helpers for views
     timeAgo,
+    formatIsoWeekDateRange,
+    formatCompactCount,
+    trendBarPixelHeight,
+    TREND_BAR_MAX_PX,
   };
 
 })();

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -426,8 +426,6 @@ const DashboardData = (() => {
         healthyTargetsPct: healthyPct,
         totalReleases,
         totalRunbooks,
-        // Estimated time saved: ~15 min saved per automated deployment vs manual
-        timeSavedHours: Math.round(totalDeploymentsCount * 15 / 60),
       },
 
       // Breakdown
@@ -609,7 +607,6 @@ const DashboardUI = (() => {
     setText('kpi-success-rate', kpi.successRate + '%');
     setText('kpi-projects', kpi.activeProjects.toLocaleString());
     setText('kpi-frequency', kpi.deployFrequency + '/day');
-    setText('kpi-time-saved', formatHours(kpi.timeSavedHours));
     setText('kpi-targets', kpi.totalTargets.toLocaleString());
     setText('kpi-target-health', kpi.healthyTargetsPct + '%');
     setText('kpi-active-spaces', kpi.activeSpaces + '/' + kpi.totalSpaces);
@@ -620,14 +617,6 @@ const DashboardUI = (() => {
     setTrendLabel('kpi-frequency-label', `last 30 days`);
     setTrendLabel('kpi-targets-label', `${kpi.healthyTargets} healthy`);
     setTrendLabel('kpi-spaces-label', `${kpi.totalSpaces} total`);
-  }
-
-  function formatHours(h) {
-    if (h >= 24) {
-      const days = Math.round(h / 8); // working days
-      return days + ' days';
-    }
-    return h + ' hrs';
   }
 
   function setTrendLabel(id, text) {
@@ -691,11 +680,21 @@ const DashboardUI = (() => {
     return parts.join(' <span class="text-tertiary" style="opacity:.4;">·</span> ') + ` <span class="text-tertiary">/ ${total}</span>`;
   }
 
+  function _tooltipAttr(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  }
+
   function healthBadge(rate, hasDeployments) {
-    if (rate >= 95) return '<span class="badge success">Healthy</span>';
-    if (rate >= 80) return '<span class="badge warning">Attention</span>';
-    if (rate < 80 && (rate > 0 || hasDeployments)) return '<span class="badge danger">At Risk</span>';
-    return '<span class="badge neutral">No data</span>';
+    if (rate >= 95) {
+      return `<span class="badge success" data-tooltip="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}">Healthy</span>`;
+    }
+    if (rate >= 80) {
+      return `<span class="badge info" data-tooltip="${_tooltipAttr('Success rate is between 80% and 94%. Worth monitoring before it drops further.')}">Attention</span>`;
+    }
+    if (rate < 80 && (rate > 0 || hasDeployments)) {
+      return `<span class="badge warning" data-tooltip="${_tooltipAttr('Success rate is below 80%, or there was deployment activity with a low success rate. Review failed deployments and trends.')}">Warning</span>`;
+    }
+    return `<span class="badge neutral" data-tooltip="${_tooltipAttr('Not enough deployment outcomes in the selected period to calculate a success rate.')}">No data</span>`;
   }
 
   // ---- Recent Deployments ----

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -983,6 +983,7 @@ const DashboardData = (() => {
 
   const ENRICH_PAGE = 200;
   const ENRICH_CAP = 10000;
+  const ENRICH_MAX_RETRIES = 3;
   const INITIAL_TAKE = 200;
   const CACHE_PFX = 'vdash_hist_';
   const CACHE_MAX_AGE = 4 * 3600 * 1000; // 4 hours
@@ -1089,7 +1090,7 @@ const DashboardData = (() => {
     const { durationBuckets, durationBucketWidth, durationStats } = agg;
     if (!durationStats || durationStats.count === 0) return null;
     const total = durationStats.count;
-    const thr = { p50: Math.floor(total * 0.5), p90: Math.floor(total * 0.9), p95: Math.floor(total * 0.95) };
+    const thr = { p50: Math.max(1, Math.ceil(total * 0.5)), p90: Math.max(1, Math.ceil(total * 0.9)), p95: Math.max(1, Math.ceil(total * 0.95)) };
     let cum = 0;
     const r = { p50: null, p90: null, p95: null };
     for (let i = 0; i < durationBuckets.length; i++) {
@@ -1133,16 +1134,22 @@ const DashboardData = (() => {
         return;
       }
 
-      const agg = _emptyAgg(lookbackMonths);
-      for (const task of _crossSpaceTasks) _accTask(agg, task);
-      _histAgg = agg;
-
       const useCutoff = !allTime;
       let cutoff = null;
       if (useCutoff) {
         cutoff = new Date();
         cutoff.setMonth(cutoff.getMonth() - lookbackMonths);
       }
+
+      const agg = _emptyAgg(lookbackMonths);
+      for (const task of _crossSpaceTasks) {
+        if (useCutoff) {
+          const td = new Date(task.CompletedTime || task.QueueTime || task.StartTime || 0);
+          if (td < cutoff) continue;
+        }
+        _accTask(agg, task);
+      }
+      _histAgg = agg;
 
       // Early-out: check if initial load already reaches the cutoff
       if (useCutoff && _crossSpaceTasks.length > 0) {
@@ -1177,20 +1184,31 @@ const DashboardData = (() => {
           if (_enrichCancelled) return;
 
           let resp;
-          try {
-            resp = await OctopusApi.get(
-              `/api/tasks?spaces=${encodeURIComponent(ids)}&name=Deploy&states=Success,Failed&take=${ENRICH_PAGE}&skip=${skip}`
-            );
-          } catch (err) {
-            if (err.status === 401 || err.status === 403) {
-              Object.assign(_enrichment, { state: 'error', error: 'Permission denied — your API key may lack TaskView permission.' });
-              notify();
-              log('Enrichment: auth/permission error', err.status);
-              return;
+          for (let attempt = 0; ; attempt++) {
+            try {
+              resp = await OctopusApi.get(
+                `/api/tasks?spaces=${encodeURIComponent(ids)}&name=Deploy&states=Success,Failed&take=${ENRICH_PAGE}&skip=${skip}`
+              );
+              break;
+            } catch (err) {
+              if (err.status === 401 || err.status === 403) {
+                Object.assign(_enrichment, { state: 'error', error: 'Permission denied — your API key may lack TaskView permission.' });
+                notify();
+                log('Enrichment: auth/permission error', err.status);
+                return;
+              }
+              if (err.status === 404) { chunkDone = true; break; }
+              if (err.status === 429 && attempt < ENRICH_MAX_RETRIES) {
+                const delay = Math.min(2000 * Math.pow(2, attempt), 16000);
+                log(`Enrichment: rate-limited (429), retrying in ${delay}ms (attempt ${attempt + 1}/${ENRICH_MAX_RETRIES})`);
+                await new Promise(r => setTimeout(r, delay));
+                if (_enrichCancelled) return;
+                continue;
+              }
+              throw err;
             }
-            if (err.status === 404) { chunkDone = true; break; }
-            throw err;
           }
+          if (chunkDone) break;
 
           if (!resp?.Items?.length) { chunkDone = true; break; }
           if (!estimatedTotal && resp.TotalResults) estimatedTotal = resp.TotalResults;

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -1277,6 +1277,11 @@ const DashboardData = (() => {
     if (!agg.weeklyBuckets || Object.keys(agg.weeklyBuckets).length === 0 || agg.totalTasksFetched === 0) {
       return null;
     }
+    // If the enrichment aggregate has no buckets or no tasks were fetched,
+    // treat this as "no enriched data" so callers fall back to base KPIs.
+    if (!agg.weeklyBuckets || Object.keys(agg.weeklyBuckets).length === 0 || agg.totalTasksFetched === 0) {
+      return null;
+    }
     let total = 0, success = 0, failed = 0;
     for (const w of Object.values(agg.weeklyBuckets)) {
       total += w.total;

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -32,11 +32,12 @@ const DashboardData = (() => {
 
   // ---- State ----
   let _spaces = [];
-  let _spaceData = {};       // keyed by space Id
+  let _spaceData = {};
   let _serverInfo = null;
   let _licenseUsage = null;
   let _licenseStatus = null;
   let _crossSpaceTasks = [];
+  let _activeSpaceIds = [];
   let _lastFetch = null;
 
   const log = (...args) => (window._debug || console.log)(...args);
@@ -102,6 +103,7 @@ const DashboardData = (() => {
     // Phase 3: Cross-space deployment tasks (may require multiple calls for many spaces)
     report('Loading deployment task history...');
     const activeSpaceIds = activeSpaces.map(s => s.Id);
+    _activeSpaceIds = activeSpaceIds;
 
     // Avoid building an excessively long query string by chunking space IDs
     const SPACE_ID_CHUNK_SIZE = 25;
@@ -974,6 +976,327 @@ const DashboardData = (() => {
     };
   }
 
+  // ---- Historical Enrichment Engine ----
+  // Pages through older deploy tasks in the background, building approximate
+  // aggregate histograms for duration percentiles and trend buckets.
+  // Aggregates are cached in localStorage so subsequent loads are near-instant.
+
+  const ENRICH_PAGE = 200;
+  const ENRICH_CAP = 10000;
+  const INITIAL_TAKE = 200;
+  const CACHE_PFX = 'vdash_hist_';
+  const CACHE_MAX_AGE = 4 * 3600 * 1000; // 4 hours
+
+  let _enrichment = { state: 'idle', lookbackMonths: 3, tasksFetched: 0, oldestDate: null, progress: 0, error: null };
+  let _enrichCancelled = false;
+  let _histAgg = null;
+
+  function _histKey() {
+    const url = OctopusApi.getInstanceUrl() || '';
+    let h = 0;
+    for (let i = 0; i < url.length; i++) { h = ((h << 5) - h) + url.charCodeAt(i); h |= 0; }
+    return CACHE_PFX + Math.abs(h).toString(36);
+  }
+
+  function _loadHistCache() {
+    try {
+      const raw = localStorage.getItem(_histKey());
+      if (!raw) return null;
+      const c = JSON.parse(raw);
+      if (c.version !== 1 || c.serverUrl !== OctopusApi.getInstanceUrl()) return null;
+      if (Date.now() - new Date(c.updatedAt).getTime() > CACHE_MAX_AGE) return null;
+      return c;
+    } catch { return null; }
+  }
+
+  function _saveHistCache(agg) {
+    try {
+      localStorage.setItem(_histKey(), JSON.stringify({
+        version: 1,
+        serverUrl: OctopusApi.getInstanceUrl(),
+        updatedAt: new Date().toISOString(),
+        lookbackMonths: agg.lookbackMonths,
+        durationBucketWidth: agg.durationBucketWidth,
+        durationBuckets: agg.durationBuckets,
+        durationStats: agg.durationStats,
+        weeklyBuckets: agg.weeklyBuckets,
+        dowCounts: agg.dowCounts,
+        hodCounts: agg.hodCounts,
+        spaceTotals: agg.spaceTotals,
+        totalTasksFetched: agg.totalTasksFetched,
+        oldestTaskDate: agg.oldestTaskDate,
+      }));
+    } catch (e) { log('History cache save failed', e.message); }
+  }
+
+  function _emptyAgg(lookbackMonths) {
+    return {
+      lookbackMonths,
+      durationBucketWidth: 30,
+      durationBuckets: new Array(120).fill(0), // 0–3600s in 30s bins
+      durationStats: { count: 0, sum: 0, min: Infinity, max: 0 },
+      weeklyBuckets: {},
+      dowCounts: new Array(7).fill(0),
+      hodCounts: new Array(24).fill(0),
+      spaceTotals: {},
+      totalTasksFetched: 0,
+      oldestTaskDate: null,
+    };
+  }
+
+  function _accTask(agg, task) {
+    if (task.StartTime && task.CompletedTime) {
+      const secs = (new Date(task.CompletedTime) - new Date(task.StartTime)) / 1000;
+      if (secs > 0 && secs < 3600) {
+        const bi = Math.min(Math.floor(secs / agg.durationBucketWidth), agg.durationBuckets.length - 1);
+        agg.durationBuckets[bi]++;
+        agg.durationStats.count++;
+        agg.durationStats.sum += secs;
+        agg.durationStats.min = Math.min(agg.durationStats.min, secs);
+        agg.durationStats.max = Math.max(agg.durationStats.max, secs);
+      }
+    }
+    const ts = task.CompletedTime || task.QueueTime;
+    if (ts) {
+      const d = new Date(ts);
+      if (!isNaN(d.getTime())) {
+        const { year, week } = getISOWeek(d);
+        const wk = `${year}-W${String(week).padStart(2, '0')}`;
+        if (!agg.weeklyBuckets[wk]) agg.weeklyBuckets[wk] = { year, week, success: 0, failed: 0, total: 0 };
+        agg.weeklyBuckets[wk].total++;
+        const st = (task.State || '').toLowerCase();
+        if (st === 'success') agg.weeklyBuckets[wk].success++;
+        else if (st === 'failed') agg.weeklyBuckets[wk].failed++;
+        agg.dowCounts[d.getUTCDay() === 0 ? 6 : d.getUTCDay() - 1]++;
+        agg.hodCounts[d.getUTCHours()]++;
+      }
+    }
+    if (task.SpaceId) {
+      if (!agg.spaceTotals[task.SpaceId]) agg.spaceTotals[task.SpaceId] = { success: 0, failed: 0, total: 0 };
+      agg.spaceTotals[task.SpaceId].total++;
+      const st = (task.State || '').toLowerCase();
+      if (st === 'success') agg.spaceTotals[task.SpaceId].success++;
+      else if (st === 'failed') agg.spaceTotals[task.SpaceId].failed++;
+    }
+    agg.totalTasksFetched++;
+    const td = task.CompletedTime || task.QueueTime || task.StartTime;
+    if (td && (!agg.oldestTaskDate || new Date(td) < new Date(agg.oldestTaskDate))) {
+      agg.oldestTaskDate = td;
+    }
+  }
+
+  function _percFromHist(agg) {
+    const { durationBuckets, durationBucketWidth, durationStats } = agg;
+    if (!durationStats || durationStats.count === 0) return null;
+    const total = durationStats.count;
+    const thr = { p50: Math.floor(total * 0.5), p90: Math.floor(total * 0.9), p95: Math.floor(total * 0.95) };
+    let cum = 0;
+    const r = { p50: null, p90: null, p95: null };
+    for (let i = 0; i < durationBuckets.length; i++) {
+      cum += durationBuckets[i];
+      const mid = Math.round((i + 0.5) * durationBucketWidth);
+      for (const [k, v] of Object.entries(thr)) { if (r[k] === null && cum >= v) r[k] = mid; }
+    }
+    return {
+      avg: Math.round(durationStats.sum / durationStats.count),
+      p50: r.p50 || 0, p90: r.p90 || 0, p95: r.p95 || 0,
+      min: Math.round(durationStats.min === Infinity ? 0 : durationStats.min),
+      max: Math.round(durationStats.max),
+      count: durationStats.count,
+    };
+  }
+
+  /**
+   * Start background enrichment: pages through task history for the given
+   * lookback period, calling onProgress with state updates.
+   * Re-renders the active view on completion via the callback.
+   */
+  async function startHistoricalEnrichment(lookbackMonths, onProgress) {
+    _enrichCancelled = true;
+    await new Promise(r => setTimeout(r, 50));
+    _enrichCancelled = false;
+
+    const allTime = lookbackMonths === 0;
+    _enrichment = { state: 'loading', lookbackMonths, tasksFetched: 0, oldestDate: null, progress: 0, error: null };
+    const notify = () => { if (onProgress) onProgress({ ..._enrichment }); };
+    notify();
+
+    try {
+      const cached = _loadHistCache();
+      const cacheValid = cached && cached.totalTasksFetched > 0 &&
+        (allTime ? cached.lookbackMonths === 0 : cached.lookbackMonths >= lookbackMonths);
+      if (cacheValid) {
+        _histAgg = cached;
+        Object.assign(_enrichment, { state: 'complete', progress: 100, tasksFetched: cached.totalTasksFetched, oldestDate: cached.oldestTaskDate });
+        notify();
+        log('History from cache', { tasks: cached.totalTasksFetched, oldest: cached.oldestTaskDate });
+        return;
+      }
+
+      const agg = _emptyAgg(lookbackMonths);
+      for (const task of _crossSpaceTasks) _accTask(agg, task);
+      _histAgg = agg;
+
+      const useCutoff = !allTime;
+      let cutoff = null;
+      if (useCutoff) {
+        cutoff = new Date();
+        cutoff.setMonth(cutoff.getMonth() - lookbackMonths);
+      }
+
+      // Early-out: check if initial load already reaches the cutoff
+      if (useCutoff && _crossSpaceTasks.length > 0) {
+        const oldest = _crossSpaceTasks.reduce((min, t) => {
+          const d = new Date(t.CompletedTime || t.QueueTime || t.StartTime || 0);
+          return !isNaN(d.getTime()) && d < min ? d : min;
+        }, new Date());
+        if (oldest <= cutoff) {
+          Object.assign(_enrichment, { state: 'complete', progress: 100, tasksFetched: agg.totalTasksFetched, oldestDate: agg.oldestTaskDate });
+          _saveHistCache(agg);
+          notify();
+          log('Initial load covers lookback');
+          return;
+        }
+      }
+
+      if (_activeSpaceIds.length === 0) {
+        Object.assign(_enrichment, { state: 'complete', progress: 100 });
+        notify();
+        return;
+      }
+
+      const CHUNK = 25;
+      let estimatedTotal = null;
+
+      for (let c = 0; c < _activeSpaceIds.length; c += CHUNK) {
+        const ids = _activeSpaceIds.slice(c, c + CHUNK).join(',');
+        let skip = INITIAL_TAKE;
+        let chunkDone = false;
+
+        while (!chunkDone && agg.totalTasksFetched < ENRICH_CAP) {
+          if (_enrichCancelled) return;
+
+          const resp = await safeGet(
+            `/api/tasks?spaces=${encodeURIComponent(ids)}&name=Deploy&states=Success,Failed&take=${ENRICH_PAGE}&skip=${skip}`
+          );
+
+          if (!resp?.Items?.length) { chunkDone = true; break; }
+          if (!estimatedTotal && resp.TotalResults) estimatedTotal = resp.TotalResults;
+
+          for (const task of resp.Items) {
+            if (useCutoff) {
+              const td = new Date(task.CompletedTime || task.QueueTime || task.StartTime || 0);
+              if (td < cutoff) { chunkDone = true; break; }
+            }
+            _accTask(agg, task);
+          }
+
+          skip += ENRICH_PAGE;
+          _histAgg = agg;
+
+          const pct = estimatedTotal
+            ? Math.min(95, Math.round((agg.totalTasksFetched / Math.min(estimatedTotal, ENRICH_CAP)) * 100))
+            : Math.min(95, Math.round((skip / 2000) * 100));
+          Object.assign(_enrichment, { progress: pct, tasksFetched: agg.totalTasksFetched, oldestDate: agg.oldestTaskDate });
+          notify();
+
+          log(`Enrichment: ${agg.totalTasksFetched} tasks, oldest ${agg.oldestTaskDate}`);
+        }
+      }
+
+      _saveHistCache(agg);
+      Object.assign(_enrichment, { state: 'complete', progress: 100, tasksFetched: agg.totalTasksFetched, oldestDate: agg.oldestTaskDate });
+      notify();
+      log('Enrichment complete', { tasks: agg.totalTasksFetched, oldest: agg.oldestTaskDate });
+
+    } catch (err) {
+      if (_enrichCancelled) return;
+      Object.assign(_enrichment, { state: 'error', error: err.message });
+      notify();
+      log('Enrichment failed', err.message);
+    }
+  }
+
+  function getEnrichmentState() { return { ..._enrichment }; }
+
+  function getHistoricalDurationPercentiles() {
+    if (_histAgg) return _percFromHist(_histAgg);
+    return computeDurationPercentiles();
+  }
+
+  function getHistoricalWeeklyTrend() {
+    if (!_histAgg?.weeklyBuckets) return null;
+    const entries = Object.values(_histAgg.weeklyBuckets);
+    if (entries.length === 0) return null;
+    const sorted = entries.sort((a, b) => a.year !== b.year ? a.year - b.year : a.week - b.week).slice(-52);
+    for (let i = 0; i < sorted.length; i++) {
+      sorted[i].showYear = i === 0 || sorted[i].year !== sorted[i - 1].year;
+    }
+    return sorted;
+  }
+
+  function getHistoricalAggregates() { return _histAgg; }
+
+  function cancelEnrichment() { _enrichCancelled = true; _enrichment.state = 'idle'; }
+
+  function clearHistoryCache() {
+    try { localStorage.removeItem(_histKey()); } catch {}
+    _histAgg = null;
+  }
+
+  function _lookbackLabel(months) {
+    if (months === 0) return 'all time';
+    if (months < 12) return `last ${months} months`;
+    const y = months / 12;
+    if (Number.isInteger(y)) return y === 1 ? 'last year' : `last ${y} years`;
+    return `last ${months} months`;
+  }
+
+  /**
+   * Time-filtered KPIs from enriched aggregates. Returns null if no
+   * enriched data is available yet. Structural KPIs (spaces, projects,
+   * targets, releases) are not included — they don't vary by period.
+   */
+  function computeEnrichedKPIs() {
+    if (!_histAgg) return null;
+    const agg = _histAgg;
+    let total = 0, success = 0, failed = 0;
+    for (const w of Object.values(agg.weeklyBuckets)) {
+      total += w.total;
+      success += w.success;
+      failed += w.failed;
+    }
+    const rated = success + failed;
+    const successRate = rated > 0 ? Math.round(success / rated * 100) : 0;
+
+    // For all-time (0), compute actual days from oldest task to now
+    let days;
+    if (agg.lookbackMonths === 0 && agg.oldestTaskDate) {
+      days = Math.max(1, Math.ceil((Date.now() - new Date(agg.oldestTaskDate).getTime()) / 86400000));
+    } else {
+      days = Math.max(1, agg.lookbackMonths * 30);
+    }
+    const deployFrequency = total > 0 ? (total / days).toFixed(1) : '0';
+
+    let avgDuration = '--';
+    if (agg.durationStats.count > 0) {
+      const s = Math.round(agg.durationStats.sum / agg.durationStats.count);
+      if (s < 60) avgDuration = `${s}s`;
+      else { const m = Math.floor(s / 60); const r = s % 60; avgDuration = r > 0 ? `${m}m ${r}s` : `${m}m`; }
+    }
+    return {
+      totalDeployments: total,
+      successRate,
+      deployFrequency,
+      avgDuration,
+      lookbackMonths: agg.lookbackMonths,
+      periodLabel: _lookbackLabel(agg.lookbackMonths),
+      totalSuccess: success,
+      totalFailed: failed,
+      durationCount: agg.durationStats.count,
+    };
+  }
+
   // ---- Public API ----
 
   return {
@@ -993,6 +1316,14 @@ const DashboardData = (() => {
     computeTrendChange,
     computeProjectVelocity,
     computeDurationPercentiles,
+    startHistoricalEnrichment,
+    getEnrichmentState,
+    getHistoricalDurationPercentiles,
+    getHistoricalWeeklyTrend,
+    getHistoricalAggregates,
+    cancelEnrichment,
+    clearHistoryCache,
+    computeEnrichedKPIs,
   };
 
 })();
@@ -1092,20 +1423,38 @@ const DashboardUI = (() => {
   // ---- KPIs ----
 
   function renderKPIs(kpi) {
-    setText('kpi-deployments', kpi.totalDeployments.toLocaleString());
-    setText('kpi-success-rate', kpi.successRate + '%');
+
+    // Structural KPIs (don't change with lookback period)
     setText('kpi-projects', kpi.activeProjects.toLocaleString());
-    setText('kpi-frequency', kpi.deployFrequency + '/day');
     setText('kpi-targets', kpi.totalTargets.toLocaleString());
     setText('kpi-target-health', kpi.healthyTargetsPct + '%');
     setText('kpi-active-spaces', kpi.activeSpaces + '/' + kpi.totalSpaces);
-    setText('kpi-avg-duration', kpi.avgDuration);
     setText('kpi-releases', kpi.totalReleases.toLocaleString());
-
-    // Update trend indicators
-    setTrendLabel('kpi-frequency-label', `last 30 days`);
     setTrendLabel('kpi-targets-label', `${kpi.healthyTargets} healthy`);
     setTrendLabel('kpi-spaces-label', `${kpi.totalSpaces} total`);
+
+    // Time-sensitive KPIs — use enriched data when available
+    const enriched = DashboardData.computeEnrichedKPIs();
+    if (enriched) {
+      const label = enriched.periodLabel;
+      setText('kpi-deployments', enriched.totalDeployments.toLocaleString());
+      setText('kpi-success-rate', enriched.successRate + '%');
+      setText('kpi-frequency', enriched.deployFrequency + '/day');
+      setText('kpi-avg-duration', enriched.avgDuration);
+      setTrendLabel('kpi-deployments-label', label);
+      setTrendLabel('kpi-success-rate-label', label);
+      setTrendLabel('kpi-frequency-label', label);
+      setTrendLabel('kpi-avg-duration-label', `${enriched.durationCount.toLocaleString()} tasks measured`);
+    } else {
+      setText('kpi-deployments', kpi.totalDeployments.toLocaleString());
+      setText('kpi-success-rate', kpi.successRate + '%');
+      setText('kpi-frequency', kpi.deployFrequency + '/day');
+      setText('kpi-avg-duration', kpi.avgDuration);
+      setTrendLabel('kpi-deployments-label', 'all time, all spaces');
+      setTrendLabel('kpi-success-rate-label', 'across recent deploys');
+      setTrendLabel('kpi-frequency-label', 'last 30 days');
+      setTrendLabel('kpi-avg-duration-label', 'per deployment');
+    }
   }
 
   function setTrendLabel(id, text) {
@@ -1679,8 +2028,28 @@ const DashboardUI = (() => {
     renderSpaceBreakdown(summary.spaceBreakdown);
     renderRecentDeployments(summary.recentDeployments);
     renderEnvHealth(summary.envHealth);
-    renderSuccessFailureChart(summary);
-    renderWeeklyTrend(summary.weeklyTrend, summary.dailyTrend);
+
+    // Use enriched counts for the donut chart when available
+    const enriched = DashboardData.computeEnrichedKPIs();
+    if (enriched) {
+      renderSuccessFailureChart({
+        ...summary,
+        successCount: enriched.totalSuccess,
+        failedCount: enriched.totalFailed,
+        cancelledCount: Math.max(0, enriched.totalDeployments - enriched.totalSuccess - enriched.totalFailed),
+      });
+    } else {
+      renderSuccessFailureChart(summary);
+    }
+
+    // Use enriched weekly trend for the chart when available
+    const enrichedWeekly = DashboardData.getHistoricalWeeklyTrend();
+    if (enrichedWeekly && enrichedWeekly.length > 0) {
+      renderWeeklyTrend(enrichedWeekly, summary.dailyTrend);
+    } else {
+      renderWeeklyTrend(summary.weeklyTrend, summary.dailyTrend);
+    }
+
     renderLicenseInfo(summary.licenseInfo);
   }
 

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -11,7 +11,7 @@
      GET /api/licenses/licenses-current-status       → Compliance, expiry, hosting; Limits[] caps / unlimited
      GET /api/{spaceId}/teams/all                    → Teams (membership & scoping; needs TeamView)
      GET /api/{spaceId}/projects?take=1000           → Projects per space
-     GET /api/{spaceId}/environments?take=100        → Environments per space
+     GET /api/{spaceId}/environments/all           → All environments per space (includes disabled/deleted)
      GET /api/{spaceId}/environments/summary         → Machine / target health summary
      GET /api/{spaceId}/deployments?take=200         → Recent deployments per space
      GET /api/{spaceId}/dashboard                    → Dashboard overview (latest per project/env)
@@ -172,7 +172,7 @@ const DashboardData = (() => {
     // Fetch everything in parallel
     const [projects, environments, envSummary, dashboard, deployments, machines, releasesResp, runbooksResp] = await Promise.all([
       safeGet(`/api/${sid}/projects?take=1000`),
-      safeGet(`/api/${sid}/environments?take=100`),
+      safeGet(`/api/${sid}/environments/all`),
       safeGet(`/api/${sid}/environments/summary`),
       safeGet(`/api/${sid}/dashboard`),
       safeGet(`/api/${sid}/deployments?take=200`),
@@ -202,9 +202,19 @@ const DashboardData = (() => {
       projectNames[p.Id] = p.Name;
     }
 
+    // /environments/all may return either a raw array or an { Items } list
+    const normalizeEnvironmentsList = (raw) => {
+      if (raw == null) return [];
+      if (Array.isArray(raw)) return raw;
+      if (Array.isArray(raw.Items)) return raw.Items;
+      return [];
+    };
+
+    const environmentsList = normalizeEnvironmentsList(environments);
+
     // Build environment name lookup
     const envNames = {};
-    for (const e of (environments?.Items || [])) {
+    for (const e of environmentsList) {
       envNames[e.Id] = e.Name;
     }
 
@@ -216,7 +226,7 @@ const DashboardData = (() => {
       space,
       projects: projects?.Items || [],
       projectNames,
-      environments: environments?.Items || [],
+      environments: environmentsList,
       envNames,
       envSummary,
       dashboard,
@@ -446,6 +456,19 @@ const DashboardData = (() => {
       totalRunbooks += runbookCount;
       totalTargets += targetCount;
       healthyTargets += (machineHealth.Healthy || 0);
+
+      // Seed envHealthMap from the full environment list so environments with no
+      // dashboard items (e.g. disabled/deleted, or never-deployed) still show up
+      // with "No data" instead of disappearing entirely.
+      for (const env of (environments || [])) {
+        const envId = env?.Id;
+        if (!envId) continue;
+        const envName = (envNames && envNames[envId]) || env?.Name || envId;
+        if (!envHealthMap[envName]) {
+          envHealthMap[envName] = { success: 0, failed: 0, total: 0, spaces: new Set() };
+        }
+        envHealthMap[envName].spaces.add(space.Name);
+      }
 
       // Count deployment states
       let spaceSuccessful = 0;

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -385,6 +385,7 @@ const DashboardData = (() => {
 
     // Build weekly trend from deployment timestamps (since the weekly report endpoint is deprecated)
     const weeklyTrend = computeWeeklyTrend(enrichedDeployments);
+    const dailyTrend = computeDailyTrend(enrichedDeployments, 30);
 
     // Deployment frequency (per day over last 30 days)
     const now = new Date();
@@ -444,6 +445,7 @@ const DashboardData = (() => {
 
       // Trends
       weeklyTrend,
+      dailyTrend,
 
       // Counts for donut
       successCount: totalSuccessful,
@@ -488,6 +490,42 @@ const DashboardData = (() => {
     }
 
     return sorted;
+  }
+
+  /**
+   * Last `numDays` UTC calendar days (today inclusive), including days with zero deployments.
+   */
+  function computeDailyTrend(deployments, numDays = 30) {
+    const dayMap = {};
+    const today = new Date();
+    const endUtc = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+
+    for (let i = numDays - 1; i >= 0; i--) {
+      const d = new Date(endUtc - i * 86400000);
+      const key = d.toISOString().slice(0, 10);
+      dayMap[key] = {
+        dateKey: key,
+        year: d.getUTCFullYear(),
+        month: d.getUTCMonth(),
+        day: d.getUTCDate(),
+        success: 0,
+        failed: 0,
+        total: 0,
+      };
+    }
+
+    for (const dep of deployments) {
+      const created = dep.Created || dep.QueueTime;
+      if (!created) continue;
+      const key = new Date(created).toISOString().slice(0, 10);
+      if (!dayMap[key]) continue;
+      dayMap[key].total++;
+      const state = (dep.State || '').toLowerCase();
+      if (state === 'success') dayMap[key].success++;
+      else if (state === 'failed') dayMap[key].failed++;
+    }
+
+    return Object.keys(dayMap).sort().map(k => dayMap[k]);
   }
 
   /**
@@ -576,7 +614,7 @@ const DashboardUI = (() => {
       renderRecentDeployments(summary.recentDeployments);
       renderEnvHealth(summary.envHealth);
       renderSuccessFailureChart(summary);
-      renderWeeklyTrend(summary.weeklyTrend);
+      renderWeeklyTrend(summary.weeklyTrend, summary.dailyTrend);
       renderLicenseInfo(summary.licenseInfo);
       updateRefreshTime();
       updateConnectionStatus();
@@ -853,8 +891,25 @@ const DashboardUI = (() => {
 
   // ---- Trend chart state ----
   let _fullWeeklyTrend = [];
+  let _fullDailyTrend = [];
   let _currentRange = '30d';
   const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+  function formatDailyAxisLabel(d, prev) {
+    const M = MONTH_NAMES;
+    if (!prev) return `${d.day}<br>${M[d.month]}<br>${d.year}`;
+    if (d.year !== prev.year) return `${d.day}<br>${M[d.month]}<br>${d.year}`;
+    if (d.month !== prev.month) return `${d.day}<br>${M[d.month]}`;
+    return String(d.day);
+  }
+
+  function formatUtcDayTip(dateKey) {
+    const parts = dateKey.split('-').map(Number);
+    const y = parts[0];
+    const mo = parts[1];
+    const da = parts[2];
+    return `${da} ${MONTH_NAMES[mo - 1]} ${y} (UTC)`;
+  }
 
   /**
    * Aggregate weekly buckets into monthly buckets for the 12-month view.
@@ -933,15 +988,17 @@ const DashboardUI = (() => {
     return `${d1} ${M[m1]} ${y1} – ${d2} ${M[m2]} ${y2}`;
   }
 
-  function renderWeeklyTrend(weeklyTrend, range) {
-    if (weeklyTrend) _fullWeeklyTrend = weeklyTrend;
-    if (range) _currentRange = range;
+  function renderWeeklyTrend(weeklyTrend, dailyTrend, range) {
+    if (weeklyTrend != null) _fullWeeklyTrend = weeklyTrend;
+    if (dailyTrend != null) _fullDailyTrend = dailyTrend;
+    if (range != null) _currentRange = range;
 
     const el = document.getElementById('chart-deployment-trends');
     if (!el) return;
 
     // Decide what to show based on range
     let bars;      // array of { total, success, failed, label, tooltip }
+    let useDailyBars = false;
     if (_currentRange === '12m') {
       const monthly = _aggregateMonthly(_fullWeeklyTrend);
       bars = monthly.map(m => ({
@@ -951,6 +1008,20 @@ const DashboardUI = (() => {
         label: MONTH_NAMES[m.month] + (m.month === 0 ? '<br>' + m.year : ''),
         tooltip: _tooltipAttr(`${MONTH_NAMES[m.month]} ${m.year}: ${m.total} deployments (${m.success} success, ${m.failed} failed, ${m.total - m.success - m.failed} other)`),
       }));
+    } else if (_currentRange === '30d' && _fullDailyTrend && _fullDailyTrend.length > 0) {
+      useDailyBars = true;
+      bars = _fullDailyTrend.map((d, i) => {
+        const prev = i > 0 ? _fullDailyTrend[i - 1] : null;
+        const counts = `${d.total} deployments (${d.success} success, ${d.failed} failed, ${d.total - d.success - d.failed} other)`;
+        const tip = `${formatUtcDayTip(d.dateKey)}. ${counts}`;
+        return {
+          total: d.total,
+          success: d.success,
+          failed: d.failed,
+          label: formatDailyAxisLabel(d, prev),
+          tooltip: _tooltipAttr(tip),
+        };
+      });
     } else {
       const weeksToShow = _currentRange === '90d' ? 13 : 5;
       const sliced = _fullWeeklyTrend.slice(-weeksToShow);
@@ -969,6 +1040,9 @@ const DashboardUI = (() => {
       });
     }
 
+    const gapPx = _currentRange === '12m' ? 8 : (useDailyBars ? 2 : (_currentRange === '90d' ? 6 : 12));
+    const chartExtra = useDailyBars ? ' deployment-trend-chart--daily' : '';
+
     if (!bars || bars.length === 0) {
       el.innerHTML = `<div class="text-tertiary" style="text-align:center;padding:var(--space-lg);">
         <i class="fa-solid fa-chart-area" style="font-size:2rem;display:block;margin-bottom:var(--space-sm);"></i>
@@ -981,8 +1055,8 @@ const DashboardUI = (() => {
     const maxTotal = Math.max(...bars.map(b => b.total), 1);
 
     el.innerHTML = `
-      <div class="deployment-trend-chart">
-        <div class="deployment-trend-bars" style="gap:6px;padding:0 var(--space-xs);">
+      <div class="deployment-trend-chart${chartExtra}">
+        <div class="deployment-trend-bars" style="gap:${gapPx}px;padding:0 var(--space-xs);">
           ${bars.map(b => {
             const t = b.total;
             const hPx = trendBarPixelHeight(t, maxTotal);
@@ -1005,7 +1079,7 @@ const DashboardUI = (() => {
                     ${succH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--success" style="height:${succH}px;border-radius:0 0 3px 3px;"></div>` : ''}
                   </div>
                 </div>
-                <div class="deployment-trend-axis-label">${b.label}</div>
+                <div class="deployment-trend-axis-label${useDailyBars ? ' deployment-trend-axis-label--dense' : ''}">${b.label}</div>
               </div>`;
           }).join('')}
         </div>
@@ -1013,7 +1087,7 @@ const DashboardUI = (() => {
   }
 
   function setTrendRange(range) {
-    renderWeeklyTrend(null, range);
+    renderWeeklyTrend(null, null, range);
   }
 
   // ---- License Info ----
@@ -1062,7 +1136,7 @@ const DashboardUI = (() => {
     renderRecentDeployments(summary.recentDeployments);
     renderEnvHealth(summary.envHealth);
     renderSuccessFailureChart(summary);
-    renderWeeklyTrend(summary.weeklyTrend);
+    renderWeeklyTrend(summary.weeklyTrend, summary.dailyTrend);
     renderLicenseInfo(summary.licenseInfo);
   }
 

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -7,7 +7,8 @@
    Key endpoints used (confirmed working 2026-02):
      GET /api                                        → Server info & version
      GET /api/spaces?take=100                        → All spaces
-     GET /api/licenses/licenses-current-usage        → Per-space project/tenant/machine counts
+     GET /api/licenses/licenses-current-usage        → SpacesUsage + Limits[] (CurrentUsage, EffectiveLimit, IsUnlimited)
+     GET /api/licenses/licenses-current-status       → Compliance, expiry, hosting; Limits[] caps / unlimited
      GET /api/{spaceId}/teams/all                    → Teams (membership & scoping; needs TeamView)
      GET /api/{spaceId}/projects?take=1000           → Projects per space
      GET /api/{spaceId}/environments?take=100        → Environments per space
@@ -251,6 +252,174 @@ const DashboardData = (() => {
     return [];
   }
 
+  /**
+   * PTM totals from GET /api/licenses/licenses-current-usage (authoritative for licensing).
+   * Sums per-space ProjectsCount, TenantsCount, MachinesCount; uses root totals if present.
+   */
+  function aggregatePtmFromLicenseUsage(licenseUsage) {
+    if (!licenseUsage || typeof licenseUsage !== 'object') return null;
+
+    const n = (v) => {
+      if (v === undefined || v === null) return null;
+      const x = Number(v);
+      return Number.isFinite(x) ? x : null;
+    };
+
+    const tp = n(licenseUsage.TotalProjectsCount ?? licenseUsage.totalProjectsCount
+      ?? licenseUsage.TotalProjects ?? licenseUsage.totalProjects);
+    const tt = n(licenseUsage.TotalTenantsCount ?? licenseUsage.totalTenantsCount
+      ?? licenseUsage.TotalTenants ?? licenseUsage.totalTenants);
+    const tm = n(licenseUsage.TotalMachinesCount ?? licenseUsage.totalMachinesCount
+      ?? licenseUsage.TotalMachines ?? licenseUsage.totalMachines);
+    if (tp != null && tt != null && tm != null) {
+      return { projects: tp, tenants: tt, machines: tm };
+    }
+
+    const spaces = licenseUsage.SpacesUsage || licenseUsage.spacesUsage;
+    if (!Array.isArray(spaces) || spaces.length === 0) return null;
+
+    let projects = 0;
+    let tenants = 0;
+    let machines = 0;
+    for (const su of spaces) {
+      projects += n(su.ProjectsCount ?? su.projectsCount) ?? 0;
+      tenants += n(su.TenantsCount ?? su.tenantsCount) ?? 0;
+      machines += n(su.MachinesCount ?? su.machinesCount) ?? 0;
+    }
+    return { projects, tenants, machines };
+  }
+
+  /**
+   * Map Octopus `Limits` row name → PTM bucket. Matches LicenseLimitUsageResource rows on
+   * /api/licenses/licenses-current-usage and licenses-current-status (Octopus.Server.Client).
+   */
+  function classifyPtmLimitName(name) {
+    if (!name || typeof name !== 'string') return null;
+    const n = name.toLowerCase().trim();
+    if (n.includes('tenant')) return 'tenants';
+    if (n.includes('project')) return 'projects';
+    if (n.includes('worker') && !n.includes('deployment')) return null;
+    // Octopus Cloud/API uses "Targets" for licensed deployment targets (PTM machines).
+    if (n === 'targets' || n.includes('machine') || n.includes('deployment target')) return 'machines';
+    return null;
+  }
+
+  /**
+   * Parse `Limits` array → PTM cells.
+   * Display cap uses LicensedLimit (entitlement); EffectiveLimit is the grace/overage ceiling (e.g. ~10% over).
+   */
+  function mapLimitsArrayToPtmCells(limitsArray) {
+    const out = { projects: null, tenants: null, machines: null };
+    if (!Array.isArray(limitsArray)) return out;
+    const n = (v) => {
+      if (v === undefined || v === null) return null;
+      const x = Number(v);
+      return Number.isFinite(x) ? x : null;
+    };
+    const POSITIVE_INT_MAX = 2147483647;
+    for (const lim of limitsArray) {
+      const key = classifyPtmLimitName(lim.Name ?? lim.name);
+      if (!key || out[key]) continue;
+      const used = n(lim.CurrentUsage ?? lim.currentUsage);
+      const eff = n(lim.EffectiveLimit ?? lim.effectiveLimit);
+      const lic = n(lim.LicensedLimit ?? lim.licensedLimit);
+      const flagUnlimited = lim.IsUnlimited === true || lim.isUnlimited === true;
+      const maxIntUnlimited = eff === POSITIVE_INT_MAX && (lic === POSITIVE_INT_MAX || lic == null);
+      const isUnlimited = flagUnlimited || maxIntUnlimited;
+      let limit = null;
+      let effectiveLimit = null;
+      if (!isUnlimited) {
+        limit = lic ?? eff;
+        if (eff != null && lic != null && eff > lic) effectiveLimit = eff;
+      }
+      out[key] = { used, limit, effectiveLimit, unlimited: isUnlimited };
+    }
+    return out;
+  }
+
+  function normalizePtmCell(cell) {
+    if (!cell) return { used: null, limit: null, effectiveLimit: null, unlimited: false };
+    const unlimited = cell.unlimited === true;
+    return {
+      used: cell.used != null ? cell.used : null,
+      limit: unlimited ? null : (cell.limit != null ? cell.limit : null),
+      effectiveLimit: unlimited ? null : (cell.effectiveLimit != null ? cell.effectiveLimit : null),
+      unlimited,
+    };
+  }
+
+  function mergePtmCells(a, b) {
+    return normalizePtmCell({
+      used: a?.used ?? b?.used,
+      limit: a?.limit ?? b?.limit,
+      effectiveLimit: a?.effectiveLimit ?? b?.effectiveLimit,
+      unlimited: !!(a && a.unlimited) || !!(b && b.unlimited),
+    });
+  }
+
+  /** Prefer usage Limits, then status Limits; fill used from SpacesUsage sum or space fallback; legacy scalar limits last. */
+  function buildLicensePtmSummary(licenseUsage, licenseStatus, spaceFallback) {
+    const keys = ['projects', 'tenants', 'machines'];
+    const usageLim = mapLimitsArrayToPtmCells(licenseUsage?.Limits || licenseUsage?.limits);
+    const statusLim = mapLimitsArrayToPtmCells(licenseStatus?.Limits || licenseStatus?.limits);
+    const fromAgg = aggregatePtmFromLicenseUsage(licenseUsage);
+    const legacyLimits = extractPtmLegacyScalarLimits(licenseStatus);
+
+    const ptm = {};
+    for (const key of keys) {
+      let cell = mergePtmCells(usageLim[key], statusLim[key]);
+      let used = cell.used;
+      if (used == null && fromAgg) used = fromAgg[key];
+      if (used == null && spaceFallback) used = spaceFallback[key];
+
+      let { limit, effectiveLimit, unlimited } = cell;
+      if (!unlimited && limit == null && legacyLimits[key] != null) limit = legacyLimits[key];
+
+      ptm[key] = { used: used ?? null, limit, effectiveLimit: unlimited ? null : effectiveLimit, unlimited };
+    }
+
+    const hasLimitsArray = (Array.isArray(licenseUsage?.Limits) && licenseUsage.Limits.length > 0)
+      || (Array.isArray(licenseUsage?.limits) && licenseUsage.limits.length > 0)
+      || (Array.isArray(licenseStatus?.Limits) && licenseStatus.Limits.length > 0)
+      || (Array.isArray(licenseStatus?.limits) && licenseStatus.limits.length > 0);
+
+    const source = hasLimitsArray ? 'license-limits' : fromAgg ? 'license-usage-spaces' : 'spaces-aggregate';
+    return { ptm, source };
+  }
+
+  /** Legacy flat limit fields on status (not the Limits[] resource). */
+  function extractPtmLegacyScalarLimits(licenseStatus) {
+    const out = { projects: null, tenants: null, machines: null };
+    if (!licenseStatus || typeof licenseStatus !== 'object') return out;
+
+    const tryKeys = (obj, keys) => {
+      if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+      for (const k of keys) {
+        const v = obj[k];
+        if (typeof v === 'number' && Number.isFinite(v) && v >= 0) return v;
+      }
+      return null;
+    };
+
+    const buckets = [
+      licenseStatus,
+      licenseStatus.License,
+      licenseStatus.license,
+      licenseStatus.LicenseDetails,
+    ];
+
+    const projectKeys = ['MaximumProjects', 'MaximumLicensedProjects', 'LicensedProjectMaximum', 'ProjectLimit'];
+    const tenantKeys = ['MaximumTenants', 'LicensedTenantMaximum', 'TenantLimit'];
+    const machineKeys = ['MaximumMachines', 'MaximumDeploymentTargets', 'MachineLimit', 'DeploymentTargetLimit', 'LicensedMachineLimit'];
+
+    for (const o of buckets) {
+      if (out.projects == null) out.projects = tryKeys(o, projectKeys);
+      if (out.tenants == null) out.tenants = tryKeys(o, tenantKeys);
+      if (out.machines == null) out.machines = tryKeys(o, machineKeys);
+    }
+    return out;
+  }
+
   // ---- Aggregation / Summary ----
 
   function getSummary(usageByName) {
@@ -425,12 +594,25 @@ const DashboardData = (() => {
     // Target health percentage
     const healthyPct = totalTargets > 0 ? Math.round(healthyTargets / totalTargets * 100) : 0;
 
-    // License info
+    // License: PTM from Limits[] on usage/status (used + cap / unlimited), else SpacesUsage, else loaded spaces
+    const { ptm: ptmCells, source: ptmSource } = buildLicensePtmSummary(
+      _licenseUsage,
+      _licenseStatus,
+      { projects: totalProjects, tenants: null, machines: totalTargets },
+    );
+
     const licenseInfo = {
       isCompliant: _licenseStatus?.IsCompliant,
       daysToExpiry: _licenseStatus?.DaysToEffectiveExpiryDate,
       expiryDate: _licenseStatus?.EffectiveExpiryDate,
       hostingEnv: _licenseStatus?.HostingEnvironment,
+      complianceSummary: _licenseStatus?.ComplianceSummary || null,
+      ptm: {
+        projects: ptmCells.projects,
+        tenants: ptmCells.tenants,
+        machines: ptmCells.machines,
+        source: ptmSource,
+      },
     };
 
     // Teams (per-space fetch in fetchSpaceData)
@@ -1167,19 +1349,100 @@ const DashboardUI = (() => {
 
   // ---- License Info ----
 
+  function formatPtmPair(used, limit, unlimited) {
+    if (unlimited) {
+      if (used == null) return 'Unlimited';
+      return `${used} / Unlimited`;
+    }
+    if (used == null && limit == null) return '—';
+    if (used == null) return limit == null ? '—' : `— / ${limit}`;
+    if (limit == null) return String(used);
+    return `${used} / ${limit}`;
+  }
+
   function renderLicenseInfo(info) {
     const el = document.getElementById('license-info');
+    const ptmEl = document.getElementById('license-ptm');
     if (!el || !info) return;
 
-    const daysClass = info.daysToExpiry > 60 ? 'success' : info.daysToExpiry > 30 ? 'warning' : 'danger';
+    const compliant = info.isCompliant === true;
+    const nonCompliant = info.isCompliant === false;
+    const badgeClass = compliant ? 'success' : nonCompliant ? 'danger' : 'neutral';
+    const badgeLabel = compliant ? 'Compliant' : nonCompliant ? 'Non-Compliant' : 'Unknown';
+
+    const days = info.daysToExpiry;
+    const daysClass = days == null ? 'secondary' : days > 60 ? 'success' : days > 30 ? 'warning' : 'danger';
+    const daysFragment = days == null
+      ? '<span class="text-secondary">Renewal date unavailable</span>'
+      : `<span class="text-${daysClass}">${days} days</span> until renewal`;
+
     el.innerHTML = `
-      <div class="flex items-center gap-sm">
-        <span class="badge ${info.isCompliant ? 'success' : 'danger'}">${info.isCompliant ? 'Compliant' : 'Non-Compliant'}</span>
+      <div class="flex items-center gap-sm flex-wrap">
+        <span class="badge ${badgeClass}">${badgeLabel}</span>
         <span class="text-secondary" style="font:var(--textBodyRegularSmall);">
-          ${info.hostingEnv || 'Self-Hosted'} &mdash; 
-          <span class="text-${daysClass}">${info.daysToExpiry} days</span> until renewal
+          ${info.hostingEnv || 'Self-Hosted'} &mdash; ${daysFragment}
         </span>
       </div>`;
+
+    if (!ptmEl) return;
+    const ptm = info.ptm;
+    if (!ptm) {
+      ptmEl.innerHTML = '';
+      return;
+    }
+
+    const metric = (label, key) => {
+      const cell = ptm[key] || {};
+      const used = cell.used;
+      const limit = cell.limit;
+      const effCap = cell.effectiveLimit;
+      const unlimited = cell.unlimited === true;
+      const text = formatPtmPair(used, limit, unlimited);
+      const overLicensed = !unlimited && typeof used === 'number' && typeof limit === 'number' && limit > 0 && used > limit;
+      const overEffective = !unlimited && typeof used === 'number' && typeof effCap === 'number' && effCap > 0 && used > effCap;
+      const inGraceZone = overLicensed && !overEffective && effCap != null && effCap > limit;
+      let valClass = 'license-ptm-metric-value';
+      if (overEffective) valClass += ' license-ptm-metric-value--over';
+      else if (inGraceZone) valClass += ' license-ptm-metric-value--grace';
+      else if (overLicensed) valClass += ' license-ptm-metric-value--over';
+      return `
+        <div class="license-ptm-metric">
+          <span class="license-ptm-metric-label">${label}</span>
+          <span class="${valClass}">${text}</span>
+        </div>`;
+    };
+
+    const capsMissing = ['projects', 'tenants', 'machines'].every((key) => {
+      const c = ptm[key] || {};
+      return !c.unlimited && (c.limit == null || c.limit === undefined);
+    });
+
+    let note = '';
+    if (ptm.source === 'spaces-aggregate') {
+      note = '<p class="license-ptm-note text-tertiary"><i class="fa-solid fa-circle-info" aria-hidden="true"></i> PTM uses loaded spaces only; grant access to read <code class="license-ptm-code">/api/licenses/licenses-current-usage</code> for exact counts and caps.</p>';
+    } else if (ptm.source === 'license-usage-spaces' && capsMissing) {
+      note = '<p class="license-ptm-note text-tertiary"><i class="fa-solid fa-circle-info" aria-hidden="true"></i> Usage totals are from per-space data; numeric caps are in the <code class="license-ptm-code">Limits</code> array on the license endpoints. Open Configuration → License in Octopus to see your full entitlement.</p>';
+    }
+
+    const summaryLine = info.complianceSummary
+      ? `<p class="license-compliance-summary text-tertiary">${String(info.complianceSummary)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>`
+      : '';
+
+    const ptmHint = (ptm.source === 'license-limits' || ptm.source === 'license-usage-spaces')
+      ? `<p class="license-ptm-hint text-tertiary">Compared to your <span class="license-ptm-hint-em">licensed</span> entitlement; Octopus also exposes a higher effective cap as a short overage allowance.</p>`
+      : '';
+
+    ptmEl.innerHTML = `
+      <div class="license-ptm-label text-tertiary">License usage (PTM)</div>
+      ${ptmHint}
+      <div class="license-ptm-grid">
+        ${metric('Projects', 'projects')}
+        ${metric('Tenants', 'tenants')}
+        ${metric('Machines', 'machines')}
+      </div>
+      ${summaryLine}
+      ${note}`;
   }
 
   // ---- Helpers ----

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -546,7 +546,6 @@ const DashboardData = (() => {
         projectCount: projects.length,
         environmentCount: environments.length,
         deploymentCount: totalDeployments,
-        recentDeploymentCount: deployments.length,
         successRate: Math.round(successRate),
         successCount: spaceSuccessful,
         failedCount: spaceFailed,
@@ -851,6 +850,130 @@ const DashboardData = (() => {
     return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
   }
 
+  // ---- Analysis helpers for Trends & Velocity views ----
+
+  function _guessEnvClass(name) {
+    const n = (name || '').toLowerCase();
+    if (n.includes('prod') && !n.includes('pre-prod') && !n.includes('preprod') && !n.includes('non-prod') && !n.includes('nonprod')) return 'production';
+    if (n.includes('stag') || n.includes('uat') || n.includes('pre-prod') || n.includes('preprod') || n.includes('test')) return 'staging';
+    return 'dev';
+  }
+
+  function computeDayOfWeekDistribution() {
+    const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    const counts = new Array(7).fill(0);
+    for (const sd of Object.values(_spaceData)) {
+      for (const dep of (sd.deployments || [])) {
+        const d = new Date(dep.Created || dep.QueueTime);
+        if (isNaN(d.getTime())) continue;
+        const jsDay = d.getUTCDay();
+        counts[jsDay === 0 ? 6 : jsDay - 1]++;
+      }
+    }
+    return DAYS.map((name, i) => ({ name, count: counts[i], isWeekend: i >= 5 }));
+  }
+
+  function computeHourOfDayDistribution() {
+    const counts = new Array(24).fill(0);
+    for (const sd of Object.values(_spaceData)) {
+      for (const dep of (sd.deployments || [])) {
+        const d = new Date(dep.Created || dep.QueueTime);
+        if (isNaN(d.getTime())) continue;
+        counts[d.getUTCHours()]++;
+      }
+    }
+    return counts.map((count, hour) => ({ hour, count }));
+  }
+
+  function computePerEnvTypeDeployments() {
+    const types = { production: 0, staging: 0, dev: 0 };
+    const perEnv = {};
+    for (const sd of Object.values(_spaceData)) {
+      const envNames = sd.envNames || {};
+      for (const dep of (sd.deployments || [])) {
+        const envName = envNames[dep.EnvironmentId] || dep.EnvironmentId || 'Unknown';
+        const cls = _guessEnvClass(envName);
+        types[cls] = (types[cls] || 0) + 1;
+        if (!perEnv[envName]) perEnv[envName] = { name: envName, cls, count: 0, success: 0, failed: 0 };
+        perEnv[envName].count++;
+        const state = (dep.State || '').toLowerCase();
+        if (state === 'success') perEnv[envName].success++;
+        else if (state === 'failed') perEnv[envName].failed++;
+      }
+    }
+    return { types, environments: Object.values(perEnv).sort((a, b) => b.count - a.count) };
+  }
+
+  function computeTrendChange(weeklyTrend) {
+    if (!weeklyTrend || weeklyTrend.length < 2) return null;
+    const recent = weeklyTrend.slice(-4);
+    const prior = weeklyTrend.slice(-8, -4);
+    if (prior.length === 0) return null;
+    const recentAvg = recent.reduce((s, w) => s + w.total, 0) / recent.length;
+    const priorAvg = prior.reduce((s, w) => s + w.total, 0) / prior.length;
+    if (priorAvg === 0) return recentAvg > 0 ? { pct: 100, direction: 'up' } : { pct: 0, direction: 'flat' };
+    const pct = Math.round(((recentAvg - priorAvg) / priorAvg) * 100);
+    return {
+      pct: Math.abs(pct),
+      direction: pct > 5 ? 'up' : pct < -5 ? 'down' : 'flat',
+      recentAvg: Math.round(recentAvg * 10) / 10,
+      priorAvg: Math.round(priorAvg * 10) / 10,
+    };
+  }
+
+  function computeProjectVelocity() {
+    const projects = [];
+    const now = new Date();
+    const thirtyDaysAgo = new Date(now - 30 * 86400000);
+    for (const [spaceId, sd] of Object.entries(_spaceData)) {
+      const spaceName = sd.space?.Name || spaceId;
+      for (const proj of (sd.projects || [])) {
+        const projDeps = (sd.deployments || []).filter(d => d.ProjectId === proj.Id);
+        const recentDeps = projDeps.filter(d => new Date(d.Created || d.QueueTime) >= thirtyDaysAgo);
+        const successCount = projDeps.filter(d => (d.State || '').toLowerCase() === 'success').length;
+        const rate = projDeps.length > 0 ? Math.round(successCount / projDeps.length * 100) : null;
+        const prodDeps = projDeps.filter(d => {
+          const envName = (sd.envNames || {})[d.EnvironmentId] || '';
+          return _guessEnvClass(envName) === 'production';
+        });
+        projects.push({
+          name: proj.Name || proj.Id,
+          space: spaceName,
+          spaceId,
+          totalDeploys: projDeps.length,
+          recentDeploys: recentDeps.length,
+          deploysPerWeek: recentDeps.length > 0 ? (recentDeps.length / 4.3).toFixed(1) : '0',
+          successRate: rate,
+          prodDeploys: prodDeps.length,
+          lastDeploy: projDeps.length > 0 ? projDeps[0].Created || projDeps[0].QueueTime : null,
+        });
+      }
+    }
+    projects.sort((a, b) => b.recentDeploys - a.recentDeploys);
+    return projects;
+  }
+
+  function computeDurationPercentiles() {
+    const durations = [];
+    for (const t of (_crossSpaceTasks || [])) {
+      if (!t.StartTime || !t.CompletedTime) continue;
+      const ms = new Date(t.CompletedTime) - new Date(t.StartTime);
+      if (ms > 0 && ms < 3600000) durations.push(ms / 1000);
+    }
+    if (durations.length === 0) return null;
+    durations.sort((a, b) => a - b);
+    const pct = (p) => durations[Math.min(Math.floor(durations.length * p), durations.length - 1)];
+    return {
+      avg: Math.round(durations.reduce((a, b) => a + b, 0) / durations.length),
+      p50: Math.round(pct(0.5)),
+      p90: Math.round(pct(0.9)),
+      p95: Math.round(pct(0.95)),
+      min: Math.round(durations[0]),
+      max: Math.round(durations[durations.length - 1]),
+      count: durations.length,
+    };
+  }
+
   // ---- Public API ----
 
   return {
@@ -864,6 +987,12 @@ const DashboardData = (() => {
     getLastFetch: () => _lastFetch,
     getLicenseUsage: () => _licenseUsage,
     getLicenseStatus: () => _licenseStatus,
+    computeDayOfWeekDistribution,
+    computeHourOfDayDistribution,
+    computePerEnvTypeDeployments,
+    computeTrendChange,
+    computeProjectVelocity,
+    computeDurationPercentiles,
   };
 
 })();
@@ -1010,7 +1139,6 @@ const DashboardUI = (() => {
         <td>${s.environmentCount}</td>
         <td>
           <span class="monospace">${s.deploymentCount}</span>
-          ${s.recentDeploymentCount > 0 ? `<span class="text-tertiary" style="font:var(--textBodyRegularXSmall);"> (${s.recentDeploymentCount} recent)</span>` : ''}
         </td>
         <td>
           <div class="flex items-center gap-xs">
@@ -1044,6 +1172,14 @@ const DashboardUI = (() => {
     return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
   }
 
+  function _escapeAttr(text) {
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
   function healthBadge(rate, hasDeployments) {
     if (rate >= 95) {
       return `<span class="badge success" data-tooltip="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}">Healthy</span>`;
@@ -1069,16 +1205,32 @@ const DashboardUI = (() => {
       return;
     }
 
+    const root = (typeof OctopusApi?.getInstanceUrl === 'function') ? OctopusApi.getInstanceUrl() : '';
+
     tbody.innerHTML = deployments.map(d => {
       const state = (d.State || 'unknown').toLowerCase();
       const statusClass = state === 'success' ? 'success' : state === 'failed' ? 'danger' : state === 'executing' ? 'info' : state === 'queued' ? 'info' : 'neutral';
       const statusLabel = state.charAt(0).toUpperCase() + state.slice(1);
 
+      const spaceId = d._spaceId;
+      const projId = d.ProjectId;
+      const envId = d.EnvironmentId;
+      const projUrl = root && spaceId && projId ? `${root}/app#/${encodeURIComponent(spaceId)}/projects/${encodeURIComponent(projId)}` : null;
+      const envUrl = root && spaceId && envId ? `${root}/app#/${encodeURIComponent(spaceId)}/infrastructure/environments/${encodeURIComponent(envId)}` : null;
+
       return `
         <tr>
-          <td>${DOMPurify.sanitize(d._projectName || d.ProjectId || '--')}</td>
+          <td>
+            ${projUrl
+              ? `<a class="text-tertiary" href="${_escapeAttr(projUrl)}" target="_blank" rel="noopener noreferrer" style="text-decoration:none;">${DOMPurify.sanitize(d._projectName || d.ProjectId || '--')}</a>`
+              : DOMPurify.sanitize(d._projectName || d.ProjectId || '--')}
+          </td>
           <td><span class="monospace">${DOMPurify.sanitize(d.ReleaseVersion || '--')}</span></td>
-          <td>${DOMPurify.sanitize(d._envName || d.EnvironmentId || '--')}</td>
+          <td>
+            ${envUrl
+              ? `<a class="text-tertiary" href="${_escapeAttr(envUrl)}" target="_blank" rel="noopener noreferrer" style="text-decoration:none;">${DOMPurify.sanitize(d._envName || d.EnvironmentId || '--')}</a>`
+              : DOMPurify.sanitize(d._envName || d.EnvironmentId || '--')}
+          </td>
           <td>
             <div class="flex items-center gap-xs">
               <div class="space-avatar sm" style="width:20px;height:20px;font-size:0.5rem;">${DOMPurify.sanitize((d._spaceName || '?').charAt(0))}</div>
@@ -1100,6 +1252,34 @@ const DashboardUI = (() => {
 
     if (envs.length === 0) return;
 
+    const root = (typeof OctopusApi?.getInstanceUrl === 'function') ? OctopusApi.getInstanceUrl() : '';
+    const allSpaceData = DashboardData.getAllSpaceData ? DashboardData.getAllSpaceData() : {};
+
+    const spaceNameToId = {};
+    for (const [sid, sd] of Object.entries(allSpaceData || {})) {
+      const spaceName = sd?.space?.Name || sid;
+      spaceNameToId[spaceName] = sid;
+    }
+
+    function octopusEnvHref(envName, envSpaces) {
+      if (!root || !envName) return null;
+      const list = Array.isArray(envSpaces) ? envSpaces : [];
+      if (list.length === 0) return null;
+
+      // Choose deterministically so URLs are stable across renders.
+      const chosenSpaceName = String(list.slice().sort((a, b) => String(a).localeCompare(String(b)))[0]);
+      const spaceId = spaceNameToId[chosenSpaceName];
+      if (!spaceId) return null;
+
+      const sd = allSpaceData?.[spaceId];
+      const environments = sd?.environments || [];
+      const env = environments.find(e => e?.Name === envName);
+      const envId = env?.Id;
+      if (!envId) return null;
+
+      return `${root}/app#/${encodeURIComponent(spaceId)}/infrastructure/environments/${encodeURIComponent(envId)}`;
+    }
+
     // Sort: production-like first, then staging, then dev, then others
     const priority = { production: 0, prod: 0, staging: 1, stage: 1, uat: 2, test: 3, development: 4, dev: 4 };
     envs.sort((a, b) => {
@@ -1110,10 +1290,13 @@ const DashboardUI = (() => {
 
     container.innerHTML = envs.map(env => {
       const tagClass = guessEnvClass(env.name);
+      const envUrl = octopusEnvHref(env.name, env.spaces);
       return `
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-sm">
-            <span class="env-tag ${tagClass}">${DOMPurify.sanitize(env.name)}</span>
+            ${envUrl
+              ? `<a class="text-tertiary" href="${_escapeAttr(envUrl)}" target="_blank" rel="noopener noreferrer" style="text-decoration:none;"><span class="env-tag ${tagClass}">${DOMPurify.sanitize(env.name)}</span></a>`
+              : `<span class="env-tag ${tagClass}">${DOMPurify.sanitize(env.name)}</span>`}
             <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);">${env.spaces.length > 1 ? env.spaces.length + ' spaces' : env.spaces[0] || ''}</span>
           </div>
           <div class="flex items-center gap-xs">
@@ -1516,3 +1699,9 @@ const DashboardUI = (() => {
   };
 
 })();
+
+// Views reference chart utilities on DashboardData — alias from DashboardUI
+DashboardData.formatCompactCount = DashboardUI.formatCompactCount;
+DashboardData.trendBarPixelHeight = DashboardUI.trendBarPixelHeight;
+DashboardData.TREND_BAR_MAX_PX = DashboardUI.TREND_BAR_MAX_PX;
+DashboardData.formatIsoWeekDateRange = DashboardUI.formatIsoWeekDateRange;

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -1586,8 +1586,8 @@ const DashboardUI = (() => {
               <span class="text-secondary">${DOMPurify.sanitize(d._spaceName || '--')}</span>
             </div>
           </td>
-          <td><span class="badge ${statusClass}"><span class="status-dot ${statusClass}"></span> ${statusLabel}</span></td>
-          <td class="text-secondary monospace">${d.Duration || '--'}</td>
+          <td><span class="badge ${statusClass}"><span class="status-dot ${statusClass}"></span> ${DOMPurify.sanitize(statusLabel)}</span></td>
+          <td class="text-secondary monospace">${DOMPurify.sanitize(d.Duration || '--')}</td>
           <td class="text-secondary">${d.Created ? timeAgo(d.Created) : '--'}</td>
         </tr>`;
     }).join('');
@@ -1646,7 +1646,7 @@ const DashboardUI = (() => {
             ${envUrl
               ? `<a class="text-tertiary" href="${_escapeAttr(envUrl)}" target="_blank" rel="noopener noreferrer" style="text-decoration:none;"><span class="env-tag ${tagClass}">${DOMPurify.sanitize(env.name)}</span></a>`
               : `<span class="env-tag ${tagClass}">${DOMPurify.sanitize(env.name)}</span>`}
-            <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);">${env.spaces.length > 1 ? env.spaces.length + ' spaces' : env.spaces[0] || ''}</span>
+            <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);">${env.spaces.length > 1 ? env.spaces.length + ' spaces' : DOMPurify.sanitize(env.spaces[0] || '')}</span>
           </div>
           <div class="flex items-center gap-xs">
             <span class="text-secondary" style="font:var(--textBodyRegularSmall);">${env.success}/${env.total}</span>
@@ -1935,7 +1935,7 @@ const DashboardUI = (() => {
       <div class="flex items-center gap-sm flex-wrap">
         <span class="badge ${badgeClass}">${badgeLabel}</span>
         <span class="text-secondary" style="font:var(--textBodyRegularSmall);">
-          ${info.hostingEnv || 'Self-Hosted'} &mdash; ${daysFragment}
+          ${DOMPurify.sanitize(info.hostingEnv || 'Self-Hosted')} &mdash; ${daysFragment}
         </span>
       </div>`;
 

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -985,7 +985,7 @@ const DashboardData = (() => {
   const ENRICH_CAP = 10000;
   const ENRICH_MAX_RETRIES = 3;
   const INITIAL_TAKE = 200;
-  const CACHE_PFX = 'vdash_hist_';
+  const CACHE_PFX = 'valuemetrics.hist.v1_';
   const CACHE_MAX_AGE = 4 * 3600 * 1000; // 4 hours
 
   let _enrichment = { state: 'idle', lookbackMonths: 3, tasksFetched: 0, oldestDate: null, progress: 0, error: null };
@@ -1192,7 +1192,10 @@ const DashboardData = (() => {
               break;
             } catch (err) {
               if (err.status === 401 || err.status === 403) {
-                Object.assign(_enrichment, { state: 'error', error: 'Permission denied — your API key may lack TaskView permission.' });
+                Object.assign(_enrichment, {
+                  state: 'error',
+                  error: 'Permission denied — the signed-in user/session may lack the TaskView permission, or your session may have expired.'
+                });
                 notify();
                 log('Enrichment: auth/permission error', err.status);
                 return;

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -559,6 +559,8 @@ const DashboardData = (() => {
 
 const DashboardUI = (() => {
 
+  let _loadingDepth = 0;
+
   async function loadDashboard() {
     if (!OctopusApi.isConfigured()) return;
 
@@ -589,7 +591,43 @@ const DashboardUI = (() => {
   }
 
   function setLoading(loading) {
-    document.body.classList.toggle('is-loading', loading);
+    const overlay = document.getElementById('metrics-loading-overlay');
+    const detail = document.getElementById('metrics-loading-detail');
+    const card = document.getElementById('metrics-loading-card');
+
+    if (loading) {
+      _loadingDepth++;
+      document.body.classList.add('is-loading');
+      if (_loadingDepth !== 1) return;
+
+      if (detail && detail.dataset.defaultText) {
+        detail.textContent = detail.dataset.defaultText;
+      }
+      if (card) card.setAttribute('aria-busy', 'true');
+      if (overlay) {
+        overlay.removeAttribute('hidden');
+        overlay.setAttribute('aria-hidden', 'false');
+        requestAnimationFrame(() => {
+          overlay.classList.add('visible');
+        });
+      }
+      return;
+    }
+
+    _loadingDepth = Math.max(0, _loadingDepth - 1);
+    if (_loadingDepth > 0) return;
+
+    document.body.classList.remove('is-loading');
+    if (card) card.setAttribute('aria-busy', 'false');
+    if (overlay) {
+      overlay.classList.remove('visible');
+      overlay.setAttribute('aria-hidden', 'true');
+      setTimeout(() => {
+        if (_loadingDepth === 0) {
+          overlay.setAttribute('hidden', '');
+        }
+      }, 300);
+    }
   }
 
   function setStatusMessage(msg) {
@@ -597,6 +635,10 @@ const DashboardUI = (() => {
     if (el) {
       el.textContent = msg || '';
       el.style.display = msg ? '' : 'none';
+    }
+    const loadingDetail = document.getElementById('metrics-loading-detail');
+    if (loadingDetail && msg && document.body.classList.contains('is-loading')) {
+      loadingDetail.textContent = msg;
     }
   }
 

--- a/dashboards/valuemetrics/data.js
+++ b/dashboards/valuemetrics/data.js
@@ -1124,7 +1124,7 @@ const DashboardData = (() => {
     try {
       const cached = _loadHistCache();
       const cacheValid = cached && cached.totalTasksFetched > 0 &&
-        (allTime ? cached.lookbackMonths === 0 : cached.lookbackMonths >= lookbackMonths);
+        cached.lookbackMonths === lookbackMonths;
       if (cacheValid) {
         _histAgg = cached;
         Object.assign(_enrichment, { state: 'complete', progress: 100, tasksFetched: cached.totalTasksFetched, oldestDate: cached.oldestTaskDate });
@@ -1176,9 +1176,21 @@ const DashboardData = (() => {
         while (!chunkDone && agg.totalTasksFetched < ENRICH_CAP) {
           if (_enrichCancelled) return;
 
-          const resp = await safeGet(
-            `/api/tasks?spaces=${encodeURIComponent(ids)}&name=Deploy&states=Success,Failed&take=${ENRICH_PAGE}&skip=${skip}`
-          );
+          let resp;
+          try {
+            resp = await OctopusApi.get(
+              `/api/tasks?spaces=${encodeURIComponent(ids)}&name=Deploy&states=Success,Failed&take=${ENRICH_PAGE}&skip=${skip}`
+            );
+          } catch (err) {
+            if (err.status === 401 || err.status === 403) {
+              Object.assign(_enrichment, { state: 'error', error: 'Permission denied — your API key may lack TaskView permission.' });
+              notify();
+              log('Enrichment: auth/permission error', err.status);
+              return;
+            }
+            if (err.status === 404) { chunkDone = true; break; }
+            throw err;
+          }
 
           if (!resp?.Items?.length) { chunkDone = true; break; }
           if (!estimatedTotal && resp.TotalResults) estimatedTotal = resp.TotalResults;
@@ -1260,6 +1272,11 @@ const DashboardData = (() => {
   function computeEnrichedKPIs() {
     if (!_histAgg) return null;
     const agg = _histAgg;
+    // If the enrichment aggregate has no buckets or no tasks were fetched,
+    // treat this as "no enriched data" so callers fall back to base KPIs.
+    if (!agg.weeklyBuckets || Object.keys(agg.weeklyBuckets).length === 0 || agg.totalTasksFetched === 0) {
+      return null;
+    }
     let total = 0, success = 0, failed = 0;
     for (const w of Object.values(agg.weeklyBuckets)) {
       total += w.total;
@@ -2029,18 +2046,12 @@ const DashboardUI = (() => {
     renderRecentDeployments(summary.recentDeployments);
     renderEnvHealth(summary.envHealth);
 
-    // Use enriched counts for the donut chart when available
-    const enriched = DashboardData.computeEnrichedKPIs();
-    if (enriched) {
-      renderSuccessFailureChart({
-        ...summary,
-        successCount: enriched.totalSuccess,
-        failedCount: enriched.totalFailed,
-        cancelledCount: Math.max(0, enriched.totalDeployments - enriched.totalSuccess - enriched.totalFailed),
-      });
-    } else {
-      renderSuccessFailureChart(summary);
-    }
+    // Always use summary deployment counts for the donut chart so that
+    // all task outcomes (including Cancelled and other non-success/failure
+    // states) are represented accurately. The enriched KPI aggregation
+    // currently only covers Success/Failed, so it must not be used to
+    // derive donut counts.
+    renderSuccessFailureChart(summary);
 
     // Use enriched weekly trend for the chart when available
     const enrichedWeekly = DashboardData.getHistoricalWeeklyTrend();

--- a/dashboards/valuemetrics/index.html
+++ b/dashboards/valuemetrics/index.html
@@ -85,6 +85,18 @@
             <span id="header-text">Platform Dashboard</span>
         </div>
         <div class="header-actions">
+            <div class="lookback-wrapper" id="lookback-wrapper">
+                <i class="fa-solid fa-clock-rotate-left"></i>
+                <select id="lookback-select" class="lookback-select" title="Historical data lookback period">
+                    <option value="3" selected>3 months</option>
+                    <option value="6">6 months</option>
+                    <option value="12">1 year</option>
+                    <option value="24">2 years</option>
+                    <option value="36">3 years</option>
+                    <option value="60">5 years</option>
+                    <option value="0">All time</option>
+                </select>
+            </div>
             <span class="text-secondary" style="font: var(--textBodyRegularSmall);">
                 <i class="fa-regular fa-clock"></i>
                 Last refreshed: <span id="last-refresh">--</span>

--- a/dashboards/valuemetrics/index.html
+++ b/dashboards/valuemetrics/index.html
@@ -123,6 +123,22 @@
 
 </div>
 
+<!-- Full-screen metrics load -->
+<div id="metrics-loading-overlay" class="onboarding-overlay metrics-loading-overlay" aria-hidden="true" hidden>
+    <div class="onboarding-card metrics-loading-card" role="status" aria-live="polite" id="metrics-loading-card">
+        <div class="onboarding-body metrics-loading-body">
+            <div class="metrics-loading-spinner-wrap" aria-hidden="true">
+                <i class="fa-solid fa-spinner fa-spin metrics-loading-spinner"></i>
+            </div>
+            <h2 class="onboarding-title metrics-loading-title">Loading metrics</h2>
+            <p class="onboarding-text metrics-loading-text" id="metrics-loading-detail"
+               data-default-text="Pulling deployment data and KPIs from your Octopus instance. This can take a moment on larger systems.">
+                Pulling deployment data and KPIs from your Octopus instance. This can take a moment on larger systems.
+            </p>
+        </div>
+    </div>
+</div>
+
 <!-- Load shared extension helper (provides getDashboardConfig) -->
 <script src="../api.js"></script>
 <!-- Our dashboard scripts -->

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -645,7 +645,24 @@ a:hover {
   word-break: break-word;
   text-align: center;
   line-height: 1.25;
-  min-height: 2.5em;
+  min-height: 4.25em;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+}
+.deployment-trend-chart--daily .deployment-trend-bar-stack {
+  max-width: min(28px, 100%);
+}
+.deployment-trend-chart--daily .deployment-trend-value {
+  font-size: 0.68rem;
+}
+.deployment-trend-axis-label--dense {
+  font-size: 0.62rem;
+  line-height: 1.15;
+  min-height: 3.6em;
 }
 
 .deployment-trend-bars > [data-tooltip]:first-child:not(:last-child)::after {

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -1045,6 +1045,15 @@ tbody tr:last-child td {
   transform: translateY(12px);
 }
 
+/* Environments modal: avoid any slide/transform animation (backdrop fade only) */
+.modal-overlay#env-spaces-modal .modal {
+  transform: none;
+  transition: none;
+}
+.modal-overlay#env-spaces-modal[aria-hidden="true"] .modal {
+  transform: none;
+}
+
 .modal-header {
   display: flex;
   align-items: center;
@@ -1938,6 +1947,74 @@ tbody tr:last-child td {
 
 .env-detail-footer {
   margin-top: var(--space-sm);
+}
+
+/* ---- Environment card links ---- */
+.env-octopus-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  font: var(--textBodyRegularXSmall);
+}
+
+.env-octopus-link-label {
+  white-space: nowrap;
+}
+
+.env-octopus-link-arrow {
+  opacity: 0.9;
+}
+
+/* ---- Environment spaces preview "+N more" ---- */
+.env-spaces-more {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+  vertical-align: middle;
+  text-decoration: none;
+}
+
+.env-spaces-more:hover .env-spaces-more-arrow {
+  opacity: 1;
+}
+
+.env-spaces-more-arrow {
+  opacity: 0.85;
+}
+
+.env-spaces-more:focus-visible {
+  outline: 2px solid var(--colorBorderActive);
+  outline-offset: 2px;
+  border-radius: var(--radiusSmall);
+}
+
+/* ---- Environment spaces modal (compact grid + pills) ---- */
+.modal-overlay#env-spaces-modal .view-search-wrapper {
+  background: var(--colorBackgroundPrimaryDefault);
+}
+
+.modal-overlay#env-spaces-modal .env-spaces-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-xxs) var(--space-sm);
+  align-items: start;
+}
+
+.modal-overlay#env-spaces-modal .env-space-pill {
+  justify-self: start;
+}
+
+.modal-overlay#env-spaces-modal .badge {
+  font: var(--textBodyRegularXSmall);
+  padding: 0.1rem 0.45rem;
 }
 
 /* ---- View Search Input (Projects view) ---- */

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -2587,3 +2587,98 @@ tbody tr:last-child td {
   margin-top: 4px;
   height: 16px;
 }
+
+/* ---- Lookback period selector ---- */
+
+.lookback-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  color: var(--colorTextTertiary);
+  font: var(--textBodyRegularSmall);
+}
+
+.lookback-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--colorBackgroundSecondaryDefault);
+  border: 1px solid var(--colorBorderDefault);
+  border-radius: var(--radiusSmall);
+  color: var(--colorTextSecondary);
+  font: var(--textBodyRegularSmall);
+  padding: 4px 24px 4px 8px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  transition: border-color var(--transitionFast);
+}
+
+.lookback-select:hover {
+  border-color: var(--colorBorderHover);
+}
+
+.lookback-select:focus {
+  outline: none;
+  border-color: var(--colorPrimary);
+  box-shadow: 0 0 0 2px rgba(var(--colorPrimaryRGB, 59, 130, 246), 0.15);
+}
+
+/* ---- Enrichment progress banner ---- */
+
+.enrichment-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-md);
+  border-radius: var(--radiusMedium);
+  background: var(--colorBackgroundSecondaryDefault);
+  border: 1px solid var(--colorBorderDefault);
+  font: var(--textBodyRegularSmall);
+  color: var(--colorTextSecondary);
+  min-height: 36px;
+}
+
+.enrichment-banner--hidden {
+  display: none;
+}
+
+.enrichment-banner--complete {
+  background: color-mix(in srgb, var(--colorSuccess) 6%, var(--colorBackgroundSecondaryDefault));
+  border-color: color-mix(in srgb, var(--colorSuccess) 20%, var(--colorBorderDefault));
+}
+
+.enrichment-banner--error {
+  background: color-mix(in srgb, var(--colorDanger) 6%, var(--colorBackgroundSecondaryDefault));
+  border-color: color-mix(in srgb, var(--colorDanger) 20%, var(--colorBorderDefault));
+}
+
+.enrichment-progress-track {
+  flex: 1;
+  height: 4px;
+  background: var(--colorBackgroundTertiary);
+  border-radius: 2px;
+  overflow: hidden;
+  max-width: 200px;
+}
+
+.enrichment-progress-bar {
+  height: 100%;
+  background: var(--colorPrimary);
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+
+.enrichment-text {
+  white-space: nowrap;
+}
+
+.enrichment-spinner {
+  animation: spin 1s linear infinite;
+  color: var(--colorPrimary);
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -706,6 +706,16 @@ a:hover {
   overflow-y: auto;
 }
 
+#reliability-space-rates,
+.reliability-space-rates {
+  --recent-scroll-visible-rows: 12;
+  --recent-scroll-row-est: calc(var(--space-sm) * 2 + 1.25rem + 1px);
+  max-height: calc(var(--recent-scroll-row-est) * var(--recent-scroll-visible-rows) + var(--space-sm) * 2 + 1.35rem + 1px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: var(--space-xs);
+}
+
 #env-health {
   --recent-scroll-visible-rows: 12;
   --recent-scroll-row-est: calc(var(--space-sm) * 2 + 1.25rem + 1px);
@@ -861,6 +871,69 @@ tbody tr:last-child td {
 .chart-container:has(.deployment-trend-chart) {
   align-items: stretch;
   justify-content: stretch;
+}
+
+/* Reliability: compact failure-rate trend */
+.reliability-failure-trend.deployment-trend-chart .deployment-trend-bars {
+  min-height: 4.5rem; /* override the shared 12.5rem minimum */
+  padding-bottom: var(--space-xxs);
+}
+.reliability-failure-trend.deployment-trend-chart .deployment-trend-value,
+.reliability-failure-trend.deployment-trend-chart .deployment-trend-axis-label {
+  display: none;
+}
+.reliability-failure-trend.deployment-trend-chart .deployment-trend-bar-stack {
+  max-width: min(28px, 100%);
+}
+
+/* Reliability: remove generic chart centering/min-height */
+.chart-container.reliability-failure-trend-container {
+  min-height: 0 !important;
+  height: auto !important;
+  align-items: flex-start !important;
+  justify-content: flex-start !important;
+}
+.chart-container.reliability-failure-trend-container:has(.deployment-trend-chart) {
+  align-items: stretch;
+  justify-content: stretch;
+}
+
+/* Reliability: Failure Rate Trend compact list */
+.reliability-failure-trend-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  /* Let the 12-week list expand; no scroll for this section. */
+  overflow-x: hidden;
+  padding-right: var(--space-xs);
+}
+
+.reliability-failure-trend-row {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr 3.5rem;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.reliability-failure-trend-week {
+  font: var(--textBodyRegularSmall);
+  color: var(--colorTextSecondary);
+  white-space: normal;
+  line-height: 1.15;
+  word-break: break-word;
+}
+
+.reliability-failure-trend-bar {
+  margin: 0;
+  width: 100%;
+  height: 6px;
+}
+
+.reliability-failure-trend-value {
+  font: var(--textBodyBoldSmall);
+  color: var(--colorDanger);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 
@@ -2422,4 +2495,95 @@ tbody tr:last-child td {
 .license-ptm-code {
   font: var(--textCodeRegularXSmall);
   word-break: break-all;
+}
+
+/* --------------------------------------------------------------------------
+   Deployment Trends — Day-of-week chart
+   -------------------------------------------------------------------------- */
+
+.dow-chart {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.dow-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.dow-row--weekend {
+  opacity: 0.6;
+}
+
+.dow-row--peak .dow-label {
+  color: var(--colorTextPrimary);
+  font-weight: 600;
+}
+
+.dow-label {
+  width: 32px;
+  font: var(--textBodyBoldSmall);
+  color: var(--colorTextSecondary);
+  flex-shrink: 0;
+}
+
+.dow-bar {
+  flex: 1;
+  min-width: 0;
+}
+
+.dow-count {
+  width: 40px;
+  text-align: right;
+  font: var(--textBodyRegularSmall);
+  color: var(--colorTextTertiary);
+  flex-shrink: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Deployment Trends — Hour-of-day chart
+   -------------------------------------------------------------------------- */
+
+.hour-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 110px;
+  padding-top: var(--space-xs);
+}
+
+.hour-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+}
+
+.hour-bar-wrap {
+  width: 100%;
+  height: 84px;
+  display: flex;
+  align-items: flex-end;
+}
+
+.hour-bar {
+  width: 100%;
+  background: var(--colorPrimary);
+  border-radius: 2px 2px 0 0;
+  min-height: 0;
+  transition: height var(--transitionFast);
+}
+
+.hour-col--peak .hour-bar {
+  background: var(--colorPrimaryLight);
+}
+
+.hour-label {
+  font: var(--textBodyRegularXSmall);
+  color: var(--colorTextTertiary);
+  margin-top: 4px;
+  height: 16px;
 }

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -353,6 +353,10 @@ a:hover {
   border-color: var(--colorBorderActive);
 }
 
+.card.card--chart-tooltips {
+  overflow: visible;
+}
+
 .card-header {
   display: flex;
   align-items: center;
@@ -564,6 +568,96 @@ a:hover {
   visibility: visible;
 }
 
+.deployment-trend-chart {
+  width: 100%;
+  min-width: 0;
+  overflow: visible;
+}
+.deployment-trend-bars {
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
+  min-width: 0;
+  overflow: visible;
+  min-height: 12.5rem;
+  height: auto;
+  padding-bottom: var(--space-xxs);
+  box-sizing: border-box;
+}
+.deployment-trend-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 100%;
+  cursor: help;
+}
+.deployment-trend-value {
+  flex-shrink: 0;
+  font: var(--textBodyRegularXSmall);
+  color: var(--colorTextTertiary);
+  margin-bottom: var(--space-xxs);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  line-height: 1.2;
+  max-width: 100%;
+}
+.deployment-trend-value--emph {
+  font: var(--textBodyBoldXSmall);
+  color: var(--colorTextSecondary);
+}
+.deployment-trend-bar-area {
+  flex-shrink: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+}
+.deployment-trend-bar-stack {
+  width: 100%;
+  max-width: min(36px, 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  box-sizing: border-box;
+}
+.deployment-trend-seg {
+  flex-shrink: 0;
+}
+.deployment-trend-seg--fail {
+  background: var(--colorDanger);
+}
+.deployment-trend-seg--other {
+  background: var(--colorBackgroundTertiary);
+}
+.deployment-trend-seg--success {
+  background: var(--colorSuccess);
+}
+.deployment-trend-axis-label {
+  flex-shrink: 0;
+  font: var(--textBodyRegularXSmall);
+  color: var(--colorTextTertiary);
+  margin-top: var(--space-xs);
+  white-space: normal;
+  word-break: break-word;
+  text-align: center;
+  line-height: 1.25;
+  min-height: 2.5em;
+}
+
+.deployment-trend-bars > [data-tooltip]:first-child:not(:last-child)::after {
+  left: 0;
+  transform: none;
+}
+.deployment-trend-bars > [data-tooltip]:last-child:not(:first-child)::after {
+  left: auto;
+  right: 0;
+  transform: none;
+}
+
 .status-dot {
   width: 8px;
   height: 8px;
@@ -712,6 +806,11 @@ tbody tr:last-child td {
   justify-content: center;
   color: var(--colorTextTertiary);
   font: var(--textBodyRegularMedium);
+}
+
+.chart-container:has(.deployment-trend-chart) {
+  align-items: stretch;
+  justify-content: stretch;
 }
 
 

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -563,7 +563,9 @@ a:hover {
   visibility: hidden;
   pointer-events: none;
 }
-[data-tooltip]:hover::after {
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after,
+[data-tooltip]:focus::after {
   opacity: 1;
   visibility: visible;
 }

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -706,6 +706,23 @@ a:hover {
   overflow-y: auto;
 }
 
+#env-health {
+  --recent-scroll-visible-rows: 12;
+  --recent-scroll-row-est: calc(var(--space-sm) * 2 + 1.25rem + 1px);
+  max-height: calc(var(--recent-scroll-row-est) * var(--recent-scroll-visible-rows) + var(--space-sm) * 2 + 1.35rem + 1px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: var(--space-xs);
+}
+
+#env-health .env-tag {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .table-wrapper--recent-scroll thead th {
   position: sticky;
   top: 0;

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -698,6 +698,22 @@ a:hover {
   overflow-x: auto;
 }
 
+/* Dense tables (Space Breakdown, Recent Deployments): ~12 rows visible, then scroll */
+.table-wrapper--recent-scroll {
+  --recent-scroll-visible-rows: 12;
+  --recent-scroll-row-est: calc(var(--space-sm) * 2 + 1.25rem + 1px);
+  max-height: calc(var(--recent-scroll-row-est) * var(--recent-scroll-visible-rows) + var(--space-sm) * 2 + 1.35rem + 1px);
+  overflow-y: auto;
+}
+
+.table-wrapper--recent-scroll thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--colorBackgroundCard);
+  box-shadow: 0 1px 0 var(--colorBorderDefault);
+}
+
 table {
   width: 100%;
   border-collapse: collapse;

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -528,6 +528,42 @@ a:hover {
   color: var(--colorTextSecondary);
 }
 
+[data-tooltip] {
+  position: relative;
+  cursor: help;
+}
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  padding: var(--space-xs) var(--space-sm);
+  max-width: min(22rem, 85vw);
+  min-width: 8rem;
+  width: max-content;
+  background: var(--colorBackgroundSecondaryDefault);
+  border: 1px solid var(--colorBorderDefault);
+  border-radius: var(--radiusMedium);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  font: var(--textBodyRegularSmall);
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: normal;
+  color: var(--colorTextPrimary);
+  white-space: normal;
+  text-align: left;
+  line-height: 1.4;
+  z-index: 10000;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+[data-tooltip]:hover::after {
+  opacity: 1;
+  visibility: visible;
+}
+
 .status-dot {
   width: 8px;
   height: 8px;

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -2204,3 +2204,128 @@ tbody tr:last-child td {
   font-size: 0.5rem;
   opacity: 0.5;
 }
+
+/* ----- License card (compliance + PTM) ----- */
+
+.license-card {
+  padding: var(--space-md) var(--space-lg);
+  border: 1px solid var(--colorBorderDefault);
+}
+
+.license-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.license-card-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  min-width: min(100%, 280px);
+}
+
+.license-card-heading {
+  font: var(--textBodyRegularSmall);
+}
+
+.license-card-status {
+  flex: 1;
+  min-width: 200px;
+}
+
+.license-card-version {
+  font: var(--textBodyRegularXSmall);
+  white-space: nowrap;
+}
+
+.license-ptm {
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--colorBorderDefault);
+}
+
+.license-ptm-label {
+  font: var(--textBodyBoldXSmall);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-sm);
+}
+
+.license-compliance-summary {
+  font: var(--textBodyRegularSmall);
+  margin: var(--space-md) 0 0;
+  line-height: 1.45;
+}
+
+.license-ptm-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-sm) var(--space-md);
+}
+
+@media (max-width: 640px) {
+  .license-ptm-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.license-ptm-metric {
+  background: var(--colorBackgroundPrimaryDefault);
+  border: 1px solid var(--colorBorderDefault);
+  border-radius: var(--radiusSmall);
+  padding: var(--space-sm) var(--space-md);
+  min-width: 0;
+}
+
+.license-ptm-metric-label {
+  display: block;
+  font: var(--textBodyRegularXSmall);
+  color: var(--colorTextTertiary);
+  margin-bottom: 4px;
+}
+
+.license-ptm-metric-value {
+  font: var(--textHeadingSmall);
+  color: var(--colorTextPrimary);
+  font-variant-numeric: tabular-nums;
+}
+
+.license-ptm-metric-value--over {
+  color: var(--colorTextDanger);
+}
+
+.license-ptm-metric-value--grace {
+  color: var(--colorTextWarning);
+}
+
+.license-ptm-hint {
+  font: var(--textBodyRegularXSmall);
+  margin: 0 0 var(--space-sm);
+  line-height: 1.45;
+  max-width: 52rem;
+}
+
+.license-ptm-hint-em {
+  font: var(--textBodyBoldXSmall);
+  color: var(--colorTextSecondary);
+}
+
+.license-ptm-note {
+  font: var(--textBodyRegularXSmall);
+  margin: var(--space-md) 0 0;
+  line-height: 1.45;
+}
+
+.license-ptm-note .fa-circle-info {
+  margin-right: 6px;
+  opacity: 0.8;
+}
+
+.license-ptm-code {
+  font: var(--textCodeRegularXSmall);
+  word-break: break-all;
+}

--- a/dashboards/valuemetrics/styles.css
+++ b/dashboards/valuemetrics/styles.css
@@ -1117,6 +1117,43 @@ tbody tr:last-child td {
   opacity: 1;
 }
 
+.metrics-loading-overlay {
+  z-index: 9998;
+}
+
+.metrics-loading-overlay[hidden] {
+  display: none !important;
+}
+
+.metrics-loading-card {
+  max-width: 440px;
+}
+
+.metrics-loading-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--space-xl) var(--space-lg);
+}
+
+.metrics-loading-spinner-wrap {
+  margin-bottom: var(--space-md);
+}
+
+.metrics-loading-spinner {
+  font-size: 2.5rem;
+  color: var(--colorPrimaryLighter);
+}
+
+.metrics-loading-title {
+  margin-bottom: var(--space-xs);
+}
+
+.metrics-loading-text {
+  margin-bottom: 0;
+}
+
 /* Header with progress */
 .onboarding-header {
   display: flex;

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -254,7 +254,7 @@ const Views = (() => {
     <div class="dashboard-grid mb-lg">
       <div class="card col-span-12">
         <div class="card-body" style="padding:0;">
-          <div class="table-wrapper">
+          <div class="table-wrapper table-wrapper--recent-scroll">
             <table>
               <thead>
                 <tr>
@@ -287,7 +287,7 @@ const Views = (() => {
           <a href="#" class="text-secondary" style="font:var(--textBodyRegularSmall);">View all <i class="fa-solid fa-arrow-right"></i></a>
         </div>
         <div class="card-body" style="padding:0;">
-          <div class="table-wrapper">
+          <div class="table-wrapper table-wrapper--recent-scroll">
             <table>
               <thead>
                 <tr>

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -1265,8 +1265,8 @@ const Views = (() => {
                 <td>${DOMPurify.sanitize(d._projectName || d.ProjectId || '--')}</td>
                 <td class="monospace">${DOMPurify.sanitize(d.ReleaseVersion || '--')}</td>
                 <td>${DOMPurify.sanitize(d._envName || d.EnvironmentId || '--')}</td>
-                <td><div class="flex items-center gap-xs"><div class="space-avatar sm" style="width:20px;height:20px;font-size:0.5rem;">${(d._spaceName || '?').charAt(0)}</div> <span class="text-secondary">${DOMPurify.sanitize(d._spaceName || '--')}</span></div></td>
-                <td class="text-secondary monospace">${d.Duration || '--'}</td>
+                <td><div class="flex items-center gap-xs"><div class="space-avatar sm" style="width:20px;height:20px;font-size:0.5rem;">${DOMPurify.sanitize((d._spaceName || '?').charAt(0))}</div> <span class="text-secondary">${DOMPurify.sanitize(d._spaceName || '--')}</span></div></td>
+                <td class="text-secondary monospace">${DOMPurify.sanitize(d.Duration || '--')}</td>
                 <td class="text-secondary">${d.Created ? timeAgo(d.Created) : '--'}</td>
               </tr>`).join('') : '<tr><td colspan="6" class="text-secondary" style="text-align:center;padding:var(--space-lg);"><i class="fa-solid fa-check-circle text-success" style="margin-right:var(--space-xs);"></i> No failed deployments — nice!</td></tr>'}
             </tbody>
@@ -1390,13 +1390,13 @@ const Views = (() => {
           <div class="card mt-lg">
             <div class="card-header">
               <h3 class="card-title">
-                <div class="space-avatar sm" style="display:inline-flex;vertical-align:middle;margin-right:var(--space-xs);">${spaceInfo.name.charAt(0).toUpperCase()}</div>
+                <div class="space-avatar sm" style="display:inline-flex;vertical-align:middle;margin-right:var(--space-xs);">${DOMPurify.sanitize(spaceInfo.name.charAt(0).toUpperCase())}</div>
                 ${DOMPurify.sanitize(spaceInfo.name)} — Detail
               </h3>
               ${octopusSpaceUrl ? `
                 <a
                   class="text-tertiary"
-                  href="${octopusSpaceUrl}"
+                  href="${_escapeAttr(octopusSpaceUrl)}"
                   target="_blank"
                   rel="noopener noreferrer"
                   style="font:var(--textBodyRegularSmall);display:inline-flex;align-items:center;gap:var(--space-xxs);text-decoration:none;"
@@ -1430,7 +1430,7 @@ const Views = (() => {
                       return `<tr>
                         <td>${DOMPurify.sanitize(d._projectName || d.ProjectId || '--')}</td>
                         <td>${DOMPurify.sanitize(d._envName || d.EnvironmentId || '--')}</td>
-                        <td><span class="badge ${cls}">${state.charAt(0).toUpperCase() + state.slice(1)}</span></td>
+                        <td><span class="badge ${cls}">${DOMPurify.sanitize(state.charAt(0).toUpperCase() + state.slice(1))}</span></td>
                         <td class="text-secondary">${d.Created ? timeAgo(d.Created) : '--'}</td>
                       </tr>`;
                     }).join('')}

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -25,6 +25,7 @@ const Views = (() => {
     return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
   }
 
+  
   function _escapeAttr(text) {
     return String(text)
       .replace(/&/g, '&amp;')
@@ -369,11 +370,40 @@ const Views = (() => {
     const totalDeploys = summary.kpi.totalDeployments;
     const successRate = summary.kpi.successRate;
     const frequency = summary.kpi.deployFrequency;
+    const trendChange = DashboardData.computeTrendChange(summary.weeklyTrend);
+    const dayOfWeek = DashboardData.computeDayOfWeekDistribution();
+    const hourOfDay = DashboardData.computeHourOfDayDistribution();
+    const envBreakdown = DashboardData.computePerEnvTypeDeployments();
+
+    const wt = summary.weeklyTrend || [];
+    const thisWeek = wt.length > 0 ? wt[wt.length - 1] : null;
+    const lastWeek = wt.length > 1 ? wt[wt.length - 2] : null;
+    const thisWeekTotal = thisWeek ? thisWeek.total : 0;
+    const weekChangeHtml = lastWeek && lastWeek.total > 0
+      ? (() => {
+          const pct = Math.round(((thisWeekTotal - lastWeek.total) / lastWeek.total) * 100);
+          const icon = pct > 0 ? 'fa-arrow-up' : pct < 0 ? 'fa-arrow-down' : 'fa-minus';
+          const cls = pct > 0 ? 'text-success' : pct < 0 ? 'text-danger' : 'text-secondary';
+          return `<span class="${cls}"><i class="fa-solid ${icon}"></i> ${Math.abs(pct)}% vs last wk</span>`;
+        })()
+      : '<span>current week</span>';
+
+    const trendArrow = !trendChange ? { icon: 'fa-minus', cls: 'amber', label: 'insufficient data' }
+      : trendChange.direction === 'up' ? { icon: 'fa-arrow-trend-up', cls: 'green', label: `↑ ${trendChange.pct}% vs prior period` }
+      : trendChange.direction === 'down' ? { icon: 'fa-arrow-trend-down', cls: 'danger', label: `↓ ${trendChange.pct}% vs prior period` }
+      : { icon: 'fa-minus', cls: 'amber', label: 'stable' };
+
+    const maxDow = Math.max(...dayOfWeek.map(d => d.count), 1);
+    const busiestDay = dayOfWeek.reduce((a, b) => a.count >= b.count ? a : b);
+    const maxHour = Math.max(...hourOfDay.map(h => h.count), 1);
+    const busiestHour = hourOfDay.reduce((a, b) => a.count >= b.count ? a : b);
+    const envTotal = envBreakdown.types.production + envBreakdown.types.staging + envBreakdown.types.dev;
+    const envPct = (n) => envTotal > 0 ? Math.round(n / envTotal * 100) : 0;
 
     return `
     <div class="page-header">
       <h1 class="page-title">Deployment Trends</h1>
-      <p class="page-subtitle">Deployment activity over time &mdash; track trends, patterns, and compare across spaces.</p>
+      <p class="page-subtitle">Deployment activity over time &mdash; track patterns, compare spaces, and spot trends.</p>
     </div>
 
     <!-- KPI strip -->
@@ -385,6 +415,14 @@ const Views = (() => {
         </div>
         <span class="kpi-value">${totalDeploys.toLocaleString()}</span>
         <span class="kpi-trend neutral"><i class="fa-solid fa-database"></i> <span>all time</span></span>
+      </div>
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">This Week</span>
+          <div class="kpi-icon purple"><i class="fa-solid fa-calendar-week"></i></div>
+        </div>
+        <span class="kpi-value">${thisWeekTotal}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-line"></i> ${weekChangeHtml}</span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -404,19 +442,11 @@ const Views = (() => {
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
-          <span class="kpi-label">Successful</span>
-          <div class="kpi-icon green"><i class="fa-solid fa-check"></i></div>
+          <span class="kpi-label">4-Week Trend</span>
+          <div class="kpi-icon ${trendArrow.cls}"><i class="fa-solid ${trendArrow.icon}"></i></div>
         </div>
-        <span class="kpi-value">${summary.successCount.toLocaleString()}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-thumbs-up"></i> <span>total successful</span></span>
-      </div>
-      <div class="kpi-card">
-        <div class="flex items-center justify-between">
-          <span class="kpi-label">Failed</span>
-          <div class="kpi-icon danger"><i class="fa-solid fa-xmark"></i></div>
-        </div>
-        <span class="kpi-value">${summary.failedCount.toLocaleString()}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-triangle-exclamation"></i> <span>total failures</span></span>
+        <span class="kpi-value" style="${trendChange ? (trendChange.direction === 'up' ? 'color:var(--colorSuccess)' : trendChange.direction === 'down' ? 'color:var(--colorDanger)' : '') : ''}">${trendChange ? (trendChange.direction === 'flat' ? 'Stable' : `${trendChange.pct}%`) : '--'}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-scale-balanced"></i> <span>${trendArrow.label}</span></span>
       </div>
     </div>
 
@@ -444,6 +474,104 @@ const Views = (() => {
         <div class="chart-container" id="trends-chart">${_renderTrendChart(summary, '30d')}</div>
       </div>
     </div>
+
+    <!-- Deployment Patterns -->
+    <div class="section-header">
+      <h2 class="section-title"><i class="fa-solid fa-calendar-alt"></i> Deployment Patterns</h2>
+    </div>
+    <div class="dashboard-grid mb-lg">
+      <div class="card col-span-6">
+        <div class="card-header">
+          <h3 class="card-title">Day of Week</h3>
+          <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);">Busiest: <strong style="color:var(--colorTextSecondary);">${busiestDay.name}</strong></span>
+        </div>
+        <div class="card-body">
+          <div class="dow-chart">
+            ${dayOfWeek.map(d => {
+              const pct = maxDow > 0 ? Math.round(d.count / maxDow * 100) : 0;
+              const isBusiest = d === busiestDay && d.count > 0;
+              return `<div class="dow-row${d.isWeekend ? ' dow-row--weekend' : ''}${isBusiest ? ' dow-row--peak' : ''}">
+                <span class="dow-label">${d.name}</span>
+                <div class="progress-bar dow-bar"><div class="progress-fill ${isBusiest ? 'info' : 'success'}" style="width:${pct}%;"></div></div>
+                <span class="dow-count monospace">${d.count}</span>
+              </div>`;
+            }).join('')}
+          </div>
+        </div>
+      </div>
+      <div class="card col-span-6">
+        <div class="card-header">
+          <h3 class="card-title">Time of Day (UTC)</h3>
+          <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);">Peak: <strong style="color:var(--colorTextSecondary);">${String(busiestHour.hour).padStart(2, '0')}:00</strong></span>
+        </div>
+        <div class="card-body">
+          <div class="hour-chart">
+            ${hourOfDay.map(h => {
+              const pct = maxHour > 0 ? Math.round(h.count / maxHour * 100) : 0;
+              const isPeak = h === busiestHour && h.count > 0;
+              return `<div class="hour-col${isPeak ? ' hour-col--peak' : ''}" data-tooltip="${String(h.hour).padStart(2, '0')}:00 UTC — ${h.count} deployments">
+                <div class="hour-bar-wrap"><div class="hour-bar" style="height:${pct}%;"></div></div>
+                <span class="hour-label">${h.hour % 6 === 0 ? String(h.hour).padStart(2, '0') : ''}</span>
+              </div>`;
+            }).join('')}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Environment Distribution -->
+    <div class="section-header">
+      <h2 class="section-title"><i class="fa-solid fa-server"></i> Environment Distribution</h2>
+    </div>
+    <div class="dashboard-grid mb-lg">
+      <div class="card col-span-4">
+        <div class="card-body" style="text-align:center;padding:var(--space-lg);">
+          <div class="env-tag production" style="margin-bottom:var(--space-sm);display:inline-block;">Production</div>
+          <div style="font:var(--textHeadingLarge);color:var(--colorTextPrimary);">${envBreakdown.types.production.toLocaleString()}</div>
+          <div style="font:var(--textBodyRegularSmall);color:var(--colorTextTertiary);margin-top:var(--space-xxs);">${envPct(envBreakdown.types.production)}% of deployments</div>
+        </div>
+      </div>
+      <div class="card col-span-4">
+        <div class="card-body" style="text-align:center;padding:var(--space-lg);">
+          <div class="env-tag staging" style="margin-bottom:var(--space-sm);display:inline-block;">Staging / UAT</div>
+          <div style="font:var(--textHeadingLarge);color:var(--colorTextPrimary);">${envBreakdown.types.staging.toLocaleString()}</div>
+          <div style="font:var(--textBodyRegularSmall);color:var(--colorTextTertiary);margin-top:var(--space-xxs);">${envPct(envBreakdown.types.staging)}% of deployments</div>
+        </div>
+      </div>
+      <div class="card col-span-4">
+        <div class="card-body" style="text-align:center;padding:var(--space-lg);">
+          <div class="env-tag dev" style="margin-bottom:var(--space-sm);display:inline-block;">Development</div>
+          <div style="font:var(--textHeadingLarge);color:var(--colorTextPrimary);">${envBreakdown.types.dev.toLocaleString()}</div>
+          <div style="font:var(--textBodyRegularSmall);color:var(--colorTextTertiary);margin-top:var(--space-xxs);">${envPct(envBreakdown.types.dev)}% of deployments</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Per-Environment Breakdown -->
+    ${envBreakdown.environments.length > 0 ? `
+    <div class="card mb-lg">
+      <div class="card-header"><h3 class="card-title">Per-Environment Breakdown</h3></div>
+      <div class="card-body" style="padding:0;">
+        <div class="table-wrapper">
+          <table>
+            <thead><tr><th>Environment</th><th>Type</th><th>Deployments</th><th>Success</th><th>Failed</th><th>Success Rate</th></tr></thead>
+            <tbody>
+              ${envBreakdown.environments.slice(0, 15).map(e => {
+                const rate = e.count > 0 ? Math.round(e.success / e.count * 100) : 0;
+                return `<tr>
+                  <td><span class="env-tag ${e.cls}">${DOMPurify.sanitize(e.name)}</span></td>
+                  <td class="text-secondary">${e.cls.charAt(0).toUpperCase() + e.cls.slice(1)}</td>
+                  <td class="monospace">${e.count}</td>
+                  <td class="text-success monospace">${e.success}</td>
+                  <td class="text-danger monospace">${e.failed}</td>
+                  <td><div class="flex items-center gap-xs"><div class="progress-bar" style="width:60px;"><div class="progress-fill ${rate >= 90 ? 'success' : rate >= 70 ? 'warning' : 'danger'}" style="width:${rate}%;"></div></div><span class="text-secondary">${rate}%</span></div></td>
+                </tr>`;
+              }).join('')}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>` : ''}
 
     <!-- Success/Failure breakdown + space comparison -->
     <div class="dashboard-grid mb-lg">
@@ -486,27 +614,6 @@ const Views = (() => {
               </tr>`).join('')}
             </tbody>
           </table>
-        </div>
-      </div>
-    </div>
-    </div>
-
-    <!-- Environment spaces modal -->
-    <div class="modal-overlay" id="env-spaces-modal" aria-hidden="true" role="presentation">
-      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="env-spaces-modal-title">
-        <div class="modal-header">
-          <h3 class="modal-title" id="env-spaces-modal-title">
-            <i class="fa-solid fa-layer-group"></i>
-            Spaces for <span id="env-spaces-modal-envname"></span>
-          </h3>
-          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button">
-            <i class="fa-solid fa-times"></i>
-          </button>
-        </div>
-        <div class="modal-body" id="env-spaces-modal-body"></div>
-        <div class="modal-footer">
-          <span class="text-tertiary" id="env-spaces-modal-meta"></span>
-          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-done" type="button">Close</button>
         </div>
       </div>
     </div>`;
@@ -715,6 +822,22 @@ const Views = (() => {
     const monthlyRate = (freq * 30).toFixed(0);
     const answers = Onboarding.getAnswers();
     const value = answers ? Onboarding.calculateValue(summary, answers) : null;
+    const trendChange = DashboardData.computeTrendChange(summary.weeklyTrend);
+    const durationStats = DashboardData.computeDurationPercentiles();
+    const projectVelocity = DashboardData.computeProjectVelocity();
+
+    const fmtSecs = (s) => {
+      if (s == null) return '--';
+      if (s < 60) return `${s}s`;
+      const mins = Math.floor(s / 60);
+      const secs = s % 60;
+      return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+    };
+
+    const trendArrow = !trendChange ? { icon: 'fa-minus', cls: 'amber', label: 'insufficient data' }
+      : trendChange.direction === 'up' ? { icon: 'fa-arrow-trend-up', cls: 'green', label: `↑ ${trendChange.pct}% vs prior period` }
+      : trendChange.direction === 'down' ? { icon: 'fa-arrow-trend-down', cls: 'danger', label: `↓ ${trendChange.pct}% vs prior period` }
+      : { icon: 'fa-minus', cls: 'amber', label: 'stable velocity' };
 
     let comparisonHtml = '';
     if (value && value.throughputMultiplier) {
@@ -745,10 +868,13 @@ const Views = (() => {
       </div>`;
     }
 
+    const activeProjects = projectVelocity.filter(p => p.recentDeploys > 0);
+    const staleProjects = projectVelocity.filter(p => p.recentDeploys === 0 && p.totalDeploys > 0);
+
     return `
     <div class="page-header">
       <h1 class="page-title">Release Velocity</h1>
-      <p class="page-subtitle">How fast your team ships &mdash; deployment frequency, cadence improvements, and per-space velocity.</p>
+      <p class="page-subtitle">How fast your team ships &mdash; deployment frequency, duration analysis, and per-project velocity.</p>
     </div>
 
     <!-- Frequency KPIs -->
@@ -785,28 +911,145 @@ const Views = (() => {
         <span class="kpi-value">${summary.kpi.totalReleases.toLocaleString()}</span>
         <span class="kpi-trend neutral"><i class="fa-solid fa-code-branch"></i> <span>across all projects</span></span>
       </div>
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">Velocity Trend</span>
+          <div class="kpi-icon ${trendArrow.cls}"><i class="fa-solid ${trendArrow.icon}"></i></div>
+        </div>
+        <span class="kpi-value" style="${trendChange ? (trendChange.direction === 'up' ? 'color:var(--colorSuccess)' : trendChange.direction === 'down' ? 'color:var(--colorDanger)' : '') : ''}">${trendChange ? (trendChange.direction === 'flat' ? 'Stable' : `${trendChange.pct}%`) : '--'}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-scale-balanced"></i> <span>${trendArrow.label}</span></span>
+      </div>
     </div>
 
     ${comparisonHtml}
 
-    <!-- Velocity trend -->
+    <!-- Velocity trend chart -->
     <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-chart-area"></i> Velocity Over Time</h2></div>
     <div class="card card--chart-tooltips mb-lg">
       <div class="card-header">
-        <h3 class="card-title"></h3>
-        <div class="flex gap-xs" style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);">
-          <span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--colorSuccess);vertical-align:middle;margin-right:3px;"></span>Success</span>
-          <span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--colorDanger);vertical-align:middle;margin-right:3px;"></span>Failed</span>
-          <span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--colorBackgroundTertiary);vertical-align:middle;margin-right:3px;"></span>Other</span>
+        <h3 class="card-title">Deployment Volume</h3>
+        <div class="flex items-center gap-md">
+          <div class="flex gap-xs" style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);">
+            <span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--colorSuccess);vertical-align:middle;margin-right:3px;"></span>Success</span>
+            <span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--colorDanger);vertical-align:middle;margin-right:3px;"></span>Failed</span>
+            <span><span style="display:inline-block;width:8px;height:8px;border-radius:2px;background:var(--colorBackgroundTertiary);vertical-align:middle;margin-right:3px;"></span>Other</span>
+          </div>
+          <div class="flex gap-xs">
+            <button class="btn btn-secondary btn-sm" data-velocity-range="30d">30 days</button>
+            <button class="btn btn-secondary btn-sm" data-velocity-range="90d">90 days</button>
+            <button class="btn btn-secondary btn-sm active-toggle" data-velocity-range="12m">12 months</button>
+          </div>
         </div>
       </div>
       <div class="card-body">
-        <div class="chart-container">${_renderTrendChart(summary, '12m')}</div>
+        <div class="chart-container" id="velocity-chart">${_renderTrendChart(summary, '12m')}</div>
       </div>
     </div>
 
-    <!-- Per-space velocity comparison -->
-    <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-ranking-star"></i> Velocity by Space</h2></div>
+    <!-- Duration Percentiles -->
+    ${durationStats ? `
+    <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-stopwatch"></i> Deployment Duration</h2></div>
+    <div class="kpi-grid mb-lg">
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">Median (p50)</span>
+          <div class="kpi-icon green"><i class="fa-solid fa-gauge"></i></div>
+        </div>
+        <span class="kpi-value">${fmtSecs(durationStats.p50)}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>50th percentile</span></span>
+      </div>
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">p90</span>
+          <div class="kpi-icon amber"><i class="fa-solid fa-clock"></i></div>
+        </div>
+        <span class="kpi-value">${fmtSecs(durationStats.p90)}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>90th percentile</span></span>
+      </div>
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">p95</span>
+          <div class="kpi-icon danger"><i class="fa-solid fa-clock"></i></div>
+        </div>
+        <span class="kpi-value">${fmtSecs(durationStats.p95)}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>95th percentile</span></span>
+      </div>
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">Fastest</span>
+          <div class="kpi-icon blue"><i class="fa-solid fa-forward-fast"></i></div>
+        </div>
+        <span class="kpi-value">${fmtSecs(durationStats.min)}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-bolt"></i> <span>minimum</span></span>
+      </div>
+      <div class="kpi-card">
+        <div class="flex items-center justify-between">
+          <span class="kpi-label">Slowest</span>
+          <div class="kpi-icon purple"><i class="fa-solid fa-hourglass-half"></i></div>
+        </div>
+        <span class="kpi-value">${fmtSecs(durationStats.max)}</span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>of ${durationStats.count} measured</span></span>
+      </div>
+    </div>` : ''}
+
+    <!-- Project Velocity -->
+    <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-ranking-star"></i> Project Velocity</h2></div>
+    <div class="dashboard-grid mb-lg">
+      <div class="card col-span-4">
+        <div class="card-body" style="text-align:center;padding:var(--space-lg);">
+          <div style="font:var(--textBodyRegularSmall);color:var(--colorTextTertiary);margin-bottom:var(--space-xs);">Active Projects</div>
+          <div style="font:var(--textHeadingLarge);color:var(--colorSuccess);">${activeProjects.length}</div>
+          <div style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);margin-top:var(--space-xs);">deployed in last 30 days</div>
+        </div>
+      </div>
+      <div class="card col-span-4">
+        <div class="card-body" style="text-align:center;padding:var(--space-lg);">
+          <div style="font:var(--textBodyRegularSmall);color:var(--colorTextTertiary);margin-bottom:var(--space-xs);">Idle Projects</div>
+          <div style="font:var(--textHeadingLarge);color:${staleProjects.length > 0 ? 'var(--colorWarningAccent)' : 'var(--colorTextPrimary)'};">${staleProjects.length}</div>
+          <div style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);margin-top:var(--space-xs);">no deploys in 30 days</div>
+        </div>
+      </div>
+      <div class="card col-span-4">
+        <div class="card-body" style="text-align:center;padding:var(--space-lg);">
+          <div style="font:var(--textBodyRegularSmall);color:var(--colorTextTertiary);margin-bottom:var(--space-xs);">Total Projects</div>
+          <div style="font:var(--textHeadingLarge);color:var(--colorTextPrimary);">${projectVelocity.length}</div>
+          <div style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);margin-top:var(--space-xs);">across all spaces</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-lg">
+      <div class="card-header">
+        <h3 class="card-title">All Projects — Last 30 Days</h3>
+        <div class="view-search-wrapper">
+          <i class="fa-solid fa-search text-tertiary"></i>
+          <input type="text" id="velocity-project-search" class="view-search-input" placeholder="Search projects...">
+        </div>
+      </div>
+      <div class="card-body" style="padding:0;">
+        <div class="table-wrapper table-wrapper--recent-scroll">
+          <table>
+            <thead><tr>
+              <th>Project</th><th>Space</th><th>Last 30d</th><th>Deploys/Wk</th><th>To Prod</th><th>Success Rate</th><th>Last Deploy</th>
+            </tr></thead>
+            <tbody id="velocity-projects-tbody">
+              ${projectVelocity.length > 0 ? projectVelocity.map(p => `<tr data-proj-name="${_escapeAttr((p.name || '').toLowerCase())}">
+                <td><div class="flex items-center gap-sm"><i class="fa-solid fa-diagram-project text-tertiary" style="font-size:0.7rem;"></i> ${DOMPurify.sanitize(p.name)}</div></td>
+                <td class="text-secondary">${DOMPurify.sanitize(p.space)}</td>
+                <td class="monospace${p.recentDeploys > 0 ? '' : ' text-tertiary'}">${p.recentDeploys}</td>
+                <td class="monospace">${p.deploysPerWeek}</td>
+                <td class="monospace">${p.prodDeploys}</td>
+                <td>${p.successRate !== null ? `<div class="flex items-center gap-xs"><div class="progress-bar" style="width:60px;"><div class="progress-fill ${p.successRate >= 90 ? 'success' : p.successRate >= 70 ? 'warning' : 'danger'}" style="width:${p.successRate}%;"></div></div><span class="text-secondary">${p.successRate}%</span></div>` : '<span class="text-tertiary">--</span>'}</td>
+                <td class="text-secondary">${p.lastDeploy ? timeAgo(p.lastDeploy) : '--'}</td>
+              </tr>`).join('') : '<tr><td colspan="7" class="text-secondary" style="text-align:center;padding:var(--space-lg);">No project data</td></tr>'}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- Velocity by Space -->
+    <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-cubes"></i> Velocity by Space</h2></div>
     <div class="card">
       <div class="card-body" style="padding:0;">
         <div class="table-wrapper">
@@ -815,8 +1058,6 @@ const Views = (() => {
             <tbody>
               ${summary.spaceBreakdown.map(s => {
                 const dpr = s.releaseCount > 0 ? (s.deploymentCount / s.releaseCount).toFixed(1) : '--';
-                // Build mini sparkline from recent deployment counts per week
-                const spaceData = DashboardData.getSpaceData(s.id);
                 const weeklyTotals = (summary.weeklyTrend || []).slice(-8).map(w => w.total);
                 return `<tr>
                   <td><div class="flex items-center gap-sm"><div class="space-avatar sm">${s.name.charAt(0).toUpperCase()}</div> ${DOMPurify.sanitize(s.name)}</div></td>
@@ -831,6 +1072,26 @@ const Views = (() => {
         </div>
       </div>
     </div>`;
+  }
+
+  function wireVelocityEvents(summary) {
+    const input = document.getElementById('velocity-project-search');
+    if (input) {
+      input.addEventListener('input', () => {
+        const query = input.value.toLowerCase().trim();
+        document.querySelectorAll('#velocity-projects-tbody tr[data-proj-name]').forEach(row => {
+          row.style.display = !query || row.dataset.projName.includes(query) ? '' : 'none';
+        });
+      });
+    }
+    document.querySelectorAll('[data-velocity-range]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-velocity-range]').forEach(b => b.classList.remove('active-toggle'));
+        btn.classList.add('active-toggle');
+        const el = document.getElementById('velocity-chart');
+        if (el) el.innerHTML = _renderTrendChart(summary, btn.dataset.velocityRange);
+      });
+    });
   }
 
 
@@ -856,9 +1117,19 @@ const Views = (() => {
       .filter(s => s.deploymentCount > 0)
       .sort((a, b) => a.successRate - b.successRate);
 
-    // Failure trend from weekly data
-    const failureTrend = (summary.weeklyTrend || []).slice(-12).map(w => w.failed);
-    const successTrend = (summary.weeklyTrend || []).slice(-12).map(w => w.total > 0 ? Math.round(w.success / w.total * 100) : 100);
+    const totalRated = summary.successCount + summary.failedCount + summary.cancelledCount;
+    const overallFailureRate = totalRated > 0 ? Math.round((summary.failedCount / totalRated) * 100) : 0;
+
+    // Failure rate trend from weekly counts
+    const failureWeeks = (summary.weeklyTrend || []).slice(-12);
+    const failureMax = Math.max(...failureWeeks.map(w => (w.total > 0 ? (w.failed / w.total) * 100 : 0)), 1);
+    const failureTrend = failureWeeks.map(w => {
+      const value = w.total > 0 ? (w.failed / w.total) * 100 : 0;
+      const showYear = !!w.showYear;
+      const label = `W${w.week}${showYear ? '<br>' + w.year : ''}`;
+      const tooltip = `ISO week ${w.week}, ${w.year}: ${w.failed} failed of ${w.total} total deployments (${value.toFixed(1).replace(/\.0$/, '')}%).`;
+      return { value, label, tooltip };
+    });
 
     return `
     <div class="page-header">
@@ -881,7 +1152,7 @@ const Views = (() => {
           <span class="kpi-label">Failure Rate</span>
           <div class="kpi-icon danger"><i class="fa-solid fa-circle-xmark"></i></div>
         </div>
-        <span class="kpi-value">${(100 - summary.kpi.successRate)}%</span>
+        <span class="kpi-value">${overallFailureRate}%</span>
         <span class="kpi-trend neutral"><i class="fa-solid fa-triangle-exclamation"></i> <span>${summary.failedCount} total failures</span></span>
       </div>
       <div class="kpi-card">
@@ -905,23 +1176,40 @@ const Views = (() => {
     <!-- Failure trend + success rate by space -->
     <div class="dashboard-grid mb-lg">
       <div class="card col-span-6">
-        <div class="card-header"><h3 class="card-title">Failure Trend (12 weeks)</h3></div>
+        <div class="card-header"><h3 class="card-title">Failure Rate Trend (12 weeks)</h3></div>
         <div class="card-body">
-          <div class="chart-container">${_renderMiniBarChart(failureTrend, 'var(--colorDanger)')}</div>
+          <div class="reliability-failure-trend-list">
+            ${failureTrend.map(w => {
+              const pct = failureMax > 0 ? (w.value / failureMax) * 100 : 0;
+              const display = `${w.value.toFixed(1).replace(/\.0$/, '')}%`;
+              return `
+                <div class="reliability-failure-trend-row" data-tooltip="${_tooltipAttr(w.tooltip)}">
+                  <div class="reliability-failure-trend-week">${w.label}</div>
+                  <div class="progress-bar reliability-failure-trend-bar" aria-hidden="true">
+                    <div class="progress-fill danger" style="width:${pct}%;"></div>
+                  </div>
+                  <div class="reliability-failure-trend-value">${display}</div>
+                </div>`;
+            }).join('')}
+          </div>
         </div>
       </div>
       <div class="card col-span-6">
         <div class="card-header"><h3 class="card-title">Success Rate by Space</h3></div>
         <div class="card-body">
-          ${spaceRates.length ? spaceRates.map(s => `
-            <div style="margin-bottom:var(--space-sm);">
-              <div class="flex items-center justify-between" style="margin-bottom:2px;">
-                <span style="font:var(--textBodyRegularSmall);color:var(--colorTextSecondary);">${DOMPurify.sanitize(s.name)}</span>
-                <span style="font:var(--textBodyBoldSmall);color:${s.successRate >= 90 ? 'var(--colorSuccess)' : s.successRate >= 70 ? 'var(--colorWarningAccent)' : 'var(--colorDanger)'};">${s.successRate}%</span>
-              </div>
-              <div class="progress-bar" style="width:100%;"><div class="progress-fill ${s.successRate >= 90 ? 'success' : s.successRate >= 70 ? 'warning' : 'danger'}" style="width:${s.successRate}%;"></div></div>
-            </div>
-          `).join('') : '<div class="text-tertiary">No space data</div>'}
+          ${spaceRates.length
+            ? `<div class="reliability-space-rates">
+                ${spaceRates.map(s => `
+                  <div style="margin-bottom:var(--space-sm);">
+                    <div class="flex items-center justify-between" style="margin-bottom:2px;">
+                      <span style="font:var(--textBodyRegularSmall);color:var(--colorTextSecondary);">${DOMPurify.sanitize(s.name)}</span>
+                      <span style="font:var(--textBodyBoldSmall);color:${s.successRate >= 90 ? 'var(--colorSuccess)' : s.successRate >= 70 ? 'var(--colorWarningAccent)' : 'var(--colorDanger)'};">${s.successRate}%</span>
+                    </div>
+                    <div class="progress-bar" style="width:100%;"><div class="progress-fill ${s.successRate >= 90 ? 'success' : s.successRate >= 70 ? 'warning' : 'danger'}" style="width:${s.successRate}%;"></div></div>
+                  </div>
+                `).join('')}
+              </div>`
+            : '<div class="text-tertiary">No space data</div>'}
         </div>
       </div>
     </div>
@@ -949,16 +1237,7 @@ const Views = (() => {
     </div>`;
   }
 
-  function _renderMiniBarChart(data, color) {
-    if (!data || data.length === 0) return '<div class="text-tertiary" style="text-align:center;">No data</div>';
-    const max = Math.max(...data, 1);
-    return `<div style="display:flex;align-items:flex-end;gap:4px;height:120px;padding:var(--space-sm) 0;">
-      ${data.map(v => {
-        const h = Math.max(v / max * 100, 2);
-        return `<div style="flex:1;background:${color};height:${h}%;border-radius:3px 3px 0 0;min-width:8px;" title="${v}"></div>`;
-      }).join('')}
-    </div>`;
-  }
+  // (legacy _renderMiniBarChart removed - replaced by a compact list)
 
 
   // ==================================================================
@@ -1141,6 +1420,7 @@ const Views = (() => {
     // Collect all projects across all spaces
     const allProjects = [];
     const allSpaceData = DashboardData.getAllSpaceData();
+    const root = (typeof OctopusApi?.getInstanceUrl === 'function') ? OctopusApi.getInstanceUrl() : '';
 
     for (const spaceId of Object.keys(allSpaceData)) {
       const sd = allSpaceData[spaceId];
@@ -1154,9 +1434,16 @@ const Views = (() => {
         const rate = projDeploys.length > 0 ? Math.round(successCount / projDeploys.length * 100) : null;
         const lastDeploy = projDeploys.length > 0 ? projDeploys[0].Created : null;
 
+        const octopusProjectUrl = root
+          ? `${root}/app#/${encodeURIComponent(spaceId)}/projects/${encodeURIComponent(p.Id)}`
+          : null;
+
         allProjects.push({
           name: p.Name || p.Id,
+          projectId: p.Id,
           space: spaceName,
+          spaceId,
+          octopusProjectUrl,
           deployments: projDeploys.length,
           successRate: rate,
           lastDeploy: lastDeploy,
@@ -1228,7 +1515,12 @@ const Views = (() => {
       return '<tr><td colspan="5" class="text-secondary" style="text-align:center;padding:var(--space-lg);">No projects found</td></tr>';
     }
     return projects.map(p => `<tr data-project-name="${DOMPurify.sanitize(p.name.toLowerCase())}">
-      <td><div class="flex items-center gap-sm"><i class="fa-solid fa-diagram-project text-tertiary" style="font-size:0.8rem;"></i> ${DOMPurify.sanitize(p.name)}</div></td>
+      <td><div class="flex items-center gap-sm">
+        <i class="fa-solid fa-diagram-project text-tertiary" style="font-size:0.8rem;"></i>
+        ${p.octopusProjectUrl
+          ? `<a class="text-tertiary" href="${_escapeAttr(p.octopusProjectUrl)}" target="_blank" rel="noopener noreferrer" style="text-decoration:none;">${DOMPurify.sanitize(p.name)}</a>`
+          : DOMPurify.sanitize(p.name)}
+      </div></td>
       <td><span class="text-secondary">${DOMPurify.sanitize(p.space)}</span></td>
       <td class="monospace">${p.deployments}</td>
       <td>${p.successRate !== null ? `<div class="flex items-center gap-xs"><div class="progress-bar" style="width:60px;"><div class="progress-fill ${p.successRate >= 90 ? 'success' : p.successRate >= 70 ? 'warning' : 'danger'}" style="width:${p.successRate}%;"></div></div><span class="text-secondary">${p.successRate}%</span></div>` : '<span class="text-tertiary">--</span>'}</td>
@@ -1738,6 +2030,7 @@ const Views = (() => {
     renderTrends,
     wireTrendsEvents,
     renderVelocity,
+    wireVelocityEvents,
     renderReliability,
     // Insight views
     renderSpaces,

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -1325,12 +1325,133 @@ const Views = (() => {
   // ==================================================================
 
   function renderTeams(summary) {
-    // Teams data isn't available from the standard Octopus Deploy REST API endpoints
-    // we're using (Spaces, Projects, Deployments, Environments, Machines).
-    // Show a helpful placeholder with available activity data.
-
     const spaces = summary.spaceBreakdown || [];
     const totalDeploys = summary.kpi.totalDeployments;
+    const ti = summary.teamsInsight || {
+      rows: [],
+      totalTeams: 0,
+      anyDenied: false,
+      anyOkFetch: false,
+      anyError: false,
+    };
+
+    const permissionExplainer = `
+    <div class="card mb-lg">
+      <div class="card-body" style="text-align:center;padding:var(--space-xl) var(--space-lg);">
+        <div style="font-size:3rem;margin-bottom:var(--space-md);color:var(--colorTextTertiary);">
+          <i class="fa-solid fa-users"></i>
+        </div>
+        <h3 style="font:var(--textHeadingSmall);color:var(--colorTextPrimary);margin:0 0 var(--space-xs);">Team list blocked for this Octopus session</h3>
+        <div class="text-secondary" style="font:var(--textBodyRegularMedium);max-width:560px;margin:0 auto var(--space-md);line-height:1.55;text-align:left;">
+          <p style="margin:0 0 var(--space-sm);">
+            This dashboard calls <code style="font-size:0.9em;">GET /api/{spaceId}/teams/all</code> using your <strong>browser session</strong> to Octopus (cookies), not a separate API key.
+            If you see this message, Octopus returned 401/403 for team data: the <strong>user you are signed in as</strong> needs <strong>TeamView</strong> (and usually space access) for those spaces.
+          </p>
+          <p style="margin:0 0 var(--space-xs);font-weight:600;color:var(--colorTextPrimary);">Typical permissions</p>
+          <ul style="margin:0 0 var(--space-sm);padding-left:1.25rem;">
+            <li><strong>TeamView</strong> — list teams and membership (system and/or space scope).</li>
+            <li><strong>UserView</strong> — optional, for resolving member IDs to display names in other views.</li>
+            <li><strong>UserRoleView</strong> — optional, for role assignments on teams.</li>
+          </ul>
+          <p style="margin:0;font-size:0.92em;">Tip: open Octopus in the same browser, confirm you are logged in as the user you expect, then reload this dashboard.</p>
+        </div>
+        <div class="flex items-center gap-sm" style="justify-content:center;flex-wrap:wrap;">
+          <a href="https://octopus.com/docs/security/users-and-teams/default-permissions" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-sm">
+            <i class="fa-solid fa-external-link-alt"></i>
+            Default permissions (TeamView, etc.)
+          </a>
+          <a href="https://octopus.com/docs/octopus-rest-api" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-sm">
+            <i class="fa-solid fa-external-link-alt"></i>
+            REST API overview
+          </a>
+        </div>
+      </div>
+    </div>`;
+
+    let statusBlock = '';
+
+    if (ti.anyError && (ti.anyOkFetch || ti.anyDenied)) {
+      statusBlock += `
+      <div class="card mb-lg" style="border-color:var(--colorWarningBorder, #b8860b);">
+        <div class="card-body text-secondary" style="font:var(--textBodyRegularMedium);">
+          <strong style="color:var(--colorTextPrimary);">Some team requests failed.</strong>
+          Check the debug log (Ctrl+D) for errors; network or server issues can hide teams even when permissions are correct.
+        </div>
+      </div>`;
+    }
+
+    if (ti.totalTeams > 0) {
+      statusBlock += `
+      <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-users"></i> Teams</h2></div>
+      <div class="card mb-lg">
+        <div class="card-body" style="padding:0;">
+          <div class="table-wrapper">
+            <table>
+              <thead><tr>
+                <th>Space</th><th>Team</th><th>Members</th><th>Project scope</th><th>Env scopes</th><th>Role assignments</th>
+                <th data-tooltip="Deployments in the recent sample (200 per space) whose project falls in this team’s scope.">Recent deploys (sample)</th>
+              </tr></thead>
+              <tbody>
+                ${ti.rows.map(r => `<tr>
+                  <td class="text-secondary">${DOMPurify.sanitize(r.spaceName)}</td>
+                  <td>${DOMPurify.sanitize(r.name)}</td>
+                  <td class="monospace">${r.memberCount}</td>
+                  <td class="text-secondary">${DOMPurify.sanitize(r.projectsLabel)}</td>
+                  <td class="monospace">${r.envScopeLabel}</td>
+                  <td class="monospace">${r.scopedRoles}</td>
+                  <td class="monospace">${r.recentDeploysInScope}</td>
+                </tr>`).join('')}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>`;
+    }
+
+    if (ti.anyDenied && ti.totalTeams > 0) {
+      statusBlock += `
+      <div class="card mb-lg">
+        <div class="card-body text-secondary" style="font:var(--textBodyRegularMedium);">
+          <strong style="color:var(--colorTextPrimary);">Partial access:</strong> at least one space returned 403 for teams. The table shows teams only from spaces where the request succeeded.
+        </div>
+      </div>`;
+    }
+
+    if (!ti.anyOkFetch && ti.anyDenied) {
+      statusBlock += permissionExplainer;
+    } else if (ti.anyOkFetch && ti.totalTeams === 0 && !ti.anyDenied) {
+      statusBlock += `
+      <div class="card mb-lg">
+        <div class="card-body text-center text-secondary" style="padding:var(--space-xl);font:var(--textBodyRegularMedium);">
+          <i class="fa-solid fa-users" style="font-size:2rem;display:block;margin-bottom:var(--space-md);color:var(--colorTextTertiary);"></i>
+          <strong style="color:var(--colorTextPrimary);">No teams in the active spaces we loaded.</strong>
+          <p style="margin:var(--space-sm) 0 0;">Spaces without projects or targets may be excluded; add teams in Octopus or widen scope if you expected to see them here.</p>
+        </div>
+      </div>`;
+    } else if (ti.anyOkFetch && ti.totalTeams === 0 && ti.anyDenied) {
+      statusBlock += permissionExplainer;
+      statusBlock += `
+      <div class="card mb-lg">
+        <div class="card-body text-secondary" style="font:var(--textBodyRegularMedium);">
+          Where teams were readable, there were no team records—combined with 403s on other spaces this often means a permission scope issue rather than an empty org.
+        </div>
+      </div>`;
+    } else if (!ti.anyOkFetch && !ti.anyDenied && ti.anyError) {
+      statusBlock += `
+      <div class="card mb-lg">
+        <div class="card-body text-secondary" style="font:var(--textBodyRegularMedium);">
+          <strong style="color:var(--colorTextPrimary);">Could not load teams.</strong>
+          Octopus did not return usable team payloads (non-auth failure). Open the debug log (Ctrl+D), verify connectivity to your Octopus URL, and reload.
+        </div>
+      </div>`;
+    } else if (!ti.anyOkFetch && !ti.anyDenied && !ti.anyError) {
+      statusBlock += `
+      <div class="card mb-lg">
+        <div class="card-body text-center text-secondary" style="padding:var(--space-xl);font:var(--textBodyRegularMedium);">
+          No per-space team requests ran (no active spaces in this summary). Load the dashboard from a connected Octopus instance with at least one active space.
+        </div>
+      </div>`;
+    }
 
     return `
     <div class="page-header">
@@ -1338,24 +1459,9 @@ const Views = (() => {
       <p class="page-subtitle">Team-level deployment activity and ownership insights.</p>
     </div>
 
-    <div class="card mb-lg">
-      <div class="card-body" style="text-align:center;padding:var(--space-xl) var(--space-lg);">
-        <div style="font-size:3rem;margin-bottom:var(--space-md);color:var(--colorTextTertiary);">
-          <i class="fa-solid fa-users"></i>
-        </div>
-        <h3 style="font:var(--textHeadingSmall);color:var(--colorTextPrimary);margin:0 0 var(--space-xs);">Team data requires additional API access</h3>
-        <p class="text-secondary" style="font:var(--textBodyRegularMedium);max-width:500px;margin:0 auto var(--space-md);line-height:1.5;">
-          The Octopus Deploy Teams API requires specific permissions to access team membership and project ownership data.
-          Below is a space-level activity breakdown as a proxy for team activity.
-        </p>
-        <a href="https://octopus.com/docs/octopus-rest-api" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-sm">
-          <i class="fa-solid fa-external-link-alt"></i>
-          Octopus REST API Docs
-        </a>
-      </div>
-    </div>
+    ${statusBlock}
 
-    <!-- Space-level activity as team proxy -->
+    <!-- Space-level activity -->
     <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-cubes"></i> Activity by Space</h2></div>
     <div class="card">
       <div class="card-body" style="padding:0;">

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -271,7 +271,7 @@ const Views = (() => {
                 <tr>
                   <th>Space</th><th>Projects</th><th>Envs</th><th>Deployments</th>
                   <th>Success Rate</th><th>Targets</th><th>Last Deploy</th>
-                  <th data-tooltip="Deployment success tier for the selected time range (not target health). Hover a badge for definitions: Healthy ≥95%, Attention 80–94%, Warning &lt;80%, No data when there is nothing to score.">Health</th>
+                  <th data-tooltip="Deployment success tier for the selected time range (not target health). Hover a badge for definitions: Healthy ≥95%, Attention 80–94%, Warning &lt;80%, No data when there is nothing to score." title="Deployment success tier for the selected time range (not target health). Hover a badge for definitions: Healthy ≥95%, Attention 80–94%, Warning &lt;80%, No data when there is nothing to score.">Health</th>
                 </tr>
               </thead>
               <tbody id="table-spaces">
@@ -515,7 +515,7 @@ const Views = (() => {
             ${hourOfDay.map(h => {
               const pct = maxHour > 0 ? Math.round(h.count / maxHour * 100) : 0;
               const isPeak = h === busiestHour && h.count > 0;
-              return `<div class="hour-col${isPeak ? ' hour-col--peak' : ''}" data-tooltip="${String(h.hour).padStart(2, '0')}:00 UTC — ${h.count} deployments">
+              return `<div class="hour-col${isPeak ? ' hour-col--peak' : ''}" tabindex="0" role="img" aria-label="${String(h.hour).padStart(2, '0')}:00 UTC — ${h.count} deployments" title="${String(h.hour).padStart(2, '0')}:00 UTC — ${h.count} deployments" data-tooltip="${String(h.hour).padStart(2, '0')}:00 UTC — ${h.count} deployments">
                 <div class="hour-bar-wrap"><div class="hour-bar" style="height:${pct}%;"></div></div>
                 <span class="hour-label">${h.hour % 6 === 0 ? String(h.hour).padStart(2, '0') : ''}</span>
               </div>`;

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -760,7 +760,7 @@ const Views = (() => {
             <i class="fa-solid fa-layer-group"></i>
             Spaces for <span id="env-spaces-modal-envname"></span>
           </h3>
-          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button">
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button" aria-label="Close modal">
             <i class="fa-solid fa-times"></i>
           </button>
         </div>

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -356,7 +356,6 @@ const Views = (() => {
   // ==================================================================
 
   function renderTrends(summary) {
-    const trend = summary.weeklyTrend || [];
     const totalDeploys = summary.kpi.totalDeployments;
     const successRate = summary.kpi.successRate;
     const frequency = summary.kpi.deployFrequency;
@@ -432,7 +431,7 @@ const Views = (() => {
         </div>
       </div>
       <div class="card-body">
-        <div class="chart-container" id="trends-chart">${_renderTrendChart(trend, '30d')}</div>
+        <div class="chart-container" id="trends-chart">${_renderTrendChart(summary, '30d')}</div>
       </div>
     </div>
 
@@ -483,13 +482,12 @@ const Views = (() => {
   }
 
   function wireTrendsEvents(summary) {
-    const trend = summary.weeklyTrend || [];
     document.querySelectorAll('[data-trends-range]').forEach(btn => {
       btn.addEventListener('click', () => {
         document.querySelectorAll('[data-trends-range]').forEach(b => b.classList.remove('active-toggle'));
         btn.classList.add('active-toggle');
         const el = document.getElementById('trends-chart');
-        if (el) el.innerHTML = _renderTrendChart(trend, btn.dataset.trendsRange);
+        if (el) el.innerHTML = _renderTrendChart(summary, btn.dataset.trendsRange);
       });
     });
   }
@@ -518,8 +516,27 @@ const Views = (() => {
     return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
   }
 
-  function _renderTrendChart(weeklyTrend, range) {
+  function _dailyAxisLabel(d, prev) {
+    const M = MONTH_NAMES;
+    if (!prev) return `${d.day}<br>${M[d.month]}<br>${d.year}`;
+    if (d.year !== prev.year) return `${d.day}<br>${M[d.month]}<br>${d.year}`;
+    if (d.month !== prev.month) return `${d.day}<br>${M[d.month]}`;
+    return String(d.day);
+  }
+
+  function _dailyUtcTip(dateKey) {
+    const [y, mo, da] = dateKey.split('-').map(Number);
+    return `${da} ${MONTH_NAMES[mo - 1]} ${y} (UTC)`;
+  }
+
+  function _renderTrendChart(summary, range) {
+    if (!summary) {
+      return '<div class="text-tertiary" style="text-align:center;padding:var(--space-lg);">No trend data available</div>';
+    }
+    const weeklyTrend = summary.weeklyTrend || [];
+    const dailyTrend = summary.dailyTrend || [];
     let bars;
+    let useDailyBars = false;
     if (range === '12m') {
       const monthly = _aggregateMonthly(weeklyTrend);
       bars = monthly.map(m => ({
@@ -527,6 +544,18 @@ const Views = (() => {
         label: MONTH_NAMES[m.month] + (m.month === 0 ? '<br>' + m.year : ''),
         tooltip: _trendTipAttr(`${MONTH_NAMES[m.month]} ${m.year}: ${m.total} deployments (${m.success} success, ${m.failed} failed, ${m.total - m.success - m.failed} other)`),
       }));
+    } else if (range === '30d' && dailyTrend.length > 0) {
+      useDailyBars = true;
+      bars = dailyTrend.map((d, i) => {
+        const prev = i > 0 ? dailyTrend[i - 1] : null;
+        const counts = `${d.total} deployments (${d.success} success, ${d.failed} failed, ${d.total - d.success - d.failed} other)`;
+        const tip = `${_dailyUtcTip(d.dateKey)}. ${counts}`;
+        return {
+          total: d.total, success: d.success, failed: d.failed,
+          label: _dailyAxisLabel(d, prev),
+          tooltip: _trendTipAttr(tip),
+        };
+      });
     } else {
       const weeks = range === '90d' ? 13 : 5;
       const sliced = weeklyTrend.slice(-weeks);
@@ -546,10 +575,11 @@ const Views = (() => {
       return '<div class="text-tertiary" style="text-align:center;padding:var(--space-lg);">No trend data available</div>';
     }
     const maxTotal = Math.max(...bars.map(b => b.total), 1);
-    const gap = range === '12m' ? 8 : range === '90d' ? 6 : 12;
+    const gap = range === '12m' ? 8 : (useDailyBars ? 2 : (range === '90d' ? 6 : 12));
+    const chartExtra = useDailyBars ? ' deployment-trend-chart--daily' : '';
     const maxBar = DashboardData.TREND_BAR_MAX_PX;
     const fmt = (n) => DashboardData.formatCompactCount(n);
-    return `<div class="deployment-trend-chart">
+    return `<div class="deployment-trend-chart${chartExtra}">
       <div class="deployment-trend-bars" style="gap:${gap}px;padding:var(--space-sm) 0;">
         ${bars.map(b => {
           const t = b.total;
@@ -572,7 +602,7 @@ const Views = (() => {
                 ${succH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--success" style="height:${succH}px;border-radius:0 0 3px 3px;"></div>` : ''}
               </div>
             </div>
-            <div class="deployment-trend-axis-label">${b.label}</div>
+            <div class="deployment-trend-axis-label${useDailyBars ? ' deployment-trend-axis-label--dense' : ''}">${b.label}</div>
           </div>`;
         }).join('')}
       </div>
@@ -720,7 +750,7 @@ const Views = (() => {
         </div>
       </div>
       <div class="card-body">
-        <div class="chart-container">${_renderTrendChart(summary.weeklyTrend || [], '12m')}</div>
+        <div class="chart-container">${_renderTrendChart(summary, '12m')}</div>
       </div>
     </div>
 

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -1553,7 +1553,7 @@ const Views = (() => {
     if (projects.length === 0) {
       return '<tr><td colspan="5" class="text-secondary" style="text-align:center;padding:var(--space-lg);">No projects found</td></tr>';
     }
-    return projects.map(p => `<tr data-project-name="${DOMPurify.sanitize(p.name.toLowerCase())}">
+    return projects.map(p => `<tr data-project-name="${_escapeAttr(p.name.toLowerCase())}">
       <td><div class="flex items-center gap-sm">
         <i class="fa-solid fa-diagram-project text-tertiary" style="font-size:0.8rem;"></i>
         ${p.octopusProjectUrl
@@ -1735,7 +1735,7 @@ const Views = (() => {
             <i class="fa-solid fa-layer-group"></i>
             Spaces for <span id="env-spaces-modal-envname"></span>
           </h3>
-          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button">
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button" aria-label="Close">
             <i class="fa-solid fa-times"></i>
           </button>
         </div>

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -121,6 +121,8 @@ const Views = (() => {
       </div>
     </div>
 
+    ${_enrichBannerHtml()}
+
     <!-- KPI Section Header -->
     <div class="section-header">
       <h2 class="section-title"><i class="fa-solid fa-gauge-high"></i> Platform Metrics</h2>
@@ -134,7 +136,7 @@ const Views = (() => {
           <div class="kpi-icon blue"><i class="fa-solid fa-rocket"></i></div>
         </div>
         <span class="kpi-value" id="kpi-deployments">--</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-database"></i> <span>all time, all spaces</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-database"></i> <span id="kpi-deployments-label">all time, all spaces</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -142,7 +144,7 @@ const Views = (() => {
           <div class="kpi-icon green"><i class="fa-solid fa-circle-check"></i></div>
         </div>
         <span class="kpi-value" id="kpi-success-rate">--</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>across recent deploys</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span id="kpi-success-rate-label">across recent deploys</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -158,7 +160,7 @@ const Views = (() => {
           <div class="kpi-icon purple"><i class="fa-solid fa-stopwatch"></i></div>
         </div>
         <span class="kpi-value" id="kpi-avg-duration">--</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-clock"></i> <span>per deployment</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-clock"></i> <span id="kpi-avg-duration-label">per deployment</span></span>
       </div>
     </div>
 
@@ -367,9 +369,11 @@ const Views = (() => {
   // ==================================================================
 
   function renderTrends(summary) {
-    const totalDeploys = summary.kpi.totalDeployments;
-    const successRate = summary.kpi.successRate;
-    const frequency = summary.kpi.deployFrequency;
+    const enriched = DashboardData.computeEnrichedKPIs();
+    const totalDeploys = enriched ? enriched.totalDeployments : summary.kpi.totalDeployments;
+    const successRate = enriched ? enriched.successRate : summary.kpi.successRate;
+    const frequency = enriched ? enriched.deployFrequency : summary.kpi.deployFrequency;
+    const periodLabel = enriched ? enriched.periodLabel : null;
     const trendChange = DashboardData.computeTrendChange(summary.weeklyTrend);
     const dayOfWeek = DashboardData.computeDayOfWeekDistribution();
     const hourOfDay = DashboardData.computeHourOfDayDistribution();
@@ -406,6 +410,8 @@ const Views = (() => {
       <p class="page-subtitle">Deployment activity over time &mdash; track patterns, compare spaces, and spot trends.</p>
     </div>
 
+    ${_enrichBannerHtml()}
+
     <!-- KPI strip -->
     <div class="kpi-grid mb-lg">
       <div class="kpi-card">
@@ -414,7 +420,7 @@ const Views = (() => {
           <div class="kpi-icon blue"><i class="fa-solid fa-rocket"></i></div>
         </div>
         <span class="kpi-value">${totalDeploys.toLocaleString()}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-database"></i> <span>all time</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-database"></i> <span>${periodLabel || 'all time'}</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -430,7 +436,7 @@ const Views = (() => {
           <div class="kpi-icon green"><i class="fa-solid fa-circle-check"></i></div>
         </div>
         <span class="kpi-value">${successRate}%</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>across all deploys</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>${periodLabel || 'across all deploys'}</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -438,7 +444,7 @@ const Views = (() => {
           <div class="kpi-icon amber"><i class="fa-solid fa-bolt"></i></div>
         </div>
         <span class="kpi-value">${frequency}/day</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-calendar-days"></i> <span>last 30 days</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-calendar-days"></i> <span>${periodLabel || 'last 30 days'}</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -816,14 +822,45 @@ const Views = (() => {
   // RELEASE VELOCITY view
   // ==================================================================
 
+  function _enrichBannerHtml() {
+    const es = DashboardData.getEnrichmentState();
+    if (es.state === 'idle') return '';
+    if (es.state === 'loading') {
+      return `<div id="enrichment-banner" class="enrichment-banner">
+        <i class="fa-solid fa-spinner enrichment-spinner"></i>
+        <div class="enrichment-progress-track"><div class="enrichment-progress-bar" style="width:${es.progress}%"></div></div>
+        <span class="enrichment-text">Loading historical data&hellip; ${(es.tasksFetched || 0).toLocaleString()} tasks</span>
+      </div>`;
+    }
+    if (es.state === 'complete') {
+      const m = es.lookbackMonths;
+      const periodLabel = m === 0 ? 'All time' : m < 12 ? `${m} months` : (m % 12 === 0 ? `${m / 12} year${m / 12 === 1 ? '' : 's'}` : `${m} months`);
+      const oldest = es.oldestDate ? new Date(es.oldestDate) : null;
+      const ageLabel = oldest ? ` (since ${oldest.toLocaleDateString('en-AU', { month: 'short', year: 'numeric' })})` : '';
+      return `<div id="enrichment-banner" class="enrichment-banner enrichment-banner--complete">
+        <i class="fa-solid fa-circle-check text-success"></i>
+        <span class="enrichment-text">${periodLabel} of data &bull; ${(es.tasksFetched || 0).toLocaleString()} tasks${ageLabel}</span>
+      </div>`;
+    }
+    if (es.state === 'error') {
+      return `<div id="enrichment-banner" class="enrichment-banner enrichment-banner--error">
+        <i class="fa-solid fa-triangle-exclamation text-danger"></i>
+        <span class="enrichment-text">Historical data load failed</span>
+      </div>`;
+    }
+    return '';
+  }
+
   function renderVelocity(summary) {
-    const freq = summary.kpi.deployFrequency;
+    const enriched = DashboardData.computeEnrichedKPIs();
+    const freq = enriched ? enriched.deployFrequency : summary.kpi.deployFrequency;
     const weeklyRate = (freq * 7).toFixed(1);
     const monthlyRate = (freq * 30).toFixed(0);
+    const periodLabel = enriched ? enriched.periodLabel : null;
     const answers = Onboarding.getAnswers();
     const value = answers ? Onboarding.calculateValue(summary, answers) : null;
     const trendChange = DashboardData.computeTrendChange(summary.weeklyTrend);
-    const durationStats = DashboardData.computeDurationPercentiles();
+    const durationStats = DashboardData.getHistoricalDurationPercentiles();
     const projectVelocity = DashboardData.computeProjectVelocity();
 
     const fmtSecs = (s) => {
@@ -877,6 +914,8 @@ const Views = (() => {
       <p class="page-subtitle">How fast your team ships &mdash; deployment frequency, duration analysis, and per-project velocity.</p>
     </div>
 
+    ${_enrichBannerHtml()}
+
     <!-- Frequency KPIs -->
     <div class="kpi-grid mb-lg">
       <div class="kpi-card">
@@ -885,7 +924,7 @@ const Views = (() => {
           <div class="kpi-icon blue"><i class="fa-solid fa-bolt"></i></div>
         </div>
         <span class="kpi-value">${freq}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-calendar-day"></i> <span>deploys/day average</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-calendar-day"></i> <span>${periodLabel ? periodLabel + ' avg' : 'deploys/day average'}</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -893,7 +932,7 @@ const Views = (() => {
           <div class="kpi-icon purple"><i class="fa-solid fa-calendar-week"></i></div>
         </div>
         <span class="kpi-value">${weeklyRate}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-line"></i> <span>deploys/week</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-line"></i> <span>${periodLabel ? periodLabel + ' avg' : 'deploys/week'}</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -901,7 +940,7 @@ const Views = (() => {
           <div class="kpi-icon amber"><i class="fa-solid fa-calendar"></i></div>
         </div>
         <span class="kpi-value">${monthlyRate}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-calendar-days"></i> <span>deploys/month</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-calendar-days"></i> <span>${periodLabel ? periodLabel + ' avg' : 'deploys/month'}</span></span>
       </div>
       <div class="kpi-card">
         <div class="flex items-center justify-between">
@@ -988,7 +1027,7 @@ const Views = (() => {
           <div class="kpi-icon purple"><i class="fa-solid fa-hourglass-half"></i></div>
         </div>
         <span class="kpi-value">${fmtSecs(durationStats.max)}</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>of ${durationStats.count} measured</span></span>
+        <span class="kpi-trend neutral"><i class="fa-solid fa-chart-simple"></i> <span>${durationStats.count.toLocaleString()} measured</span></span>
       </div>
     </div>` : ''}
 

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -320,15 +320,16 @@ const Views = (() => {
     </div>
 
     <!-- License Info -->
-    <div class="card mt-lg" style="padding:var(--space-sm) var(--space-md);">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-sm">
-          <i class="fa-solid fa-id-badge text-tertiary"></i>
-          <span class="text-secondary" style="font:var(--textBodyRegularSmall);">License</span>
-          <span id="license-info">--</span>
+    <div class="card license-card mt-lg">
+      <div class="license-card-header">
+        <div class="license-card-main">
+          <i class="fa-solid fa-id-badge text-tertiary" aria-hidden="true"></i>
+          <span class="license-card-heading text-secondary">License</span>
+          <div id="license-info" class="license-card-status">--</div>
         </div>
-        <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);" id="server-version"></span>
+        <span class="text-tertiary license-card-version" id="server-version"></span>
       </div>
+      <div id="license-ptm" class="license-ptm" aria-label="Licensed usage: projects, tenants, machines"></div>
     </div>`;
   }
 

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -204,7 +204,7 @@ const Views = (() => {
 
     <!-- Charts Row -->
     <div class="dashboard-grid mb-lg">
-      <div class="card col-span-8">
+      <div class="card col-span-8 card--chart-tooltips">
         <div class="card-header">
           <h3 class="card-title">Deployment Trends</h3>
           <div class="flex items-center gap-md">
@@ -415,7 +415,7 @@ const Views = (() => {
     <div class="section-header">
       <h2 class="section-title"><i class="fa-solid fa-chart-bar"></i> Deployment Timeline</h2>
     </div>
-    <div class="card mb-lg">
+    <div class="card card--chart-tooltips mb-lg">
       <div class="card-header">
         <h3 class="card-title">Deployments Over Time</h3>
         <div class="flex items-center gap-md">
@@ -514,6 +514,10 @@ const Views = (() => {
     return Object.values(monthMap).sort((a, b) => a.year !== b.year ? a.year - b.year : a.month - b.month).slice(-12);
   }
 
+  function _trendTipAttr(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  }
+
   function _renderTrendChart(weeklyTrend, range) {
     let bars;
     if (range === '12m') {
@@ -521,17 +525,20 @@ const Views = (() => {
       bars = monthly.map(m => ({
         total: m.total, success: m.success, failed: m.failed,
         label: MONTH_NAMES[m.month] + (m.month === 0 ? '<br>' + m.year : ''),
-        tooltip: `${MONTH_NAMES[m.month]} ${m.year}: ${m.total} deployments (${m.success} success, ${m.failed} failed, ${m.total - m.success - m.failed} other)`,
+        tooltip: _trendTipAttr(`${MONTH_NAMES[m.month]} ${m.year}: ${m.total} deployments (${m.success} success, ${m.failed} failed, ${m.total - m.success - m.failed} other)`),
       }));
     } else {
       const weeks = range === '90d' ? 13 : 5;
       const sliced = weeklyTrend.slice(-weeks);
       bars = sliced.map((w, i) => {
         const showYear = i === 0 || (sliced[i - 1] && sliced[i - 1].year !== w.year);
+        const rangeStr = DashboardData.formatIsoWeekDateRange(w.year, w.week);
+        const counts = `${w.total} deployments (${w.success} success, ${w.failed} failed, ${w.total - w.success - w.failed} other)`;
+        const tip = `${rangeStr} · ISO week ${w.week}, ${w.year} (Mon–Sun, UTC). ${counts}`;
         return {
           total: w.total, success: w.success, failed: w.failed,
           label: `W${w.week}${showYear ? '<br>' + w.year : ''}`,
-          tooltip: `Week ${w.week}, ${w.year}: ${w.total} deployments (${w.success} success, ${w.failed} failed, ${w.total - w.success - w.failed} other)`,
+          tooltip: _trendTipAttr(tip),
         };
       });
     }
@@ -539,25 +546,33 @@ const Views = (() => {
       return '<div class="text-tertiary" style="text-align:center;padding:var(--space-lg);">No trend data available</div>';
     }
     const maxTotal = Math.max(...bars.map(b => b.total), 1);
-    const barWidth = range === '12m' ? 32 : range === '90d' ? 24 : 40;
     const gap = range === '12m' ? 8 : range === '90d' ? 6 : 12;
-    const maxBarH = 180;
-    return `<div style="width:100%;overflow-x:auto;">
-      <div style="display:flex;align-items:flex-end;gap:${gap}px;height:200px;padding:var(--space-sm) 0;">
+    const maxBar = DashboardData.TREND_BAR_MAX_PX;
+    const fmt = (n) => DashboardData.formatCompactCount(n);
+    return `<div class="deployment-trend-chart">
+      <div class="deployment-trend-bars" style="gap:${gap}px;padding:var(--space-sm) 0;">
         ${bars.map(b => {
-          const h = Math.max(4, (b.total / maxTotal) * maxBarH);
-          const successH = b.total > 0 ? (b.success / b.total * h) : 0;
-          const failH = b.total > 0 ? (b.failed / b.total * h) : 0;
-          const otherH = h - successH - failH;
+          const t = b.total;
+          const hPx = DashboardData.trendBarPixelHeight(t, maxTotal, maxBar);
+          let failH = 0;
+          let otherH = 0;
+          let succH = 0;
+          if (t > 0 && hPx > 0) {
+            failH = Math.round((b.failed / t) * hPx);
+            succH = Math.round((b.success / t) * hPx);
+            otherH = Math.max(0, hPx - failH - succH);
+          }
           const topSegment = failH > 0 ? 'fail' : (otherH > 0 ? 'other' : 'success');
-          return `<div style="display:flex;flex-direction:column;align-items:center;flex:1;min-width:${barWidth}px;max-width:60px;" title="${b.tooltip}">
-            <div style="font:var(--textBodyBoldXSmall);color:var(--colorTextSecondary);margin-bottom:4px;">${b.total}</div>
-            <div style="width:100%;display:flex;flex-direction:column;">
-              ${failH > 0 ? `<div style="height:${failH}px;background:var(--colorDanger);border-radius:${topSegment === 'fail' ? '3px 3px' : '0 0'} 0 0;"></div>` : ''}
-              ${otherH > 0 ? `<div style="height:${otherH}px;background:var(--colorBackgroundTertiary);border-radius:${topSegment === 'other' ? '3px 3px' : '0 0'} ${successH > 0 ? '0 0' : '3px 3px'};"></div>` : ''}
-              ${successH > 0 ? `<div style="height:${successH}px;background:var(--colorSuccess);border-radius:0 0 3px 3px;"></div>` : ''}
+          return `<div class="deployment-trend-col" data-tooltip="${b.tooltip}">
+            <div class="deployment-trend-value deployment-trend-value--emph">${fmt(t)}</div>
+            <div class="deployment-trend-bar-area">
+              <div class="deployment-trend-bar-stack" style="height:${t > 0 ? hPx : 0}px;">
+                ${failH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--fail" style="height:${failH}px;border-radius:${topSegment === 'fail' ? '3px 3px' : '0 0'} 0 0;"></div>` : ''}
+                ${otherH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--other" style="height:${otherH}px;border-radius:${topSegment === 'other' ? '3px 3px' : '0 0'} ${succH > 0 ? '0 0' : '3px 3px'};"></div>` : ''}
+                ${succH > 0 ? `<div class="deployment-trend-seg deployment-trend-seg--success" style="height:${succH}px;border-radius:0 0 3px 3px;"></div>` : ''}
+              </div>
             </div>
-            <div style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);margin-top:4px;text-align:center;height:2.5em;line-height:1.25em;">${b.label}</div>
+            <div class="deployment-trend-axis-label">${b.label}</div>
           </div>`;
         }).join('')}
       </div>
@@ -695,7 +710,7 @@ const Views = (() => {
 
     <!-- Velocity trend -->
     <div class="section-header"><h2 class="section-title"><i class="fa-solid fa-chart-area"></i> Velocity Over Time</h2></div>
-    <div class="card mb-lg">
+    <div class="card card--chart-tooltips mb-lg">
       <div class="card-header">
         <h3 class="card-title"></h3>
         <div class="flex gap-xs" style="font:var(--textBodyRegularXSmall);color:var(--colorTextTertiary);">

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -37,15 +37,15 @@ const Views = (() => {
   /** Deployment success–rate tier for the selected dashboard period (not target/machine health). */
   function healthBadge(rate, hasDeployments) {
     if (rate >= 95) {
-      return `<span class="badge success" data-tooltip="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}">Healthy</span>`;
+      return `<span class="badge success" data-tooltip="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}" aria-label="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}" title="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}">Healthy</span>`;
     }
     if (rate >= 80) {
-      return `<span class="badge info" data-tooltip="${_tooltipAttr('Success rate is between 80% and 94%. Worth monitoring before it drops further.')}">Attention</span>`;
+      return `<span class="badge info" data-tooltip="${_tooltipAttr('Success rate is between 80% and 94%. Worth monitoring before it drops further.')}" aria-label="${_tooltipAttr('Success rate is between 80% and 94%. Worth monitoring before it drops further.')}" title="${_tooltipAttr('Success rate is between 80% and 94%. Worth monitoring before it drops further.')}">Attention</span>`;
     }
     if (rate < 80 && (rate > 0 || hasDeployments)) {
-      return `<span class="badge warning" data-tooltip="${_tooltipAttr('Success rate is below 80%, or there was deployment activity with a low success rate. Review failed deployments and trends.')}">Warning</span>`;
+      return `<span class="badge warning" data-tooltip="${_tooltipAttr('Success rate is below 80%, or there was deployment activity with a low success rate. Review failed deployments and trends.')}" aria-label="${_tooltipAttr('Success rate is below 80%, or there was deployment activity with a low success rate. Review failed deployments and trends.')}" title="${_tooltipAttr('Success rate is below 80%, or there was deployment activity with a low success rate. Review failed deployments and trends.')}">Warning</span>`;
     }
-    return `<span class="badge neutral" data-tooltip="${_tooltipAttr('Not enough deployment outcomes in the selected period to calculate a success rate.')}">No data</span>`;
+    return `<span class="badge neutral" data-tooltip="${_tooltipAttr('Not enough deployment outcomes in the selected period to calculate a success rate.')}" aria-label="${_tooltipAttr('Not enough deployment outcomes in the selected period to calculate a success rate.')}" title="${_tooltipAttr('Not enough deployment outcomes in the selected period to calculate a success rate.')}">No data</span>`;
   }
 
   function guessEnvClass(name) {

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -21,11 +21,22 @@ const Views = (() => {
     return date.toLocaleDateString('en-AU', { day: 'numeric', month: 'short' });
   }
 
+  function _tooltipAttr(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  }
+
+  /** Deployment success–rate tier for the selected dashboard period (not target/machine health). */
   function healthBadge(rate, hasDeployments) {
-    if (rate >= 95) return '<span class="badge success">Healthy</span>';
-    if (rate >= 80) return '<span class="badge warning">Attention</span>';
-    if (rate < 80 && (rate > 0 || hasDeployments)) return '<span class="badge danger">At Risk</span>';
-    return '<span class="badge neutral">No data</span>';
+    if (rate >= 95) {
+      return `<span class="badge success" data-tooltip="${_tooltipAttr('Deployment success rate is 95% or higher for this row in the selected time range.')}">Healthy</span>`;
+    }
+    if (rate >= 80) {
+      return `<span class="badge info" data-tooltip="${_tooltipAttr('Success rate is between 80% and 94%. Worth monitoring before it drops further.')}">Attention</span>`;
+    }
+    if (rate < 80 && (rate > 0 || hasDeployments)) {
+      return `<span class="badge warning" data-tooltip="${_tooltipAttr('Success rate is below 80%, or there was deployment activity with a low success rate. Review failed deployments and trends.')}">Warning</span>`;
+    }
+    return `<span class="badge neutral" data-tooltip="${_tooltipAttr('Not enough deployment outcomes in the selected period to calculate a success rate.')}">No data</span>`;
   }
 
   function guessEnvClass(name) {
@@ -140,14 +151,6 @@ const Views = (() => {
         <span class="kpi-value" id="kpi-avg-duration">--</span>
         <span class="kpi-trend neutral"><i class="fa-solid fa-clock"></i> <span>per deployment</span></span>
       </div>
-      <div class="kpi-card">
-        <div class="flex items-center justify-between">
-          <span class="kpi-label">Time Saved (est.)</span>
-          <div class="kpi-icon green"><i class="fa-solid fa-hourglass-half"></i></div>
-        </div>
-        <span class="kpi-value" id="kpi-time-saved">--</span>
-        <span class="kpi-trend neutral"><i class="fa-solid fa-hand-sparkles"></i> <span>vs manual process</span></span>
-      </div>
     </div>
 
     <!-- KPI Row 2 -->
@@ -245,7 +248,6 @@ const Views = (() => {
     <!-- Spaces Section Header -->
     <div class="section-header">
       <h2 class="section-title"><i class="fa-solid fa-cubes"></i> Space Breakdown</h2>
-      <span class="badge info">All Spaces</span>
     </div>
 
     <!-- Spaces Breakdown Table -->
@@ -257,7 +259,8 @@ const Views = (() => {
               <thead>
                 <tr>
                   <th>Space</th><th>Projects</th><th>Envs</th><th>Deployments</th>
-                  <th>Success Rate</th><th>Targets</th><th>Last Deploy</th><th>Health</th>
+                  <th>Success Rate</th><th>Targets</th><th>Last Deploy</th>
+                  <th data-tooltip="Deployment success tier for the selected time range (not target health). Hover a badge for definitions: Healthy ≥95%, Attention 80–94%, Warning &lt;80%, No data when there is nothing to score.">Health</th>
                 </tr>
               </thead>
               <tbody id="table-spaces">
@@ -1254,7 +1257,7 @@ const Views = (() => {
       <div class="card-body" style="padding:0;">
         <div class="table-wrapper">
           <table>
-            <thead><tr><th>Environment</th><th>Type</th><th>Spaces</th><th>Deployments</th><th>Success Rate</th><th>Health</th></tr></thead>
+            <thead><tr><th>Environment</th><th>Type</th><th>Spaces</th><th>Deployments</th><th>Success Rate</th><th data-tooltip="Deployment success tier for the selected time range (not target machine health). Hover each badge for Healthy, Attention, Warning, and No data.">Health</th></tr></thead>
             <tbody>
               ${envHealth.map(e => `<tr>
                 <td><span class="env-tag ${guessEnvClass(e.name)}">${DOMPurify.sanitize(e.name)}</span></td>

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -1628,7 +1628,7 @@ const Views = (() => {
       const url = octopusEnvUrl(envName, spaceName);
       if (!url) return '';
 
-      return `<a class="env-octopus-link text-tertiary" href="${url}" target="_blank" rel="noopener noreferrer" data-tooltip="${_tooltipAttr('Open this environment in Octopus (in the selected space)')}">
+      return `<a class="env-octopus-link text-tertiary" href="${_escapeAttr(url)}" target="_blank" rel="noopener noreferrer" data-tooltip="${_tooltipAttr('Open this environment in Octopus (in the selected space)')}">
         <span class="env-octopus-link-label">Open in Octopus</span>
         <span class="env-octopus-link-arrow" aria-hidden="true">&rarr;</span>
       </a>`;

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -25,6 +25,14 @@ const Views = (() => {
     return String(text).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
   }
 
+  function _escapeAttr(text) {
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
   /** Deployment success–rate tier for the selected dashboard period (not target/machine health). */
   function healthBadge(rate, hasDeployments) {
     if (rate >= 95) {
@@ -330,7 +338,8 @@ const Views = (() => {
         <span class="text-tertiary license-card-version" id="server-version"></span>
       </div>
       <div id="license-ptm" class="license-ptm" aria-label="Licensed usage: projects, tenants, machines"></div>
-    </div>`;
+    </div>
+`;
   }
 
   /** Wire up Overview-specific event listeners after HTML is inserted */
@@ -479,6 +488,27 @@ const Views = (() => {
           </table>
         </div>
       </div>
+    </div>
+    </div>
+
+    <!-- Environment spaces modal -->
+    <div class="modal-overlay" id="env-spaces-modal" aria-hidden="true" role="presentation">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="env-spaces-modal-title">
+        <div class="modal-header">
+          <h3 class="modal-title" id="env-spaces-modal-title">
+            <i class="fa-solid fa-layer-group"></i>
+            Spaces for <span id="env-spaces-modal-envname"></span>
+          </h3>
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button">
+            <i class="fa-solid fa-times"></i>
+          </button>
+        </div>
+        <div class="modal-body" id="env-spaces-modal-body"></div>
+        <div class="modal-footer">
+          <span class="text-tertiary" id="env-spaces-modal-meta"></span>
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-done" type="button">Close</button>
+        </div>
+      </div>
     </div>`;
   }
 
@@ -606,6 +636,26 @@ const Views = (() => {
             <div class="deployment-trend-axis-label${useDailyBars ? ' deployment-trend-axis-label--dense' : ''}">${b.label}</div>
           </div>`;
         }).join('')}
+      </div>
+    </div>
+
+    <!-- Environment spaces modal -->
+    <div class="modal-overlay" id="env-spaces-modal" aria-hidden="true" role="presentation">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="env-spaces-modal-title">
+        <div class="modal-header">
+          <h3 class="modal-title" id="env-spaces-modal-title">
+            <i class="fa-solid fa-layer-group"></i>
+            Spaces for <span id="env-spaces-modal-envname"></span>
+          </h3>
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button">
+            <i class="fa-solid fa-times"></i>
+          </button>
+        </div>
+        <div class="modal-body" id="env-spaces-modal-body"></div>
+        <div class="modal-footer">
+          <span class="text-tertiary" id="env-spaces-modal-meta"></span>
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-done" type="button">Close</button>
+        </div>
       </div>
     </div>`;
   }
@@ -1189,6 +1239,63 @@ const Views = (() => {
     // Build richer environment data with categorisation
     const envGroups = { production: [], staging: [], dev: [] };
 
+    const SPACES_PREVIEW_LIMIT = 4;
+
+    const spaceNameToId = new Map();
+    const envIdBySpaceAndName = new Map(); // `${spaceId}::${envName}` → envId
+
+    // Build environment deep-link ids so we can open environments in Octopus.
+    for (const [spaceId, sd] of Object.entries(allSpaceData || {})) {
+      const spaceName = sd?.space?.Name || spaceId;
+      spaceNameToId.set(spaceName, spaceId);
+
+      for (const env of (sd?.environments || [])) {
+        if (!env?.Id || !env?.Name) continue;
+        envIdBySpaceAndName.set(`${spaceId}::${env.Name}`, env.Id);
+      }
+    }
+
+    function octopusEnvUrl(envName, spaceName) {
+      const spaceId = spaceNameToId.get(spaceName);
+      if (!spaceId) return null;
+      const envId = envIdBySpaceAndName.get(`${spaceId}::${envName}`);
+      if (!envId) return null;
+
+      const root = (typeof OctopusApi?.getInstanceUrl === 'function') ? OctopusApi.getInstanceUrl() : '';
+      if (!root) return null;
+
+      return `${root}/app#/${encodeURIComponent(spaceId)}/infrastructure/environments/${encodeURIComponent(envId)}`;
+    }
+
+    function renderOctopusEnvLink(envName, spaces) {
+      const list = Array.isArray(spaces) ? spaces.slice() : [];
+      if (!list.length) return '';
+
+      // Choose first space deterministically (spaces in envHealth are a Set so order is not stable).
+      list.sort((a, b) => String(a).localeCompare(String(b)));
+      const spaceName = list[0];
+      const url = octopusEnvUrl(envName, spaceName);
+      if (!url) return '';
+
+      return `<a class="env-octopus-link text-tertiary" href="${url}" target="_blank" rel="noopener noreferrer" data-tooltip="${_tooltipAttr('Open this environment in Octopus (in the selected space)')}">
+        <span class="env-octopus-link-label">Open in Octopus</span>
+        <span class="env-octopus-link-arrow" aria-hidden="true">&rarr;</span>
+      </a>`;
+    }
+
+    function renderSpacesPreview(envName, spaces) {
+      const allSpaces = Array.isArray(spaces) ? spaces : [];
+      if (allSpaces.length === 0) return '<span class="text-tertiary">No spaces</span>';
+
+      const preview = allSpaces.slice(0, SPACES_PREVIEW_LIMIT);
+      const remaining = allSpaces.length - preview.length;
+
+      const previewHtml = preview.map(s => DOMPurify.sanitize(String(s))).join(', ');
+      if (remaining <= 0) return previewHtml;
+
+      return `${previewHtml} <button class="env-spaces-more view-env-spaces" data-env-name="${_escapeAttr(envName)}" type="button"><span>+${remaining} more</span><span class="env-spaces-more-arrow" aria-hidden="true">→</span></button>`;
+    }
+
     for (const env of envHealth) {
       const cls = guessEnvClass(env.name);
       const entry = {
@@ -1249,11 +1356,14 @@ const Views = (() => {
               </div>
               <div class="env-detail-footer">
                 <span class="text-tertiary" style="font:var(--textBodyRegularXSmall);">
-                  <i class="fa-solid fa-cubes"></i> ${e.spaces.length} space${e.spaces.length !== 1 ? 's' : ''}: ${e.spaces.join(', ')}
+                  <i class="fa-solid fa-cubes"></i> ${e.spaces.length} space${e.spaces.length !== 1 ? 's' : ''}: ${renderSpacesPreview(e.name, e.spaces)}
                 </span>
               </div>
               <div style="margin-top:var(--space-xs);">
                 <div class="progress-bar" style="width:100%;"><div class="progress-fill ${e.successRate >= 90 ? 'success' : e.successRate >= 70 ? 'warning' : 'danger'}" style="width:${e.successRate}%;"></div></div>
+              </div>
+              <div style="margin-top:var(--space-sm);">
+                ${renderOctopusEnvLink(e.name, e.spaces)}
               </div>
             </div>
           `).join('')}
@@ -1264,6 +1374,26 @@ const Views = (() => {
     <div class="page-header">
       <h1 class="page-title">Environments</h1>
       <p class="page-subtitle">Environment health, deployment success rates, and target health grouped by type.</p>
+    </div>
+
+    <!-- Environment spaces modal -->
+    <div class="modal-overlay" id="env-spaces-modal" aria-hidden="true" role="presentation">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="env-spaces-modal-title">
+        <div class="modal-header">
+          <h3 class="modal-title" id="env-spaces-modal-title">
+            <i class="fa-solid fa-layer-group"></i>
+            Spaces for <span id="env-spaces-modal-envname"></span>
+          </h3>
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-close" type="button">
+            <i class="fa-solid fa-times"></i>
+          </button>
+        </div>
+        <div class="modal-body" id="env-spaces-modal-body"></div>
+        <div class="modal-footer">
+          <span class="text-tertiary" id="env-spaces-modal-meta"></span>
+          <button class="btn btn-secondary btn-sm" id="env-spaces-modal-done" type="button">Close</button>
+        </div>
+      </div>
     </div>
 
     <div class="kpi-grid mb-lg">
@@ -1303,12 +1433,13 @@ const Views = (() => {
       <div class="card-body" style="padding:0;">
         <div class="table-wrapper">
           <table>
-            <thead><tr><th>Environment</th><th>Type</th><th>Spaces</th><th>Deployments</th><th>Success Rate</th><th data-tooltip="Deployment success tier for the selected time range (not target machine health). Hover each badge for Healthy, Attention, Warning, and No data.">Health</th></tr></thead>
+            <thead><tr><th>Environment</th><th>Type</th><th>Spaces</th><th>Octopus</th><th>Deployments</th><th>Success Rate</th><th data-tooltip="Deployment success tier for the selected time range (not target machine health). Hover each badge for Healthy, Attention, Warning, and No data.">Health</th></tr></thead>
             <tbody>
               ${envHealth.map(e => `<tr>
                 <td><span class="env-tag ${guessEnvClass(e.name)}">${DOMPurify.sanitize(e.name)}</span></td>
                 <td class="text-secondary">${guessEnvClass(e.name).charAt(0).toUpperCase() + guessEnvClass(e.name).slice(1)}</td>
-                <td class="text-secondary">${e.spaces.join(', ')}</td>
+                <td class="text-secondary">${renderSpacesPreview(e.name, e.spaces)}</td>
+                <td>${renderOctopusEnvLink(e.name, e.spaces)}</td>
                 <td class="monospace">${e.total}</td>
                 <td><div class="flex items-center gap-xs"><div class="progress-bar" style="width:60px;"><div class="progress-fill ${e.successRate >= 90 ? 'success' : e.successRate >= 70 ? 'warning' : 'danger'}" style="width:${e.successRate}%;"></div></div><span class="text-secondary">${e.successRate}%</span></div></td>
                 <td>${healthBadge(e.successRate, e.total > 0)}</td>
@@ -1318,6 +1449,91 @@ const Views = (() => {
         </div>
       </div>
     </div>`;
+  }
+
+  function wireEnvironmentsEvents(summary) {
+    const overlay = document.getElementById('env-spaces-modal');
+    if (!overlay) return;
+
+    const closeBtn = document.getElementById('env-spaces-modal-close');
+    const doneBtn = document.getElementById('env-spaces-modal-done');
+    const body = document.getElementById('env-spaces-modal-body');
+    const envNameEl = document.getElementById('env-spaces-modal-envname');
+    const metaEl = document.getElementById('env-spaces-modal-meta');
+
+    const envHealth = summary?.envHealth || [];
+    const envSpacesByName = new Map(envHealth.map(e => [e.name, e.spaces || []]));
+
+    function close() {
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+
+    function open(envName) {
+      const spaces = envSpacesByName.get(envName) || [];
+      envNameEl.textContent = envName;
+      metaEl.textContent = `${spaces.length} space${spaces.length !== 1 ? 's' : ''}`;
+
+      body.innerHTML = spaces.length
+        ? `
+          <div style="margin-bottom:var(--space-sm);">
+            <div class="view-search-wrapper" style="max-width:100%;padding:var(--space-xs) var(--space-sm);">
+              <i class="fa-solid fa-search text-tertiary"></i>
+              <input type="text" id="env-spaces-search-input" class="view-search-input" placeholder="Search spaces...">
+            </div>
+          </div>
+          <div class="env-spaces-grid" id="env-spaces-grid">
+            ${spaces
+              .slice()
+              .sort((a, b) => String(a).localeCompare(String(b)))
+              .map(s => {
+                const name = String(s);
+                const needle = name.toLowerCase();
+                return `<span class="badge neutral env-space-pill" data-space-name="${_escapeAttr(needle)}">${DOMPurify.sanitize(name)}</span>`;
+              })
+              .join('')}
+          </div>`
+        : `<div class="text-tertiary">No spaces</div>`;
+
+      overlay.setAttribute('aria-hidden', 'false');
+      closeBtn?.focus?.();
+
+      const input = document.getElementById('env-spaces-search-input');
+      if (input) {
+        input.addEventListener('input', () => {
+          const q = input.value.toLowerCase().trim();
+          const grid = document.getElementById('env-spaces-grid');
+          if (!grid) return;
+
+          grid.querySelectorAll('.env-space-pill').forEach(pill => {
+            const name = pill.dataset.spaceName || '';
+            pill.style.display = !q || name.includes(q) ? '' : 'none';
+          });
+        });
+      }
+    }
+
+    document.querySelectorAll('.view-env-spaces[data-env-name]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        open(btn.dataset.envName || '');
+      });
+    });
+
+    closeBtn?.addEventListener('click', close);
+    doneBtn?.addEventListener('click', close);
+    overlay?.addEventListener('click', (e) => {
+      if (e.target === overlay) close();
+    });
+
+    if (!wireEnvironmentsEvents._escInstalled) {
+      wireEnvironmentsEvents._escInstalled = true;
+      document.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') return;
+        const modal = document.getElementById('env-spaces-modal');
+        if (!modal) return;
+        if (modal.getAttribute('aria-hidden') === 'true') return;
+        document.getElementById('env-spaces-modal-close')?.click?.();
+      });
+    }
   }
 
 
@@ -1509,6 +1725,7 @@ const Views = (() => {
     renderProjects,
     wireProjectsEvents,
     renderEnvironments,
+    wireEnvironmentsEvents,
     renderTeams,
   };
 

--- a/dashboards/valuemetrics/views.js
+++ b/dashboards/valuemetrics/views.js
@@ -1063,10 +1063,30 @@ const Views = (() => {
         const deploys = spaceData?.deployments || [];
         const recent = deploys.slice(0, 10);
 
+        const root = (typeof OctopusApi?.getInstanceUrl === 'function') ? OctopusApi.getInstanceUrl() : '';
+        const octopusSpaceUrl = root
+          ? `${root}/app#/${encodeURIComponent(spaceId)}/projects`
+          : '';
+
         panel.innerHTML = `
           <div class="card mt-lg">
             <div class="card-header">
-              <h3 class="card-title"><div class="space-avatar sm" style="display:inline-flex;vertical-align:middle;margin-right:var(--space-xs);">${spaceInfo.name.charAt(0).toUpperCase()}</div> ${DOMPurify.sanitize(spaceInfo.name)} — Detail</h3>
+              <h3 class="card-title">
+                <div class="space-avatar sm" style="display:inline-flex;vertical-align:middle;margin-right:var(--space-xs);">${spaceInfo.name.charAt(0).toUpperCase()}</div>
+                ${DOMPurify.sanitize(spaceInfo.name)} — Detail
+              </h3>
+              ${octopusSpaceUrl ? `
+                <a
+                  class="text-tertiary"
+                  href="${octopusSpaceUrl}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style="font:var(--textBodyRegularSmall);display:inline-flex;align-items:center;gap:var(--space-xxs);text-decoration:none;"
+                >
+                  <span>Open in Octopus</span>
+                  <span aria-hidden="true" style="opacity:.9;">&rarr;</span>
+                </a>
+              ` : ''}
               <button class="btn btn-secondary btn-sm" id="close-space-detail"><i class="fa-solid fa-times"></i></button>
             </div>
             <div class="card-body">


### PR DESCRIPTION
Deployment Trends page - timeline chart (30d/90d/12m), day-of-week & hour-of-day patterns, environment distribution, success/failure donut, per-space breakdown

Release Velocity page - deploy frequency KPIs, duration percentiles (p50/p90/p95), per-project velocity table with search, before-vs-now comparison
Historical data engine - background paging through task history (up to 10k tasks), localStorage cache, lookback selector (3m → all time), progress banner

Overview enrichment - KPIs, donut chart, and trend chart all reflect the selected lookback period

Other fixes - daily trend bars, ISO week chart, loading overlay, license PTM display, teams fix, deep links to Octopus, health pill tooltips, UX caps on large tables