### PR TITLE
fix: project checkbox deselection logic and search cursor position

### DIFF
--- a/dashboards/valuemetrics/tenants.js
+++ b/dashboards/valuemetrics/tenants.js
@@ -10,6 +10,7 @@ const TenantView = (() => {
     let _docListenersAttached = false;
     const _wireTimeouts = {};
     let _spaceLoadId = 0;
+    const _detailSearchCursors = {};
 
     const tenantsState = {
         allTenants: [],
@@ -1085,18 +1086,14 @@ const TenantView = (() => {
         const searchInput = detail.querySelector('.tv-detail-search');
         if (searchInput) {
             searchInput.addEventListener('input', e => {
-                const pos = e.target.selectionStart;
+                _detailSearchCursors[tenantId] = e.target.selectionStart;
                 tenantsState.detailSearchQueries[tenantId] = e.target.value;
                 refreshDetail(tenantId);
-                // refreshDetail replaces the DOM — find the new input and restore cursor
-                const newInput = document.querySelector(`[data-detail-for="${tenantId}"] .tv-detail-search`);
-                if (newInput) {
-                    newInput.focus();
-                    newInput.setSelectionRange(pos, pos);
-                }
             });
             searchInput.focus();
-            searchInput.setSelectionRange(searchInput.value.length, searchInput.value.length);
+            const savedPos = _detailSearchCursors[tenantId];
+            const cursorPos = savedPos != null ? Math.min(savedPos, searchInput.value.length) : searchInput.value.length;
+            searchInput.setSelectionRange(cursorPos, cursorPos);
         }
     }
 

--- a/dashboards/valuemetrics/tenants.js
+++ b/dashboards/valuemetrics/tenants.js
@@ -466,11 +466,16 @@ const TenantView = (() => {
                 renderStats();
             } else if (optBtn) {
                 const proj = optBtn.dataset.project;
-                const idx  = tenantsState.filters.projects.indexOf(proj);
-                if (idx === -1) tenantsState.filters.projects.push(proj);
-                else tenantsState.filters.projects.splice(idx, 1);
-                if (tenantsState.filters.projects.length === tenantsState.projects.length) {
-                    tenantsState.filters.projects = [];
+                if (tenantsState.filters.projects.length === 0) {
+                    // All were selected — deselect this one by selecting everything else
+                    tenantsState.filters.projects = tenantsState.projects.filter(p => p !== proj);
+                } else {
+                    const idx = tenantsState.filters.projects.indexOf(proj);
+                    if (idx === -1) tenantsState.filters.projects.push(proj);
+                    else tenantsState.filters.projects.splice(idx, 1);
+                    if (tenantsState.filters.projects.length === tenantsState.projects.length) {
+                        tenantsState.filters.projects = [];
+                    }
                 }
                 updateProjectCheckboxes();
                 applyFilters();
@@ -1080,10 +1085,18 @@ const TenantView = (() => {
         const searchInput = detail.querySelector('.tv-detail-search');
         if (searchInput) {
             searchInput.addEventListener('input', e => {
+                const pos = e.target.selectionStart;
                 tenantsState.detailSearchQueries[tenantId] = e.target.value;
                 refreshDetail(tenantId);
+                // refreshDetail replaces the DOM — find the new input and restore cursor
+                const newInput = document.querySelector(`[data-detail-for="${tenantId}"] .tv-detail-search`);
+                if (newInput) {
+                    newInput.focus();
+                    newInput.setSelectionRange(pos, pos);
+                }
             });
             searchInput.focus();
+            searchInput.setSelectionRange(searchInput.value.length, searchInput.value.length);
         }
     }
 


### PR DESCRIPTION
- Clicking a project when all are selected now deselects that one (selects all others) instead of inverting to show only that project
- Detail search no longer types backwards — cursor position is saved before re-render and restored on the new input after refreshDetail replaces the DOM