### PR TITLE
Add Infrastructure (PreAlpha) community dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ copilotDiffState.xml
 node_modules
 .playwright-mcp
 .vagrant
+.superpowers/

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -4,14 +4,20 @@ var IP = { estate:null, serverUrl:null, context:{}, filters:{}, search:'', page:
 async function ipBoot() {
   const el = document.getElementById('main-content');
   el.innerHTML = Views.stateView('loading');
-  const { serverUrl, context } = await Data.readConfig();
-  IP.serverUrl = serverUrl; IP.context = context;
-  const res = await Data.loadEstate(serverUrl);
-  if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
-  if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
-  if (res.status === 'empty') { IP.estate = Data.buildEstate([]); Onboarding.renderFirstRun(IP); return; }
-  IP.estate = Data.buildEstate(res.perSpace);
-  Router.init();
+  try {
+    const { serverUrl, context } = await Data.readConfig();
+    IP.serverUrl = serverUrl; IP.context = context;
+    if (!serverUrl) { el.innerHTML = Views.stateView('noconfig'); return; }
+    const res = await Data.loadEstate(serverUrl);
+    if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
+    if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
+    if (res.status === 'empty') { IP.estate = Data.buildEstate([]); Onboarding.renderFirstRun(IP); return; }
+    IP.estate = Data.buildEstate(res.perSpace);
+    Router.init();
+  } catch (e) {
+    // Never leave the loading spinner up: surface any unexpected failure.
+    el.innerHTML = Views.stateView('error', (e && e.message) || 'Unexpected error');
+  }
 }
 
 if (typeof module === 'undefined' || !module.exports) {

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -12,7 +12,12 @@ async function ipBoot() {
     const res = await Data.loadEstate(serverUrl);
     if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
     if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
-    if (res.status === 'empty') { IP.estate = Data.buildEstate([]); Onboarding.renderFirstRun(IP); return; }
+    if (!res.perSpace || !res.perSpace.length) {
+      // No spaces at all (or nothing loadable) — nothing to switch between.
+      IP.estate = Data.buildEstate([]);
+      Onboarding.renderFirstRun(IP);
+      return;
+    }
     IP.perSpace = res.perSpace;
     IP.spaces = (res.spaces || []).map(s => ({ Id: s.Id, Name: s.Name }));
     const ctx = IP.context || {};

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -1,2 +1,20 @@
 'use strict';
-// Populated in later tasks.
+var IP = { estate:null, serverUrl:null, context:{}, filters:{}, search:'', page:1, detailId:null };
+
+async function ipBoot() {
+  const el = document.getElementById('main-content');
+  el.innerHTML = Views.stateView('loading');
+  const { serverUrl, context } = await Data.readConfig();
+  IP.serverUrl = serverUrl; IP.context = context;
+  const res = await Data.loadEstate(serverUrl);
+  if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
+  if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
+  if (res.status === 'empty') { IP.estate = Data.buildEstate([]); Onboarding.renderFirstRun(IP); return; }
+  IP.estate = Data.buildEstate(res.perSpace);
+  Router.init();
+}
+
+if (typeof module === 'undefined' || !module.exports) {
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', ipBoot);
+  else ipBoot();
+}

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -3,6 +3,15 @@ var IP = { estate:null, serverUrl:null, context:{}, filters:{}, search:'', page:
   wFilters:{}, wSearch:'', wPage:1 };
 
 async function ipBoot() {
+  // Theme init — applied before anything else renders so there's no light/dark flash.
+  try {
+    const stored = localStorage.getItem('iprealpha:theme');
+    const dark = stored ? stored === 'dark'
+      : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', !!dark);
+    IP.theme = dark ? 'dark' : 'light';
+  } catch (e) { IP.theme = 'light'; }
+
   const el = document.getElementById('main-content');
   el.innerHTML = Views.stateView('loading');
   try {
@@ -29,6 +38,8 @@ async function ipBoot() {
     IP.rescope();
     const switchEl = document.getElementById('ip-space-switch');
     if (switchEl) { switchEl.innerHTML = Views.renderSpaceSwitch(IP); Views.bindSpaceSwitch(IP); }
+    const themeEl = document.getElementById('ip-theme-toggle');
+    if (themeEl) { themeEl.innerHTML = Views.renderThemeToggle(IP); Views.bindThemeToggle(IP); }
     Router.init();
   } catch (e) {
     // Never leave the loading spinner up: surface any unexpected failure.

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -1,0 +1,2 @@
+'use strict';
+// Populated in later tasks.

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -1,5 +1,6 @@
 'use strict';
-var IP = { estate:null, serverUrl:null, context:{}, filters:{}, search:'', page:1, detailId:null };
+var IP = { estate:null, serverUrl:null, context:{}, filters:{}, search:'', page:1, detailId:null,
+  wFilters:{}, wSearch:'', wPage:1 };
 
 async function ipBoot() {
   const el = document.getElementById('main-content');

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -13,7 +13,17 @@ async function ipBoot() {
     if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
     if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
     if (res.status === 'empty') { IP.estate = Data.buildEstate([]); Onboarding.renderFirstRun(IP); return; }
-    IP.estate = Data.buildEstate(res.perSpace);
+    IP.perSpace = res.perSpace;
+    IP.spaces = (res.spaces || []).map(s => ({ Id: s.Id, Name: s.Name }));
+    const ctx = IP.context || {};
+    const m = (IP.spaces || []).find(s => s.Name === ctx.space);
+    IP.spaceId = m ? m.Id : null;
+    IP.rescope = () => {
+      IP.estate = Data.buildEstate(IP.spaceId ? IP.perSpace.filter(s => s.sp.Id === IP.spaceId) : IP.perSpace);
+    };
+    IP.rescope();
+    const switchEl = document.getElementById('ip-space-switch');
+    if (switchEl) { switchEl.innerHTML = Views.renderSpaceSwitch(IP); Views.bindSpaceSwitch(IP); }
     Router.init();
   } catch (e) {
     // Never leave the loading spinner up: surface any unexpected failure.

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -22,9 +22,18 @@ async function ipBoot() {
     if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
     if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
     if (!res.perSpace || !res.perSpace.length) {
-      // No spaces at all (or nothing loadable) — nothing to switch between.
+      // No spaces at all (or nothing loadable) — nothing to switch between. Still go
+      // through Router.init(): rendering first-run directly and returning skips the
+      // hashchange listener entirely, which leaves every nav item inert and strands
+      // the user on the cold-start screen. The router's own empty-estate check draws
+      // first-run for each route, and keeps #targets/new reachable.
       IP.estate = Data.buildEstate([]);
-      Onboarding.renderFirstRun(IP);
+      IP.perSpace = [];
+      IP.spaces = [];
+      IP.rescope = () => { IP.estate = Data.buildEstate([]); };
+      const themeOnly = document.getElementById('ip-theme-toggle');
+      if (themeOnly) { themeOnly.innerHTML = Views.renderThemeToggle(IP); Views.bindThemeToggle(IP); }
+      Router.init();
       return;
     }
     IP.perSpace = res.perSpace;

--- a/dashboards/infrastructureprealpha/dashboard.js
+++ b/dashboards/infrastructureprealpha/dashboard.js
@@ -18,33 +18,57 @@ async function ipBoot() {
     const { serverUrl, context } = await Data.readConfig();
     IP.serverUrl = serverUrl; IP.context = context;
     if (!serverUrl) { el.innerHTML = Views.stateView('noconfig'); return; }
-    const res = await Data.loadEstate(serverUrl);
-    if (res.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
-    if (res.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
-    if (!res.perSpace || !res.perSpace.length) {
-      // No spaces at all (or nothing loadable) — nothing to switch between. Still go
-      // through Router.init(): rendering first-run directly and returning skips the
-      // hashchange listener entirely, which leaves every nav item inert and strands
-      // the user on the cold-start screen. The router's own empty-estate check draws
-      // first-run for each route, and keeps #targets/new reachable.
+    const listed = await Data.loadSpaces(serverUrl);
+    if (listed.status === 'auth')  { el.innerHTML = Views.stateView('auth'); return; }
+    if (listed.status === 'error') { el.innerHTML = Views.stateView('error', 'Failed to reach the Octopus API'); return; }
+
+    IP.spaces = (listed.spaces || []).map(s => ({ Id: s.Id, Name: s.Name }));
+    IP.spaceCache = {};
+
+    if (!IP.spaces.length) {
+      // No spaces at all — nothing to switch between. Still go through Router.init():
+      // rendering first-run directly and returning skips the hashchange listener
+      // entirely, which leaves every nav item inert and strands the user on the
+      // cold-start screen. The router's own empty-estate check draws first-run for each
+      // route, and keeps #targets/new reachable.
       IP.estate = Data.buildEstate([]);
       IP.perSpace = [];
-      IP.spaces = [];
-      IP.rescope = () => { IP.estate = Data.buildEstate([]); };
+      IP.rescope = async () => { IP.estate = Data.buildEstate([]); };
       const themeOnly = document.getElementById('ip-theme-toggle');
       if (themeOnly) { themeOnly.innerHTML = Views.renderThemeToggle(IP); Views.bindThemeToggle(IP); }
       Router.init();
       return;
     }
-    IP.perSpace = res.perSpace;
-    IP.spaces = (res.spaces || []).map(s => ({ Id: s.Id, Name: s.Name }));
+
+    // Always a concrete space: the extension's context space when it matches, otherwise
+    // the first one. There is no all-spaces view, so there is no null case to carry.
     const ctx = IP.context || {};
-    const m = (IP.spaces || []).find(s => s.Name === ctx.space);
-    IP.spaceId = m ? m.Id : null;
-    IP.rescope = () => {
-      IP.estate = Data.buildEstate(IP.spaceId ? IP.perSpace.filter(s => s.sp.Id === IP.spaceId) : IP.perSpace);
+    const m = IP.spaces.find(s => s.Name === ctx.space);
+    IP.spaceId = (m || IP.spaces[0]).Id;
+
+    // Hydrate on demand and remember the result, so switching back to a space already
+    // seen costs nothing. Only the selected space is ever loaded — one space's six
+    // requests instead of the whole instance's.
+    const hydrate = async (sp) => {
+      if (!(sp.Id in IP.spaceCache)) IP.spaceCache[sp.Id] = await Data.hydrateSpace(sp);
+      return IP.spaceCache[sp.Id];
     };
-    IP.rescope();
+    IP.rescope = async () => {
+      const sp = IP.spaces.find(s => s.Id === IP.spaceId) || IP.spaces[0];
+      const hydrated = await hydrate(sp);
+      IP.perSpace = hydrated ? [hydrated] : [];
+      IP.estate = Data.buildEstate(IP.perSpace);
+      // Octopus listed this space but its infrastructure wouldn't load. That is a read
+      // failure, not an empty estate, and not an auth failure either since the space list
+      // came back — usually a permissions boundary on that space. Held on IP so the
+      // router renders it; setting innerHTML here would just be overwritten by the first
+      // route render, and the switcher must stay live so another space is one click away.
+      IP.spaceError = hydrated ? null
+        : 'Octopus listed this space but its infrastructure could not be read. '
+          + 'Your account may not have permission here — try another space.';
+    };
+    await IP.rescope();
+
     const switchEl = document.getElementById('ip-space-switch');
     if (switchEl) { switchEl.innerHTML = Views.renderSpaceSwitch(IP); Views.bindSpaceSwitch(IP); }
     const themeEl = document.getElementById('ip-theme-toggle');

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -8,3 +8,22 @@ describe('Infrastructure PreAlpha — data layer', () => {
     expect(typeof data).toBe('object');
   });
 });
+
+describe('fetchJson', () => {
+  const data = require('./data');
+  test('401 throws an error flagged auth', async () => {
+    global.fetch = async () => ({ status: 401, ok: false, statusText: 'Unauthorized' });
+    data.setServerUrl('https://x.octopus.app/');
+    await expect(data.fetchJson('/api/spaces/all')).rejects.toMatchObject({ auth: true });
+  });
+  test('500 throws an error with code, not auth', async () => {
+    global.fetch = async () => ({ status: 500, ok: false, statusText: 'Server Error' });
+    data.setServerUrl('https://x.octopus.app/');
+    await expect(data.fetchJson('/api/spaces/all')).rejects.toMatchObject({ code: '500 Server Error' });
+  });
+  test('200 returns parsed json', async () => {
+    global.fetch = async () => ({ status: 200, ok: true, json: async () => [{ Id: 'Spaces-1' }] });
+    data.setServerUrl('https://x.octopus.app/');
+    await expect(data.fetchJson('/api/spaces/all')).resolves.toEqual([{ Id: 'Spaces-1' }]);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -91,6 +91,22 @@ describe('overview + facets + filters', () => {
   });
 });
 
+describe('typeGroup', () => {
+  const d = require('./data');
+  test('collapses and cleans communication styles', () => {
+    expect(d.typeGroup('TentacleActive')).toBe('Tentacle');
+    expect(d.typeGroup('TentaclePassive')).toBe('Tentacle');
+    expect(d.typeGroup('Ssh')).toBe('SSH');
+    expect(d.typeGroup('KubernetesTentacle')).toBe('Kubernetes');
+    expect(d.typeGroup('Kubernetes')).toBe('Kubernetes');
+    expect(d.typeGroup('AzureWebApp')).toBe('Azure Web App');
+    expect(d.typeGroup('OfflineDrop')).toBe('Offline Drop');
+    expect(d.typeGroup('None')).toBe('Cloud Region');
+    expect(d.typeGroup('AzureCloudService')).toBe('Cloud Region');
+    expect(d.typeGroup('SomethingNew')).toBe('SomethingNew');
+  });
+});
+
 describe('readConfig robustness', () => {
   const d = require('./data');
   afterEach(() => { delete global.dashboardGetConfig; });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -226,6 +226,53 @@ describe('os + dead-facet suppression', () => {
   });
 });
 
+describe('workersModel + workerFacets + applyWorkerFilters', () => {
+  const d = require('./data');
+  const workers = [
+    { id:'Workers-1', name:'worker-a', health:'Healthy', healthKey:'healthy', pool:'Default Worker Pool', version:'8.3.0', kind:'Tentacle (Listening)' },
+    { id:'Workers-2', name:'worker-b', health:'Unhealthy', healthKey:'unhealthy', pool:'Default Worker Pool', version:'8.1.0', kind:'Tentacle (Polling)' },
+    { id:'Workers-3', name:'worker-c', health:'Healthy', healthKey:'healthy', pool:'Docker Pool', version:'8.3.0', kind:'Kubernetes Agent' }
+  ];
+  test('workersModel aggregates pools by total descending with healthy/unhealthy counts, and passes through rows', () => {
+    const m = d.workersModel(workers);
+    expect(m.pools).toEqual([
+      { name:'Default Worker Pool', total:2, healthy:1, unhealthy:1 },
+      { name:'Docker Pool', total:1, healthy:1, unhealthy:0 }
+    ]);
+    expect(m.rows).toEqual(workers);
+  });
+  test('workerFacets produces counted options for Health, Pool and Agent version', () => {
+    const facets = d.workerFacets(workers);
+    const health = facets.find(f => f.key==='health');
+    expect(health.options).toEqual(expect.arrayContaining([
+      { value:'healthy', label:'Healthy', count:2 },
+      { value:'unhealthy', label:'Unhealthy', count:1 }
+    ]));
+    const pool = facets.find(f => f.key==='pool');
+    expect(pool.options).toEqual(expect.arrayContaining([
+      { value:'Default Worker Pool', label:'Default Worker Pool', count:2 },
+      { value:'Docker Pool', label:'Docker Pool', count:1 }
+    ]));
+    const version = facets.find(f => f.key==='version');
+    expect(version.options).toEqual(expect.arrayContaining([
+      { value:'8.3.0', label:'8.3.0', count:2 },
+      { value:'8.1.0', label:'8.1.0', count:1 }
+    ]));
+  });
+  test('workerFacets omits a facet whose only option is —', () => {
+    const single = [{ id:'Workers-1', name:'w', health:'Healthy', healthKey:'healthy', pool:'—', version:'—', kind:'Tentacle (Listening)' }];
+    const keys = d.workerFacets(single).map(f => f.key);
+    expect(keys).not.toContain('pool');
+    expect(keys).not.toContain('version');
+    expect(keys).toContain('health');
+  });
+  test('applyWorkerFilters filters by health/pool facet and by name search', () => {
+    expect(d.applyWorkerFilters(workers, { health:['healthy'] }, '').map(w=>w.name)).toEqual(['worker-a','worker-c']);
+    expect(d.applyWorkerFilters(workers, {}, 'worker-b').map(w=>w.name)).toEqual(['worker-b']);
+    expect(d.applyWorkerFilters(workers, { pool:['Docker Pool'] }, '').map(w=>w.name)).toEqual(['worker-c']);
+  });
+});
+
 describe('readConfig robustness', () => {
   const d = require('./data');
   afterEach(() => { delete global.dashboardGetConfig; });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -135,6 +135,28 @@ describe('health categorisation', () => {
   });
 });
 
+describe('os + dead-facet suppression', () => {
+  const d = require('./data');
+  test('osLabel reads common candidate fields, else —', () => {
+    expect(d.osLabel({ TentacleVersionDetails:{ OperatingSystem:'Windows Server 2022' } })).toBe('Windows Server 2022');
+    expect(d.osLabel({}, { OperatingSystem:'Ubuntu 22.04 LTS' })).toBe('Ubuntu 22.04 LTS');
+    expect(d.osLabel({}, {})).toBe('—');
+  });
+  test('osVersionLabel reads common candidate fields, else —', () => {
+    expect(d.osVersionLabel({ TentacleVersionDetails:{ OperatingSystemVersion:'10.0.20348' } })).toBe('10.0.20348');
+    expect(d.osVersionLabel({}, { OperatingSystemVersion:'22.04' })).toBe('22.04');
+    expect(d.osVersionLabel({}, {})).toBe('—');
+  });
+  test('buildFacets omits a facet whose only option is —', () => {
+    const targets = [{ type:'Tentacle', healthKey:'healthy', health:'Healthy', env:'P', tag:'a',
+      tenant:'No tenants', policy:'D', version:'8.3.0', os:'—', osVersion:'—' }];
+    const keys = d.buildFacets(targets).map(f => f.key);
+    expect(keys).not.toContain('os');
+    expect(keys).not.toContain('osVersion');
+    expect(keys).toContain('type'); // real facets still present (Type facet keyed 'type' since A2)
+  });
+});
+
 describe('readConfig robustness', () => {
   const d = require('./data');
   afterEach(() => { delete global.dashboardGetConfig; });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -396,6 +396,16 @@ describe('facets drop blank-value options', () => {
   });
 });
 
+describe('isEmptyEstate', () => {
+  const d = require('./data');
+  test('true when no targets and no workers; false otherwise', () => {
+    expect(d.isEmptyEstate(null)).toBe(true);
+    expect(d.isEmptyEstate({ targets:[], workers:[] })).toBe(true);
+    expect(d.isEmptyEstate({ targets:[{name:'a'}], workers:[] })).toBe(false);
+    expect(d.isEmptyEstate({ targets:[], workers:[{name:'w'}] })).toBe(false);
+  });
+});
+
 describe('OS "Unknown" literal treated as blank', () => {
   const d = require('./data');
   test('osLabel/osVersionLabel return blank for a literal Unknown value', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -91,6 +91,34 @@ describe('overview + facets + filters', () => {
   });
 });
 
+describe('environmentsModel', () => {
+  const d = require('./data');
+  const targets = [
+    { name:'web-01', type:'Tentacle', healthKey:'healthy', health:'Healthy', env:'Production', tag:'web', tenant:'No tenants' },
+    { name:'api-01', type:'Kubernetes', healthKey:'unhealthy', health:'Unhealthy', env:'Production', tag:'api', tenant:'No tenants' },
+    { name:'web-02', type:'Tentacle', healthKey:'disabled', health:'Disabled', env:'Dev', tag:'web', tenant:'No tenants' }
+  ];
+  const environments = [
+    { id:'Environments-1', name:'Production', spaceId:'Spaces-1' },
+    { id:'Environments-2', name:'Dev', spaceId:'Spaces-1' },
+    { id:'Environments-3', name:'Staging', spaceId:'Spaces-1' }
+  ];
+  test('groups targets by environment with health counts, sorted by total descending', () => {
+    const rows = d.environmentsModel(targets, environments);
+    expect(rows.map(r => r.name)).toEqual(['Production', 'Dev', 'Staging']);
+    const prod = rows.find(r => r.name === 'Production');
+    expect(prod).toMatchObject({ total: 2, healthy: 1, unhealthy: 1, disabled: 0 });
+    expect(prod.targets).toEqual([
+      { name:'web-01', type:'Tentacle', healthKey:'healthy', health:'Healthy', tag:'web', tenant:'No tenants' },
+      { name:'api-01', type:'Kubernetes', healthKey:'unhealthy', health:'Unhealthy', tag:'api', tenant:'No tenants' }
+    ]);
+    const dev = rows.find(r => r.name === 'Dev');
+    expect(dev).toMatchObject({ total: 1, healthy: 0, unhealthy: 0, disabled: 1 });
+    const staging = rows.find(r => r.name === 'Staging');
+    expect(staging).toMatchObject({ total: 0, healthy: 0, unhealthy: 0, disabled: 0, targets: [] });
+  });
+});
+
 describe('typeGroup', () => {
   const d = require('./data');
   test('collapses and cleans communication styles', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -206,15 +206,15 @@ describe('health categorisation', () => {
 
 describe('os + dead-facet suppression', () => {
   const d = require('./data');
-  test('osLabel reads common candidate fields, else —', () => {
+  test('osLabel reads common candidate fields, else blank', () => {
     expect(d.osLabel({ TentacleVersionDetails:{ OperatingSystem:'Windows Server 2022' } })).toBe('Windows Server 2022');
     expect(d.osLabel({}, { OperatingSystem:'Ubuntu 22.04 LTS' })).toBe('Ubuntu 22.04 LTS');
-    expect(d.osLabel({}, {})).toBe('—');
+    expect(d.osLabel({}, {})).toBe('');
   });
-  test('osVersionLabel reads common candidate fields, else —', () => {
+  test('osVersionLabel reads common candidate fields, else blank', () => {
     expect(d.osVersionLabel({ TentacleVersionDetails:{ OperatingSystemVersion:'10.0.20348' } })).toBe('10.0.20348');
     expect(d.osVersionLabel({}, { OperatingSystemVersion:'22.04' })).toBe('22.04');
-    expect(d.osVersionLabel({}, {})).toBe('—');
+    expect(d.osVersionLabel({}, {})).toBe('');
   });
   test('buildFacets omits a facet whose only option is —', () => {
     const targets = [{ type:'Tentacle', healthKey:'healthy', health:'Healthy', env:'P', tag:'a',
@@ -223,6 +223,21 @@ describe('os + dead-facet suppression', () => {
     expect(keys).not.toContain('os');
     expect(keys).not.toContain('osVersion');
     expect(keys).toContain('type'); // real facets still present (Type facet keyed 'type' since A2)
+  });
+});
+
+describe('OS blank behaviour', () => {
+  const d = require('./data');
+  test('osLabel/osVersionLabel return empty string when unknown', () => {
+    expect(d.osLabel({}, {})).toBe('');
+    expect(d.osVersionLabel({}, {})).toBe('');
+  });
+  test('a facet whose only option is empty string is suppressed', () => {
+    const targets = [{ type:'Tentacle', healthKey:'healthy', health:'Healthy', env:'P', tag:'a',
+      tenant:'No tenants', policy:'D', version:'8.3.0', os:'', osVersion:'' }];
+    const keys = d.buildFacets(targets).map(f=>f.key);
+    expect(keys).not.toContain('os');
+    expect(keys).not.toContain('osVersion');
   });
 });
 

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -339,6 +339,49 @@ describe('readConfig robustness', () => {
   });
 });
 
+describe('agentsModel', () => {
+  const d = require('./data');
+  const targets = [
+    { name:'t1', type:'Tentacle', env:'P', version:'8.5.1', policy:'D', healthKey:'healthy' },
+    { name:'t2', type:'Tentacle', env:'P', version:'8.4.0', policy:'D', healthKey:'healthy' }, // same major as latest → NOT behind
+    { name:'t3', type:'Tentacle', env:'S', version:'7.4.3', policy:'D', healthKey:'healthy' }, // one major behind → behind
+    { name:'t4', type:'Tentacle', env:'D', version:'—',     policy:'D', healthKey:'unhealthy' }, // unknown
+    { name:'k1', type:'Kubernetes', env:'P', version:'2.6.0', policy:'D', healthKey:'healthy' }
+  ];
+  test('derives latest; behind = one or more MAJOR versions behind', () => {
+    const m = d.agentsModel(targets);
+    expect(m.tentacle.latest).toBe('8.5.1');
+    expect(m.tentacle.total).toBe(4);
+    expect(m.tentacle.behind).toBe(1);     // only 7.4.3 (major 7 < 8); 8.4.0 is same major, not behind
+    expect(m.tentacle.upToDate).toBe(2);   // 8.5.1 and 8.4.0 (known, same major as latest)
+    expect(m.tentacle.unknown).toBe(1);    // '—'
+    expect(m.tentacle.rows.find(r=>r.name==='t2').behind).toBe(false);
+    expect(m.tentacle.rows.find(r=>r.name==='t3').behind).toBe(true);
+    expect(m.kubernetes.latest).toBe('2.6.0');
+  });
+  test('majorVersion + versionBand', () => {
+    expect(d.majorVersion('8.4.0')).toBe(8);
+    expect(d.majorVersion('—')).toBeNaN();
+    expect(d.versionBand('4.0.0')).toBe('red');
+    expect(d.versionBand('6.3.417')).toBe('yellow');
+    expect(d.versionBand('8.5.1')).toBe('green');
+    expect(d.versionBand('—')).toBe('unknown');
+  });
+});
+describe('overview agents-behind', () => {
+  const d = require('./data');
+  test('overviewModel exposes agents.latest and agents.behind (major-version rule)', () => {
+    const targets = [
+      { name:'a', type:'Tentacle', env:'P', version:'8.5.1', policy:'D', healthKey:'healthy' },
+      { name:'b', type:'Tentacle', env:'P', version:'7.4.0', policy:'D', healthKey:'healthy' }, // major behind
+      { name:'c', type:'Tentacle', env:'P', version:'8.2.0', policy:'D', healthKey:'healthy' }  // same major, not behind
+    ];
+    const ov = d.overviewModel(targets, []);
+    expect(ov.agents.latest).toBe('8.5.1');
+    expect(ov.agents.behind).toBe(1);
+  });
+});
+
 describe('facets drop blank-value options', () => {
   const d = require('./data');
   test('os facet omits the empty-string option on a mixed estate', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -90,3 +90,19 @@ describe('overview + facets + filters', () => {
     expect(d.applyFilters(targets, { env:['Dev'] }, '').map(t=>t.name)).toEqual(['c']);
   });
 });
+
+describe('readConfig robustness', () => {
+  const d = require('./data');
+  afterEach(() => { delete global.dashboardGetConfig; });
+
+  test('resolves (never rejects) when dashboardGetConfig throws — e.g. no chrome.storage on file://', async () => {
+    global.dashboardGetConfig = () => { throw new TypeError("Cannot read properties of undefined (reading 'local')"); };
+    d.setServerUrl(null);
+    await expect(d.readConfig()).resolves.toEqual({ serverUrl: null, context: {} });
+  });
+
+  test('uses lastServerUrl and context from a valid config', async () => {
+    global.dashboardGetConfig = (cb) => cb({ lastServerUrl: 'https://x.octopus.app/', context: { space: 'S' } });
+    await expect(d.readConfig()).resolves.toEqual({ serverUrl: 'https://x.octopus.app/', context: { space: 'S' } });
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -107,6 +107,34 @@ describe('typeGroup', () => {
   });
 });
 
+describe('health categorisation', () => {
+  const d = require('./data');
+  test('healthKey folds unavailable/unknown into unhealthy; disabled wins', () => {
+    expect(d.healthKey('Healthy', false)).toBe('healthy');
+    expect(d.healthKey('HealthyWithWarnings', false)).toBe('healthy');
+    expect(d.healthKey('Unhealthy', false)).toBe('unhealthy');
+    expect(d.healthKey('Unavailable', false)).toBe('unhealthy');
+    expect(d.healthKey(null, false)).toBe('unhealthy');
+    expect(d.healthKey('Unavailable', true)).toBe('disabled');
+  });
+  test('healthKeyLabel is canonical per key', () => {
+    expect(d.healthKeyLabel('healthy')).toBe('Healthy');
+    expect(d.healthKeyLabel('unhealthy')).toBe('Unhealthy');
+    expect(d.healthKeyLabel('disabled')).toBe('Disabled');
+  });
+  test('health facet has clean 3-way options with canonical labels', () => {
+    const targets = [
+      { type:'Tentacle', healthKey:'healthy', health:'Healthy', env:'P', tag:'a', tenant:'No tenants', policy:'D', version:'8.3.0', os:'—', osVersion:'—' },
+      { type:'Tentacle', healthKey:'disabled', health:'Unavailable', env:'P', tag:'a', tenant:'No tenants', policy:'D', version:'8.3.0', os:'—', osVersion:'—' }
+    ];
+    const health = d.buildFacets(targets).find(f => f.key==='health');
+    expect(health.options).toEqual(expect.arrayContaining([
+      { value:'healthy', label:'Healthy', count:1 },
+      { value:'disabled', label:'Disabled', count:1 }
+    ]));
+  });
+});
+
 describe('readConfig robustness', () => {
   const d = require('./data');
   afterEach(() => { delete global.dashboardGetConfig; });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -395,3 +395,14 @@ describe('facets drop blank-value options', () => {
     expect(os.options.some(o => o.value === '')).toBe(false);
   });
 });
+
+describe('OS "Unknown" literal treated as blank', () => {
+  const d = require('./data');
+  test('osLabel/osVersionLabel return blank for a literal Unknown value', () => {
+    expect(d.osLabel({ OperatingSystem: 'Unknown' }, {})).toBe('');
+    expect(d.osLabel({ OperatingSystem: 'unknown' }, {})).toBe('');
+    expect(d.osVersionLabel({ OperatingSystemVersion: 'Unknown' }, {})).toBe('');
+    // a real OS value is still returned
+    expect(d.osLabel({ OperatingSystem: 'Windows Server 2022' }, {})).toBe('Windows Server 2022');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -288,6 +288,20 @@ describe('workersModel + workerFacets + applyWorkerFilters', () => {
   });
 });
 
+describe('buildEstate scoping (space switcher)', () => {
+  const d = require('./data');
+  test('buildEstate scopes to the given perSpace slice', () => {
+    const perSpace = [
+      { sp:{Id:'Spaces-1',Name:'A'}, envs:[], policies:[], tenants:[], workerpools:[], workers:[],
+        machines:[{Id:'m1',Name:'a1',Endpoint:{CommunicationStyle:'TentaclePassive'},EnvironmentIds:[],Roles:[],TenantIds:[]}] },
+      { sp:{Id:'Spaces-2',Name:'B'}, envs:[], policies:[], tenants:[], workerpools:[], workers:[],
+        machines:[{Id:'m2',Name:'b1',Endpoint:{CommunicationStyle:'TentaclePassive'},EnvironmentIds:[],Roles:[],TenantIds:[]}] }
+    ];
+    expect(d.buildEstate(perSpace).targets.map(t=>t.name).sort()).toEqual(['a1','b1']);
+    expect(d.buildEstate(perSpace.filter(s=>s.sp.Id==='Spaces-1')).targets.map(t=>t.name)).toEqual(['a1']);
+  });
+});
+
 describe('readConfig robustness', () => {
   const d = require('./data');
   afterEach(() => { delete global.dashboardGetConfig; });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -338,3 +338,17 @@ describe('readConfig robustness', () => {
     await expect(d.readConfig()).resolves.toEqual({ serverUrl: 'https://x.octopus.app/', context: { space: 'S' } });
   });
 });
+
+describe('facets drop blank-value options', () => {
+  const d = require('./data');
+  test('os facet omits the empty-string option on a mixed estate', () => {
+    const targets = [
+      { type:'Tentacle', healthKey:'healthy', health:'Healthy', env:'P', tag:'a', tenant:'No tenants', policy:'D', version:'8.3.0', os:'Windows Server 2022', osVersion:'10.0' },
+      { type:'Kubernetes', healthKey:'healthy', health:'Healthy', env:'P', tag:'a', tenant:'No tenants', policy:'D', version:'2.6.0', os:'', osVersion:'' }
+    ];
+    const os = d.buildFacets(targets).find(f => f.key === 'os');
+    expect(os).toBeDefined();
+    expect(os.options.map(o => o.value)).toEqual(['Windows Server 2022']);
+    expect(os.options.some(o => o.value === '')).toBe(false);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -119,6 +119,47 @@ describe('environmentsModel', () => {
   });
 });
 
+describe('policiesModel', () => {
+  const d = require('./data');
+  const policies = [
+    { Id:'MachinePolicies-1', Name:'Default Machine Policy', IsDefault:true, Description:'The default policy.',
+      MachineHealthCheckPolicy: { HealthCheckInterval:'00:10:00', HealthCheckType:'RunScript' },
+      MachineUpdatePolicy: { TentacleUpgradePolicy:'Manual', CalamariUpdatePolicy:'Automatic', KubernetesAgentUpgradePolicy:'Automatic' },
+      MachineConnectivityPolicy: { MachineConnectivityBehavior:'ExpectedToBeOnline' },
+      MachineCleanupPolicy: { DeleteMachinesBehavior:'DoNotDelete' } },
+    { Id:'MachinePolicies-2', Name:'Kubernetes agents', IsDefault:false, Description:'' }
+  ];
+  const targets = [
+    { name:'a', policy:'Default Machine Policy' },
+    { name:'b', policy:'Default Machine Policy' },
+    { name:'c', policy:'Kubernetes agents' }
+  ];
+  test('maps name, isDefault, description and counts usage from targets', () => {
+    const rows = d.policiesModel(policies, targets);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ name:'Default Machine Policy', isDefault:true, description:'The default policy.', usage:2 });
+    expect(rows[1]).toMatchObject({ name:'Kubernetes agents', isDefault:false, description:'', usage:1 });
+  });
+  test('falls back to Name-based default detection when IsDefault is absent', () => {
+    const rows = d.policiesModel([{ Name:'Default Machine Policy' }], []);
+    expect(rows[0].isDefault).toBe(true);
+  });
+  test('extracts governance fields from the policy resource', () => {
+    const rows = d.policiesModel(policies, targets);
+    expect(rows[0]).toMatchObject({
+      interval:'00:10:00', healthCheckType:'RunScript',
+      tentacle:'Manual', calamari:'Automatic', k8s:'Automatic',
+      connectivity:'ExpectedToBeOnline', cleanup:'DoNotDelete'
+    });
+  });
+  test('falls back to — for missing/unrecognised governance fields', () => {
+    const rows = d.policiesModel([{ Name:'Empty policy' }], []);
+    expect(rows[0]).toMatchObject({
+      interval:'—', healthCheckType:'—', tentacle:'—', calamari:'—', k8s:'—', connectivity:'—', cleanup:'—'
+    });
+  });
+});
+
 describe('typeGroup', () => {
   const d = require('./data');
   test('collapses and cleans communication styles', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -27,3 +27,66 @@ describe('fetchJson', () => {
     await expect(data.fetchJson('/api/spaces/all')).resolves.toEqual([{ Id: 'Spaces-1' }]);
   });
 });
+
+describe('normalisation', () => {
+  const d = require('./data');
+  test('healthLabel maps API values', () => {
+    expect(d.healthLabel('Healthy')).toBe('Healthy');
+    expect(d.healthLabel('HealthyWithWarnings')).toBe('Healthy with warnings');
+    expect(d.healthLabel('Unhealthy')).toBe('Unhealthy');
+    expect(d.healthLabel(null)).toBe('Unavailable');
+  });
+  test('kindLabel maps communication styles', () => {
+    expect(d.kindLabel('TentaclePassive')).toBe('Tentacle (Listening)');
+    expect(d.kindLabel('TentacleActive')).toBe('Tentacle (Polling)');
+    expect(d.kindLabel('KubernetesTentacle')).toBe('Kubernetes Agent');
+  });
+  test('extractVersion reads TentacleVersionDetails.Version', () => {
+    expect(d.extractVersion({ TentacleVersionDetails: { Version: '8.3.0' } })).toBe('8.3.0');
+    expect(d.extractVersion({})).toBe('—');
+  });
+});
+
+describe('machineToTarget', () => {
+  const d = require('./data');
+  const ctx = { envMap:{'Environments-1':'Production'}, policyMap:{'MachinePolicies-1':{Name:'Default'}},
+    tenantMap:{}, spaceId:'Spaces-1', spaceName:'Default' };
+  const m = { Id:'Machines-1', Name:'web-01', HealthStatus:'Healthy', IsDisabled:false,
+    EnvironmentIds:['Environments-1'], MachinePolicyId:'MachinePolicies-1', Roles:['web'], TenantIds:[],
+    Endpoint:{ CommunicationStyle:'TentaclePassive', TentacleVersionDetails:{ Version:'8.3.0' } } };
+  test('maps a machine to a target view model', () => {
+    const t = d.machineToTarget(m, ctx);
+    expect(t).toMatchObject({ id:'Machines-1', name:'web-01', kind:'Tentacle (Listening)',
+      health:'Healthy', healthKey:'healthy', env:'Production', tag:'web', policy:'Default', version:'8.3.0' });
+  });
+});
+
+describe('overview + facets + filters', () => {
+  const d = require('./data');
+  const targets = [
+    { name:'a', kind:'Tentacle (Listening)', health:'Healthy', healthKey:'healthy', env:'Production',
+      tag:'web', tenant:'No tenants', policy:'Default', version:'8.3.0', os:'Windows', osVersion:'2022' },
+    { name:'b', kind:'Kubernetes Agent', health:'Unhealthy', healthKey:'unhealthy', env:'Production',
+      tag:'api', tenant:'No tenants', policy:'Default', version:'2.6.0', os:'Linux', osVersion:'—' },
+    { name:'c', kind:'Tentacle (Listening)', health:'Disabled', healthKey:'disabled', env:'Dev',
+      tag:'web', tenant:'No tenants', policy:'Default', version:'8.1.0', os:'Windows', osVersion:'2019' }
+  ];
+  test('overviewModel counts health correctly', () => {
+    const ov = d.overviewModel(targets, []);
+    expect(ov).toMatchObject({ total:3, healthy:1, unhealthy:1, disabled:1, healthyPct:33 });
+    expect(ov.byEnv.find(e => e.name==='Production')).toMatchObject({ total:2, healthy:1, unhealthy:1 });
+  });
+  test('buildFacets produces counted options for Health and Environment', () => {
+    const facets = d.buildFacets(targets);
+    const health = facets.find(f => f.key==='health');
+    expect(health.options).toEqual(expect.arrayContaining([
+      { value:'healthy', label:'Healthy', count:1 },
+      { value:'unhealthy', label:'Unhealthy', count:1 }
+    ]));
+  });
+  test('applyFilters filters by facet and search', () => {
+    expect(d.applyFilters(targets, { health:['healthy'] }, '').map(t=>t.name)).toEqual(['a']);
+    expect(d.applyFilters(targets, {}, 'b').map(t=>t.name)).toEqual(['b']);
+    expect(d.applyFilters(targets, { env:['Dev'] }, '').map(t=>t.name)).toEqual(['c']);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -302,6 +302,27 @@ describe('buildEstate scoping (space switcher)', () => {
   });
 });
 
+describe('filterEnvTargets', () => {
+  const v = require('./views');
+  const targets = [
+    { name:'a', type:'Tentacle', healthKey:'healthy', health:'Healthy', tag:'web', tenant:'No tenants' },
+    { name:'b', type:'Kubernetes', healthKey:'unhealthy', health:'Unhealthy', tag:'api', tenant:'No tenants' },
+    { name:'c', type:'Tentacle', healthKey:'disabled', health:'Disabled', tag:'web', tenant:'No tenants' }
+  ];
+  test('key "all" returns every target unchanged', () => {
+    expect(v.filterEnvTargets(targets, 'all')).toEqual(targets);
+  });
+  test('filters targets by healthKey when key is not "all"', () => {
+    expect(v.filterEnvTargets(targets, 'healthy').map(t => t.name)).toEqual(['a']);
+    expect(v.filterEnvTargets(targets, 'unhealthy').map(t => t.name)).toEqual(['b']);
+    expect(v.filterEnvTargets(targets, 'disabled').map(t => t.name)).toEqual(['c']);
+  });
+  test('treats a missing targets array as empty, for any key', () => {
+    expect(v.filterEnvTargets(undefined, 'all')).toEqual([]);
+    expect(v.filterEnvTargets(undefined, 'healthy')).toEqual([]);
+  });
+});
+
 describe('readConfig robustness', () => {
   const d = require('./data');
   afterEach(() => { delete global.dashboardGetConfig; });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1,0 +1,10 @@
+'use strict';
+global.window = { location: { hash: '' } };
+global.document = { getElementById: () => ({ innerHTML: '' }), addEventListener: () => {} };
+
+describe('Infrastructure PreAlpha — data layer', () => {
+  const data = require('./data');
+  test('module loads and exports an object', () => {
+    expect(typeof data).toBe('object');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -685,3 +685,29 @@ describe('designed zero states (Targets / Workers)', () => {
     expect(html).toContain('ip-facets');
   });
 });
+
+describe('filterEnvRows', () => {
+  const d = require('./data');
+  const rows = [
+    { name:'Production',  total:5, healthy:3, unhealthy:2, disabled:0 },
+    { name:'Staging',     total:4, healthy:4, unhealthy:0, disabled:0 },
+    { name:'Development', total:0, healthy:0, unhealthy:0, disabled:0 }
+  ];
+  test('all passes everything through', () => {
+    expect(d.filterEnvRows(rows, '', 'all')).toHaveLength(3);
+  });
+  test('needs attention keeps only environments with something unhealthy', () => {
+    expect(d.filterEnvRows(rows, '', 'attention').map(r => r.name)).toEqual(['Production']);
+  });
+  test('all healthy keeps environments with nothing unhealthy', () => {
+    expect(d.filterEnvRows(rows, '', 'healthy').map(r => r.name)).toEqual(['Staging','Development']);
+  });
+  test('search is case-insensitive and combines with the mode', () => {
+    expect(d.filterEnvRows(rows, 'prod', 'all').map(r => r.name)).toEqual(['Production']);
+    expect(d.filterEnvRows(rows, 'prod', 'healthy')).toEqual([]);
+  });
+  test('missing arguments degrade to everything', () => {
+    expect(d.filterEnvRows(rows)).toHaveLength(3);
+    expect(d.filterEnvRows(null, '', 'all')).toEqual([]);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -489,3 +489,125 @@ describe('renderAddTarget', () => {
     expect(html).not.toContain('<script>');
   });
 });
+
+describe('machine activity (per-target tasks)', () => {
+  const d = require('./data');
+  // Shapes taken from a live probe of /api/{space}/machines/{id}/tasks.
+  const tasks = [
+    { Id:'ServerTasks-1', Name:'Deploy', Description:'Deploy TelemetryProxy release 0.0.998 to Production',
+      State:'Success', FinishedSuccessfully:true, CompletedTime:'2025-04-30T03:51:24.000+00:00',
+      ProjectId:'Projects-3225', Arguments:{ DeploymentId:'Deployments-1526356' } },
+    { Id:'ServerTasks-2', Name:'Deploy', Description:'Deploy TelemetryProxy release 0.0.997 to Production',
+      State:'Failed', FinishedSuccessfully:false, CompletedTime:'2025-04-29T01:00:00.000+00:00',
+      ProjectId:'Projects-3225', Arguments:{ DeploymentId:'Deployments-1526000' } },
+    { Id:'ServerTasks-3', Name:'Health', Description:'Check target health',
+      State:'Success', FinishedSuccessfully:true, CompletedTime:'2026-07-27T01:00:00.000+00:00', Arguments:{} }
+  ];
+
+  test('taskKind maps the task names the API actually returns', () => {
+    expect(d.taskKind('Deploy')).toBe('deploy');
+    expect(d.taskKind('Health')).toBe('health');
+    expect(d.taskKind('Upgrade')).toBe('upgrade');
+    expect(d.taskKind('SomethingElse')).toBe('other');
+    expect(d.taskKind(undefined)).toBe('other');
+  });
+
+  test('splits deployments from health checks and keeps newest first', () => {
+    const m = d.machineActivityModel(tasks);
+    expect(m.deployments.map(r => r.id)).toEqual(['ServerTasks-1','ServerTasks-2']);
+    expect(m.health).toHaveLength(1);
+    expect(m.deployments[0].description).toContain('0.0.998');
+    expect(m.deployments[1].success).toBe(false);
+  });
+
+  test('lastSuccessfulDeploy is the newest deploy that actually succeeded', () => {
+    const m = d.machineActivityModel(tasks);
+    expect(m.lastSuccessfulDeploy.id).toBe('ServerTasks-1');
+    // a target whose only deploy failed has no last successful release to show
+    const failedOnly = d.machineActivityModel([tasks[1]]);
+    expect(failedOnly.lastSuccessfulDeploy).toBe(null);
+  });
+
+  test('empty or missing task list yields empty groups, not a crash', () => {
+    const m = d.machineActivityModel(null);
+    expect(m.deployments).toEqual([]);
+    expect(m.lastSuccessfulDeploy).toBe(null);
+  });
+});
+
+describe('fetchMachineDetail', () => {
+  const d = require('./data');
+  beforeEach(() => d.setServerUrl('https://x.octopus.app/'));
+
+  test('returns tasks and connection when both succeed', async () => {
+    global.fetch = async (url) => ({
+      status: 200, ok: true, statusText: 'OK',
+      json: async () => String(url).includes('/tasks')
+        ? { Items: [{ Id:'ServerTasks-1', Name:'Deploy' }] }
+        : { Status: 'Online', CurrentTentacleVersion: '8.5.1' }
+    });
+    const r = await d.fetchMachineDetail('Spaces-1', 'Machines-1');
+    expect(r.tasks).toHaveLength(1);
+    expect(r.connection.CurrentTentacleVersion).toBe('8.5.1');
+  });
+
+  test('a failed half comes back null, not an empty list — "unknown" must not read as "none"', async () => {
+    global.fetch = async (url) => String(url).includes('/tasks')
+      ? { status: 500, ok: false, statusText: 'Server Error' }
+      : { status: 200, ok: true, json: async () => ({ Status: 'Online' }) };
+    const r = await d.fetchMachineDetail('Spaces-1', 'Machines-1');
+    expect(r.tasks).toBe(null);
+    expect(r.connection.Status).toBe('Online');
+  });
+
+  test('no tasks for a target is an empty list, which is a real answer', async () => {
+    global.fetch = async () => ({ status: 200, ok: true, json: async () => ({ Items: [] }) });
+    const r = await d.fetchMachineDetail('Spaces-1', 'Machines-1');
+    expect(r.tasks).toEqual([]);
+  });
+});
+
+describe('target detail cards (async-filled)', () => {
+  const Views = require('./views');
+  const d = require('./data');
+  const t = { id:'Machines-1', spaceId:'Spaces-1', comm:'Polling Tentacle', health:'Healthy', version:'8.5.1' };
+  const tasks = [
+    { Id:'ServerTasks-1', Name:'Deploy', Description:'Deploy Web release 1.2.3 to Production',
+      State:'Success', FinishedSuccessfully:true, CompletedTime:'2026-04-30T03:51:24.000+00:00' }
+  ];
+
+  test('a failed load says so; it does not claim the target has no deployments', () => {
+    const html = Views.deploymentsCardHtml(t, d.machineActivityModel(null), null, 'https://x.octopus.app/');
+    expect(html).toMatch(/couldn.t load/i);
+    expect(html).not.toMatch(/no deployments/i);
+  });
+
+  test('an empty-but-successful load says there are none', () => {
+    const html = Views.deploymentsCardHtml(t, d.machineActivityModel([]), [], 'https://x.octopus.app/');
+    expect(html).toMatch(/no deployments/i);
+  });
+
+  test('renders real rows and names the last successful release', () => {
+    const html = Views.deploymentsCardHtml(t, d.machineActivityModel(tasks), tasks, 'https://x.octopus.app/');
+    expect(html).toContain('Deploy Web release 1.2.3 to Production');
+    expect(html).toContain('Spaces-1/tasks/ServerTasks-1');   // links out to the task
+    expect(html).toMatch(/last successful/i);
+  });
+
+  test('connectivity uses live connection data when present, target fields otherwise', () => {
+    const withConn = Views.connectivityCardHtml(t, { Status:'Online', CurrentTentacleVersion:'8.5.1',
+      LastChecked:'2026-07-27T01:00:00.000+00:00' });
+    expect(withConn).toContain('Online');
+    const without = Views.connectivityCardHtml(t, null);
+    expect(without).toContain('Polling Tentacle');
+    expect(without).not.toContain('Online');
+  });
+
+  test('escapes hostile task descriptions', () => {
+    const nasty = [{ Id:'ServerTasks-2', Name:'Deploy', Description:'<img src=x onerror=alert(1)>',
+      State:'Success', FinishedSuccessfully:true, CompletedTime:'2026-01-01T00:00:00.000+00:00' }];
+    const html = Views.deploymentsCardHtml(t, d.machineActivityModel(nasty), nasty, 'https://x.octopus.app/');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -416,3 +416,27 @@ describe('OS "Unknown" literal treated as blank', () => {
     expect(d.osLabel({ OperatingSystem: 'Windows Server 2022' }, {})).toBe('Windows Server 2022');
   });
 });
+
+describe('escHtml escapes the single quote', () => {
+  const Views = require('./views');
+  test('single quote becomes &#39; (attribute-safe) and other entities still escape', () => {
+    expect(Views.escHtml("O'Brien")).toBe('O&#39;Brien');
+    expect(Views.escHtml(`<a href='x' title="y">&`)).toBe('&lt;a href=&#39;x&#39; title=&quot;y&quot;&gt;&amp;');
+  });
+});
+
+describe('_mapLimit', () => {
+  const d = require('./data');
+  test('preserves input order and caps concurrency', async () => {
+    let inFlight = 0, maxInFlight = 0;
+    const items = [1,2,3,4,5,6,7,8];
+    const out = await d._mapLimit(items, 3, async (n) => {
+      inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise(r => setTimeout(r, 5));
+      inFlight--;
+      return n * 10;
+    });
+    expect(out).toEqual([10,20,30,40,50,60,70,80]); // order preserved
+    expect(maxInFlight).toBeLessThanOrEqual(3);      // concurrency capped
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -817,3 +817,56 @@ describe('environment heat cells are operable by keyboard (Copilot review)', () 
     expect(html).toMatch(/aria-label="[^"]+"/);
   });
 });
+
+describe('per-target events', () => {
+  const d = require('./data');
+  // Shape from a live probe of /api/{space}/events?regarding={machineId}
+  const raw = [
+    { Id:'Events-1', Category:'MachineHealthy', Username:'system', IsService:false,
+      Occurred:'2026-07-27T03:49:42.220+00:00', Message:'Machine web-01 is now healthy',
+      MessageHtml:'<a href="#">Machine</a> web-01 is now healthy' },
+    { Id:'Events-2', Category:'Modified', Username:'lucy.spence',
+      Occurred:'2026-07-26T01:00:00.000+00:00', Message:'Machine web-01 was modified' }
+  ];
+  test('normalises to id, category, who, when and plain message', () => {
+    const rows = d.eventsModel(raw);
+    expect(rows[0]).toMatchObject({ id:'Events-1', category:'MachineHealthy',
+      who:'system', message:'Machine web-01 is now healthy' });
+    expect(rows[0].occurred).toBe('2026-07-27T03:49:42.220+00:00');
+  });
+  test('takes the plain Message, never MessageHtml', () => {
+    const rows = d.eventsModel(raw);
+    expect(rows[0].message).not.toContain('<a');
+  });
+  test('newest first', () => {
+    expect(d.eventsModel(raw).map(r => r.id)).toEqual(['Events-1','Events-2']);
+  });
+  test('null and empty degrade without throwing', () => {
+    expect(d.eventsModel(null)).toEqual([]);
+    expect(d.eventsModel([])).toEqual([]);
+  });
+});
+
+describe('events card rendering', () => {
+  const Views = require('./views');
+  const d = require('./data');
+  const t = { id:'Machines-1', spaceId:'Spaces-1' };
+  test('a failed events fetch is not reported as no events', () => {
+    const html = Views.eventsCardHtml(t, d.eventsModel(null), null, 'https://x.octopus.app/');
+    expect(html).toMatch(/couldn.t load/i);
+    expect(html).not.toMatch(/no events/i);
+  });
+  test('an empty result says none are retained, and says why that can happen', () => {
+    const html = Views.eventsCardHtml(t, d.eventsModel([]), [], 'https://x.octopus.app/');
+    expect(html).toMatch(/no events/i);
+    // must explain why an empty result is possible, not just assert emptiness
+    expect(html).toMatch(/prune|retention|retained/i);
+  });
+  test('renders rows and escapes the message', () => {
+    const nasty = [{ Id:'Events-9', Category:'Modified', Username:'x',
+      Occurred:'2026-01-01T00:00:00.000+00:00', Message:'<img src=x onerror=alert(1)>' }];
+    const html = Views.eventsCardHtml(t, d.eventsModel(nasty), nasty, 'https://x.octopus.app/');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -425,21 +425,7 @@ describe('escHtml escapes the single quote', () => {
   });
 });
 
-describe('_mapLimit', () => {
-  const d = require('./data');
-  test('preserves input order and caps concurrency', async () => {
-    let inFlight = 0, maxInFlight = 0;
-    const items = [1,2,3,4,5,6,7,8];
-    const out = await d._mapLimit(items, 3, async (n) => {
-      inFlight++; maxInFlight = Math.max(maxInFlight, inFlight);
-      await new Promise(r => setTimeout(r, 5));
-      inFlight--;
-      return n * 10;
-    });
-    expect(out).toEqual([10,20,30,40,50,60,70,80]); // order preserved
-    expect(maxInFlight).toBeLessThanOrEqual(3);      // concurrency capped
-  });
-});
+
 
 describe('emptyKind', () => {
   const d = require('./data');

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -711,3 +711,109 @@ describe('filterEnvRows', () => {
     expect(d.filterEnvRows(null, '', 'all')).toEqual([]);
   });
 });
+
+describe('overviewModel byType — disabled targets (Copilot review)', () => {
+  const d = require('./data');
+  const targets = [
+    { type:'Tentacle', healthKey:'healthy' },
+    { type:'Tentacle', healthKey:'unhealthy' },
+    { type:'Tentacle', healthKey:'disabled' },
+    { type:'Kubernetes', healthKey:'disabled' }
+  ];
+  test('a disabled target is counted in its type row, not dropped', () => {
+    const ov = d.overviewModel(targets, []);
+    const tent = ov.byType.find(r => r.name === 'Tentacle');
+    expect(tent).toMatchObject({ healthy:1, unhealthy:1, disabled:1, total:3 });
+  });
+  test('a type whose targets are all disabled still appears with a real count', () => {
+    const ov = d.overviewModel(targets, []);
+    const k8s = ov.byType.find(r => r.name === 'Kubernetes');
+    expect(k8s).toMatchObject({ healthy:0, unhealthy:0, disabled:1, total:1 });
+  });
+  test('per-type totals reconcile with the estate totals', () => {
+    const ov = d.overviewModel(targets, []);
+    const sum = k => ov.byType.reduce((n, r) => n + r[k], 0);
+    expect(sum('healthy')).toBe(ov.healthy);
+    expect(sum('unhealthy')).toBe(ov.unhealthy);
+    expect(sum('disabled')).toBe(ov.disabled);
+    expect(sum('total')).toBe(ov.total);
+  });
+});
+
+describe('loadEstate partial failures (Copilot review)', () => {
+  const d = require('./data');
+  const page = items => ({ status:200, ok:true, json: async () => items });
+
+  test('a resource that fails to load is recorded, not silently emptied', async () => {
+    global.fetch = async (url) => {
+      const u = String(url);
+      if (u.includes('/spaces/all')) return page([{ Id:'Spaces-1', Name:'Default' }]);
+      if (u.includes('/environments/all')) return { status:403, ok:false, statusText:'Forbidden' };
+      if (u.includes('/machines/all')) return page([]);
+      return page([]);
+    };
+    const res = await d.loadEstate('https://x.octopus.app/');
+    expect(res.perSpace[0].failed).toContain('environments');
+    // and the estate carries it through, so a view can say "couldn't load" not "there are none"
+    const estate = d.buildEstate(res.perSpace);
+    expect(estate.failed.environments).toBe(true);
+    expect(estate.failed.policies).toBe(false);
+  });
+
+  test('everything loading cleanly leaves no failure flags', async () => {
+    global.fetch = async (url) => String(url).includes('/spaces/all')
+      ? page([{ Id:'Spaces-1', Name:'Default' }]) : page([]);
+    const res = await d.loadEstate('https://x.octopus.app/');
+    expect(res.perSpace[0].failed).toEqual([]);
+    expect(d.buildEstate(res.perSpace).failed.environments).toBe(false);
+  });
+});
+
+describe('unreadable resources are not reported as empty (Copilot review)', () => {
+  const Views = require('./views');
+  global.Data = require('./data');
+  const base = { serverUrl:'https://x.octopus.app/', envQuery:'', envMode:'all',
+    wFilters:{}, wSearch:'', wPage:1, filters:{}, search:'', page:1 };
+  const estate = (failed) => ({ targets:[], workers:[], environments:[], policies:[],
+    failed: Object.assign({ environments:false, policies:false, tenants:false,
+      workerpools:false, workers:false }, failed) });
+
+  test('environments that failed to load say so, and do not offer to add one', () => {
+    const html = Views.renderEnvironments({ ...base, estate: estate({ environments:true }) });
+    expect(html).toMatch(/couldn.t load/i);
+    expect(html).not.toMatch(/No environments in this space/);
+  });
+
+  test('environments that genuinely are empty still say so', () => {
+    const html = Views.renderEnvironments({ ...base, estate: estate() });
+    expect(html).toMatch(/No environments in this space/);
+    expect(html).not.toMatch(/couldn.t load/i);
+  });
+
+  test('workers that failed to load do not render the add-your-first zero state', () => {
+    const html = Views.renderWorkers({ ...base, estate: estate({ workers:true }) });
+    expect(html).toMatch(/couldn.t load/i);
+    expect(html).not.toContain('Add your first worker');
+  });
+
+  test('workers that genuinely are empty get the designed zero state', () => {
+    const html = Views.renderWorkers({ ...base, estate: estate() });
+    expect(html).toContain('Add your first worker');
+  });
+});
+
+describe('environment heat cells are operable by keyboard (Copilot review)', () => {
+  const Views = require('./views');
+  global.Data = require('./data');
+  const IP = { serverUrl:'https://x.octopus.app/', envQuery:'', envMode:'all', envExpanded:{},
+    estate:{ failed:{}, environments:[{ id:'e1', name:'Production', spaceId:'s1' }],
+      targets:[{ name:'a', type:'Tentacle', healthKey:'healthy', health:'Healthy',
+                 env:'Production', tag:'web', tenant:'No tenants' }] } };
+
+  test('clickable cells expose a role, are focusable, and are labelled', () => {
+    const html = Views.renderEnvironments(IP);
+    expect(html).toContain('role="button"');
+    expect(html).toContain('tabindex="0"');
+    expect(html).toMatch(/aria-label="[^"]+"/);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -740,34 +740,31 @@ describe('overviewModel byType — disabled targets (Copilot review)', () => {
   });
 });
 
-describe('loadEstate partial failures (Copilot review)', () => {
+describe('per-space partial failures (Copilot review)', () => {
   const d = require('./data');
   const page = items => ({ status:200, ok:true, json: async () => items });
 
   test('a resource that fails to load is recorded, not silently emptied', async () => {
-    global.fetch = async (url) => {
-      const u = String(url);
-      if (u.includes('/spaces/all')) return page([{ Id:'Spaces-1', Name:'Default' }]);
-      if (u.includes('/environments/all')) return { status:403, ok:false, statusText:'Forbidden' };
-      if (u.includes('/machines/all')) return page([]);
-      return page([]);
-    };
-    const res = await d.loadEstate('https://x.octopus.app/');
-    expect(res.perSpace[0].failed).toContain('environments');
+    global.fetch = async (url) => String(url).includes('/environments/all')
+      ? { status:403, ok:false, statusText:'Forbidden' } : page([]);
+    d.setServerUrl('https://x.octopus.app/');
+    const hydrated = await d.hydrateSpace({ Id:'Spaces-1', Name:'Default' });
+    expect(hydrated.failed).toContain('environments');
     // and the estate carries it through, so a view can say "couldn't load" not "there are none"
-    const estate = d.buildEstate(res.perSpace);
+    const estate = d.buildEstate([hydrated]);
     expect(estate.failed.environments).toBe(true);
     expect(estate.failed.policies).toBe(false);
   });
 
   test('everything loading cleanly leaves no failure flags', async () => {
-    global.fetch = async (url) => String(url).includes('/spaces/all')
-      ? page([{ Id:'Spaces-1', Name:'Default' }]) : page([]);
-    const res = await d.loadEstate('https://x.octopus.app/');
-    expect(res.perSpace[0].failed).toEqual([]);
-    expect(d.buildEstate(res.perSpace).failed.environments).toBe(false);
+    global.fetch = async () => page([]);
+    d.setServerUrl('https://x.octopus.app/');
+    const hydrated = await d.hydrateSpace({ Id:'Spaces-1', Name:'Default' });
+    expect(hydrated.failed).toEqual([]);
+    expect(d.buildEstate([hydrated]).failed.environments).toBe(false);
   });
 });
+
 
 describe('unreadable resources are not reported as empty (Copilot review)', () => {
   const Views = require('./views');
@@ -869,4 +866,46 @@ describe('events card rendering', () => {
     expect(html).not.toContain('<img');
     expect(html).toContain('&lt;img');
   });
+});
+
+describe('lazy space hydration', () => {
+  const d = require('./data');
+  const page = items => ({ status:200, ok:true, json: async () => items });
+  const spaces = [{ Id:'Spaces-1', Name:'One' }, { Id:'Spaces-2', Name:'Two' }];
+  let calls;
+  const mock = () => { calls = []; global.fetch = async (url) => {
+    calls.push(String(url));
+    if (String(url).includes('/spaces/all')) return page(spaces);
+    return page([]);
+  }; };
+  beforeEach(() => { mock(); d.setServerUrl('https://x.octopus.app/'); });
+
+  test('loadSpaces lists spaces without hydrating any of them', async () => {
+    const res = await d.loadSpaces('https://x.octopus.app/');
+    expect(res.spaces).toHaveLength(2);
+    expect(calls).toHaveLength(1);                       // one request, not 1 + 2*6
+    expect(calls[0]).toContain('/spaces/all');
+  });
+
+  test('hydrateSpace loads exactly one space and records its failures', async () => {
+    global.fetch = async (url) => String(url).includes('/environments/all')
+      ? { status:403, ok:false, statusText:'Forbidden' } : page([]);
+    const s = await d.hydrateSpace({ Id:'Spaces-1', Name:'One' });
+    expect(s.sp.Id).toBe('Spaces-1');
+    expect(s.failed).toContain('environments');
+  });
+
+  test('a space whose machines cannot be read yields null, not a half-empty space', async () => {
+    global.fetch = async (url) => String(url).includes('/machines/all')
+      ? { status:500, ok:false, statusText:'Server Error' } : page([]);
+    expect(await d.hydrateSpace({ Id:'Spaces-1', Name:'One' })).toBe(null);
+  });
+
+  test('auth failure on the space list is still distinguishable from an empty instance', async () => {
+    global.fetch = async () => ({ status:401, ok:false, statusText:'Unauthorized' });
+    expect((await d.loadSpaces('https://x.octopus.app/')).status).toBe('auth');
+    global.fetch = async () => page([]);
+    expect((await d.loadSpaces('https://x.octopus.app/')).status).toBe('empty');
+  });
+
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -611,3 +611,32 @@ describe('target detail cards (async-filled)', () => {
     expect(html).toContain('&lt;img');
   });
 });
+
+describe('coldStartApplies — which views hide behind first-run', () => {
+  const d = require('./data');
+  const bare    = { targets:[], workers:[], environments:[],       policies:[] };
+  const noInfra = { targets:[], workers:[], environments:[{id:'e'}], policies:[{Id:'p'}] };
+  const full    = { targets:[{id:'t'}], workers:[], environments:[], policies:[] };
+
+  test('a wholly bare space shows cold-start everywhere', () => {
+    ['overview','targets','workers','agents','environments','machinepolicies']
+      .forEach(v => expect(d.coldStartApplies(v, bare)).toBe(true));
+  });
+
+  test('no targets but real environments/policies: only the target-centric views hide', () => {
+    expect(d.coldStartApplies('overview', noInfra)).toBe(true);
+    expect(d.coldStartApplies('targets', noInfra)).toBe(true);
+    expect(d.coldStartApplies('workers', noInfra)).toBe(true);
+    // these have data of their own — hiding them asserts "nothing here" while holding 9 environments
+    expect(d.coldStartApplies('environments', noInfra)).toBe(false);
+    expect(d.coldStartApplies('machinepolicies', noInfra)).toBe(false);
+  });
+
+  test('the add-target walkthrough is never gated', () => {
+    expect(d.coldStartApplies('targets/new', bare)).toBe(false);
+  });
+
+  test('a populated estate never shows cold-start', () => {
+    ['overview','targets','environments'].forEach(v => expect(d.coldStartApplies(v, full)).toBe(false));
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -640,3 +640,48 @@ describe('coldStartApplies — cold-start is a landing screen, not a wall', () =
     ['overview','targets','environments'].forEach(v => expect(d.coldStartApplies(v, full)).toBe(false));
   });
 });
+
+describe('designed zero states (Targets / Workers)', () => {
+  const Views = require('./views');
+  // views.js reaches for `Data` as a browser global; the populated path needs it here.
+  global.Data = require('./data');
+  const IP = { serverUrl:'https://x.octopus.app/', estate:{ targets:[], workers:[], environments:[], policies:[] },
+               filters:{}, search:'', page:1, wFilters:{}, wSearch:'', wPage:1 };
+
+  test('targets zero state matches the design: heading, add action, learn link, no filter panel', () => {
+    const html = Views.renderTargets(IP);
+    expect(html).toContain('Add your first deployment target');
+    expect(html).toContain('#targets/new');
+    expect(html).toMatch(/Learn about deployment targets/);
+    expect(html).not.toContain('ip-facets');           // filters are hidden when there is nothing to filter
+    expect(html).not.toMatch(/clearing your search/i); // and never the wrong-filter advice
+  });
+
+  test('targets zero state carries a labelled preview, not data pretending to be real', () => {
+    const html = Views.renderTargets(IP);
+    expect(html).toMatch(/Preview/i);
+    expect(html).toContain('Once added, your targets appear here');
+    expect(html).toContain('web-prod-public-api-01');
+    expect(html).toContain('ip-preview');              // the dimmed wrapper carries the visual signal
+  });
+
+  test('workers zero state matches the design, previewing pools', () => {
+    const html = Views.renderWorkers(IP);
+    expect(html).toContain('Add your first worker');
+    expect(html).toMatch(/Learn about workers/);
+    expect(html).toContain('Once added, workers are grouped into pools');
+    expect(html).toContain('Default Pool');
+    expect(html).not.toContain('ip-facets');
+  });
+
+  test('a populated estate still renders the real list, not the preview', () => {
+    const live = { ...IP, estate: { ...IP.estate, targets: [
+      { id:'t1', name:'real-target', type:'Tentacle', kind:'Tentacle (Polling)', os:'', osVersion:'',
+        health:'Healthy', healthKey:'healthy', env:'Production', envCat:'production', tag:'web',
+        moreTags:0, tenant:'No tenants', policy:'Default', version:'8.5.1' } ] } };
+    const html = Views.renderTargets(live);
+    expect(html).toContain('real-target');
+    expect(html).not.toContain('web-prod-public-api-01');
+    expect(html).toContain('ip-facets');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -440,3 +440,21 @@ describe('_mapLimit', () => {
     expect(maxInFlight).toBeLessThanOrEqual(3);      // concurrency capped
   });
 });
+
+describe('emptyKind', () => {
+  const d = require('./data');
+  test('rows when anything is shown', () => {
+    expect(d.emptyKind(10, 3)).toBe('rows');
+    expect(d.emptyKind(1, 1)).toBe('rows');
+  });
+  test('none when the collection itself is empty', () => {
+    expect(d.emptyKind(0, 0)).toBe('none');
+  });
+  test('nomatch when items exist but filters hide them all', () => {
+    expect(d.emptyKind(10, 0)).toBe('nomatch');
+  });
+  test('tolerates missing/garbage counts as empty', () => {
+    expect(d.emptyKind(undefined, undefined)).toBe('none');
+    expect(d.emptyKind(null, 0)).toBe('none');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -612,24 +612,24 @@ describe('target detail cards (async-filled)', () => {
   });
 });
 
-describe('coldStartApplies — which views hide behind first-run', () => {
+describe('coldStartApplies — cold-start is a landing screen, not a wall', () => {
   const d = require('./data');
-  const bare    = { targets:[], workers:[], environments:[],       policies:[] };
+  const bare    = { targets:[], workers:[], environments:[],        policies:[] };
   const noInfra = { targets:[], workers:[], environments:[{id:'e'}], policies:[{Id:'p'}] };
   const full    = { targets:[{id:'t'}], workers:[], environments:[], policies:[] };
 
-  test('a wholly bare space shows cold-start everywhere', () => {
-    ['overview','targets','workers','agents','environments','machinepolicies']
-      .forEach(v => expect(d.coldStartApplies(v, bare)).toBe(true));
+  test('overview is the welcome moment when there is no infrastructure', () => {
+    expect(d.coldStartApplies('overview', bare)).toBe(true);
+    expect(d.coldStartApplies('overview', noInfra)).toBe(true);
   });
 
-  test('no targets but real environments/policies: only the target-centric views hide', () => {
-    expect(d.coldStartApplies('overview', noInfra)).toBe(true);
-    expect(d.coldStartApplies('targets', noInfra)).toBe(true);
-    expect(d.coldStartApplies('workers', noInfra)).toBe(true);
-    // these have data of their own — hiding them asserts "nothing here" while holding 9 environments
-    expect(d.coldStartApplies('environments', noInfra)).toBe(false);
-    expect(d.coldStartApplies('machinepolicies', noInfra)).toBe(false);
+  test('an explicit nav click always reaches its own view, empty or not', () => {
+    // clicking a nav item and getting the screen you were already on is a dead end
+    ['targets','workers','agents','environments','machinepolicies','argocd']
+      .forEach(v => {
+        expect(d.coldStartApplies(v, bare)).toBe(false);
+        expect(d.coldStartApplies(v, noInfra)).toBe(false);
+      });
   });
 
   test('the add-target walkthrough is never gated', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -458,3 +458,34 @@ describe('emptyKind', () => {
     expect(d.emptyKind(null, 0)).toBe('none');
   });
 });
+
+describe('renderAddTarget', () => {
+  const Views = require('./views');
+  const IP = { serverUrl: 'https://x.octopus.app/' };
+
+  test('step 1 lists every target type and creates nothing', () => {
+    const html = Views.renderAddTarget(IP);
+    expect(html).toContain('Step 1 of 2');
+    ['Listening Tentacle','Polling Tentacle','Kubernetes agent','SSH connection'].forEach(n =>
+      expect(html).toContain(n));
+    expect(html).not.toMatch(/<form|method="post"/i); // read-only walkthrough
+  });
+
+  test('step 2 shows the chosen type, what it needs, and a link-out', () => {
+    const html = Views.renderAddTarget({ ...IP, addTargetType: 'polling' });
+    expect(html).toContain('Step 2 of 2');
+    expect(html).toContain('Polling Tentacle');
+    expect(html).toContain('10943');
+    expect(html).toContain('rel="noopener"');
+    expect(html).toContain('#targets/new');   // back to the chooser
+  });
+
+  test('an unknown type falls back to the chooser rather than a blank page', () => {
+    expect(Views.renderAddTarget({ ...IP, addTargetType: 'nonsense' })).toContain('Step 1 of 2');
+  });
+
+  test('escapes the server url into hrefs', () => {
+    const html = Views.renderAddTarget({ serverUrl: 'https://x.octopus.app/"><script>', addTargetType: 'ssh' });
+    expect(html).not.toContain('<script>');
+  });
+});

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -84,6 +84,21 @@ function kindLabel(style) {
   if (style === 'None') return 'SSH / Cloud';
   return style || 'Unknown';
 }
+function typeGroup(style) {
+  switch (style) {
+    case 'TentacleActive':
+    case 'TentaclePassive': return 'Tentacle';
+    case 'Ssh': return 'SSH';
+    case 'Kubernetes':
+    case 'KubernetesTentacle': return 'Kubernetes';
+    case 'AzureWebApp': return 'Azure Web App';
+    case 'AzureCloudService':
+    case 'AzureServiceFabricCluster': return 'Cloud Region';
+    case 'OfflineDrop': return 'Offline Drop';
+    case 'None': return 'Cloud Region';
+    default: return style || 'Unknown';
+  }
+}
 function envCat(name) {
   const n = (name || '').toLowerCase();
   if (/prod/.test(n)) return 'production';
@@ -115,6 +130,7 @@ function machineToTarget(m, ctx) {
   return {
     id: m.Id, name: m.Name || m.Id, spaceId: ctx.spaceId,
     kind: kindLabel(ep.CommunicationStyle),
+    type: typeGroup(ep.CommunicationStyle),
     comm: commLabel(ep.CommunicationStyle),
     os: osLabel(ep), osVersion: '—',
     health: healthLabel(m.HealthStatus), healthKey: healthKey(m.HealthStatus, m.IsDisabled),
@@ -207,10 +223,10 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget }; }
+  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget, typeGroup }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-    healthLabel, healthKey, commLabel, kindLabel, envCat, extractVersion, osLabel,
+    healthLabel, healthKey, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel,
     machineToTarget, buildEstate, overviewModel, buildFacets, applyFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -199,6 +199,9 @@ function applyFilters(targets, filters, search) {
   });
 }
 
+if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
+  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget }; }
+
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, commLabel, kindLabel, envCat, extractVersion, osLabel,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -122,23 +122,25 @@ function extractVersion(ep) {
 }
 function osLabel(ep, m) {
   // FLAG: exact Octopus OS field is unconfirmed; verify on a live instance.
-  // Defensive candidate scan across likely locations, falling back to '—'.
+  // Defensive candidate scan across likely locations, falling back to '' (blank cell —
+  // not '—', to avoid "unknown, unknown, unknown" repetition across the Targets table).
   ep = ep || {}; m = m || {};
   const cands = [
     ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystem,
     m.OperatingSystem, ep.OperatingSystem,
     m.HealthStatus && m.OperatingSystem
   ].filter(s => typeof s === 'string' && s.trim());
-  return cands[0] || '—';
+  return cands[0] || '';
 }
 function osVersionLabel(ep, m) {
   // FLAG: exact Octopus OS version field is unconfirmed; verify on a live instance.
+  // Falls back to '' (blank cell), not '—' — see osLabel.
   ep = ep || {}; m = m || {};
   const cands = [
     ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystemVersion,
     m.OperatingSystemVersion, ep.OperatingSystemVersion
   ].filter(s => typeof s === 'string' && s.trim());
-  return cands[0] || '—';
+  return cands[0] || '';
 }
 function machineToTarget(m, ctx) {
   const ep = m.Endpoint || {};
@@ -262,7 +264,7 @@ function _facet(key, label, values) {
     .sort((a,b)=>b.count-a.count);
   return { key, label, options };
 }
-function _isDeadFacet(f) { return f.options.length <= 1 && (!f.options[0] || f.options[0].value === '—'); }
+function _isDeadFacet(f) { return f.options.length <= 1 && (!f.options[0] || f.options[0].value === '—' || f.options[0].value === ''); }
 function buildFacets(targets) {
   return [
     _facet('type','Type', targets.map(t=>({value:t.type,label:t.type}))),

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -120,9 +120,25 @@ function extractVersion(ep) {
   for (const k in ep) { if (/version/i.test(k) && looksLikeVersion(ep[k])) return ep[k]; }
   return '—';
 }
-function osLabel(ep) {
-  // FLAG: verify OS fields on a live instance; fall back to '—'.
-  return (ep && (ep.OperatingSystem || (ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystem))) || '—';
+function osLabel(ep, m) {
+  // FLAG: exact Octopus OS field is unconfirmed; verify on a live instance.
+  // Defensive candidate scan across likely locations, falling back to '—'.
+  ep = ep || {}; m = m || {};
+  const cands = [
+    ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystem,
+    m.OperatingSystem, ep.OperatingSystem,
+    m.HealthStatus && m.OperatingSystem
+  ].filter(s => typeof s === 'string' && s.trim());
+  return cands[0] || '—';
+}
+function osVersionLabel(ep, m) {
+  // FLAG: exact Octopus OS version field is unconfirmed; verify on a live instance.
+  ep = ep || {}; m = m || {};
+  const cands = [
+    ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystemVersion,
+    m.OperatingSystemVersion, ep.OperatingSystemVersion
+  ].filter(s => typeof s === 'string' && s.trim());
+  return cands[0] || '—';
 }
 function machineToTarget(m, ctx) {
   const ep = m.Endpoint || {};
@@ -136,7 +152,7 @@ function machineToTarget(m, ctx) {
     kind: kindLabel(ep.CommunicationStyle),
     type: typeGroup(ep.CommunicationStyle),
     comm: commLabel(ep.CommunicationStyle),
-    os: osLabel(ep), osVersion: '—',
+    os: osLabel(ep, m), osVersion: osVersionLabel(ep, m),
     health: healthLabel(m.HealthStatus), healthKey: healthKey(m.HealthStatus, m.IsDisabled),
     env, envCat: envCat(env),
     tag: roles[0] || '—', moreTags: Math.max(0, roles.length - 1),
@@ -197,6 +213,7 @@ function _facet(key, label, values) {
     .sort((a,b)=>b.count-a.count);
   return { key, label, options };
 }
+function _isDeadFacet(f) { return f.options.length <= 1 && (!f.options[0] || f.options[0].value === '—'); }
 function buildFacets(targets) {
   return [
     _facet('type','Type', targets.map(t=>({value:t.type,label:t.type}))),
@@ -208,7 +225,7 @@ function buildFacets(targets) {
     _facet('tenant','Tenant', targets.map(t=>({value:t.tenant,label:t.tenant}))),
     _facet('policy','Machine policy', targets.map(t=>({value:t.policy,label:t.policy}))),
     _facet('version','Agent version', targets.map(t=>({value:t.version,label:t.version})))
-  ];
+  ].filter(f => !_isDeadFacet(f));
 }
 function applyFilters(targets, filters, search) {
   const q = (search||'').trim().toLowerCase();
@@ -227,10 +244,10 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel }; }
+  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-    healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel,
+    healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
     machineToTarget, buildEstate, overviewModel, buildFacets, applyFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -260,6 +260,7 @@ function _facet(key, label, values) {
   const counts = {};
   values.forEach(v => { counts[v.value] = (counts[v.value]||0)+1; if (!counts['_lbl_'+v.value]) counts['_lbl_'+v.value]=v.label; });
   const options = Object.keys(counts).filter(k=>!k.startsWith('_lbl_'))
+    .filter(value => value !== '') // an empty facet value (e.g. unknown OS) isn't a useful filter option
     .map(value => ({ value, label: counts['_lbl_'+value], count: counts[value] }))
     .sort((a,b)=>b.count-a.count);
   return { key, label, options };

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -16,10 +16,17 @@ async function fetchJson(path) {
 function readConfig() {
   return new Promise(resolve => {
     if (typeof dashboardGetConfig !== 'function') { resolve({ serverUrl: _serverUrl, context: {} }); return; }
-    dashboardGetConfig(cfg => resolve({
-      serverUrl: (cfg && cfg.lastServerUrl) || _serverUrl,
-      context: (cfg && cfg.context) || {}
-    }));
+    try {
+      dashboardGetConfig(cfg => resolve({
+        serverUrl: (cfg && cfg.lastServerUrl) || _serverUrl,
+        context: (cfg && cfg.context) || {}
+      }));
+    } catch (e) {
+      // dashboardGetConfig reaches chrome.storage, which is absent when the page
+      // is opened outside the extension (e.g. directly as a file:// URL). Degrade
+      // instead of leaving the caller's promise unresolved.
+      resolve({ serverUrl: _serverUrl, context: {} });
+    }
   });
 }
 

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -120,6 +120,12 @@ function extractVersion(ep) {
   for (const k in ep) { if (/version/i.test(k) && looksLikeVersion(ep[k])) return ep[k]; }
   return '—';
 }
+// An OS / OS-version candidate is only usable if it's a non-empty string that isn't a
+// placeholder. The Octopus API sometimes reports a literal "Unknown" for un-health-checked
+// machines; treat that (and blanks) as no value so the cell renders blank, not "Unknown".
+function _knownOsStr(s) {
+  return typeof s === 'string' && s.trim() && !/^(unknown|n\/?a|none|-|—)$/i.test(s.trim());
+}
 function osLabel(ep, m) {
   // FLAG: exact Octopus OS field is unconfirmed; verify on a live instance.
   // Defensive candidate scan across likely locations, falling back to '' (blank cell —
@@ -129,7 +135,7 @@ function osLabel(ep, m) {
     ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystem,
     m.OperatingSystem, ep.OperatingSystem,
     m.HealthStatus && m.OperatingSystem
-  ].filter(s => typeof s === 'string' && s.trim());
+  ].filter(_knownOsStr);
   return cands[0] || '';
 }
 function osVersionLabel(ep, m) {
@@ -139,7 +145,7 @@ function osVersionLabel(ep, m) {
   const cands = [
     ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystemVersion,
     m.OperatingSystemVersion, ep.OperatingSystemVersion
-  ].filter(s => typeof s === 'string' && s.trim());
+  ].filter(_knownOsStr);
   return cands[0] || '';
 }
 function machineToTarget(m, ctx) {

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -51,6 +51,156 @@ async function loadEstate(serverUrl) {
   return { status: (anyMachines || anyWorkers) ? 'ready' : 'empty', spaces, perSpace };
 }
 
+function healthLabel(api) {
+  if (api === 'Healthy') return 'Healthy';
+  if (api === 'HealthyWithWarnings') return 'Healthy with warnings';
+  if (api === 'Unhealthy') return 'Unhealthy';
+  if (api === 'Unavailable') return 'Unavailable';
+  return 'Unavailable';
+}
+function healthKey(api, isDisabled) {
+  if (isDisabled) return 'disabled';
+  if (api === 'Healthy' || api === 'HealthyWithWarnings') return 'healthy';
+  if (api === 'Unhealthy') return 'unhealthy';
+  return 'unavailable';
+}
+function commLabel(style) {
+  if (style === 'TentacleActive') return 'Polling Tentacle';
+  if (style === 'TentaclePassive') return 'Listening Tentacle';
+  if (style === 'KubernetesTentacle') return 'Kubernetes Agent';
+  return style || '';
+}
+function kindLabel(style) {
+  if (style === 'TentacleActive') return 'Tentacle (Polling)';
+  if (style === 'TentaclePassive') return 'Tentacle (Listening)';
+  if (style === 'KubernetesTentacle') return 'Kubernetes Agent';
+  if (style === 'None') return 'SSH / Cloud';
+  return style || 'Unknown';
+}
+function envCat(name) {
+  const n = (name || '').toLowerCase();
+  if (/prod/.test(n)) return 'production';
+  if (/stag|preprod|pre-prod|uat|qa|test/.test(n)) return 'staging';
+  if (/dev|internal|sandbox|local/.test(n)) return 'dev';
+  return 'other';
+}
+function looksLikeVersion(s) { return typeof s === 'string' && /^\d+\.\d+/.test(s); }
+function extractVersion(ep) {
+  if (!ep) return '—';
+  if (ep.TentacleVersionDetails && ep.TentacleVersionDetails.Version) return ep.TentacleVersionDetails.Version;
+  const kad = ep.KubernetesAgentDetails || {};
+  const cands = [kad.AgentVersion, kad.Version, kad.HelmChartVersion, ep.AgentVersion, ep.HelmChartVersion, ep.Version].filter(looksLikeVersion);
+  if (cands.length) return cands[0];
+  for (const k in ep) { if (/version/i.test(k) && looksLikeVersion(ep[k])) return ep[k]; }
+  return '—';
+}
+function osLabel(ep) {
+  // FLAG: verify OS fields on a live instance; fall back to '—'.
+  return (ep && (ep.OperatingSystem || (ep.TentacleVersionDetails && ep.TentacleVersionDetails.OperatingSystem))) || '—';
+}
+function machineToTarget(m, ctx) {
+  const ep = m.Endpoint || {};
+  const env = (m.EnvironmentIds || []).map(id => ctx.envMap[id]).filter(Boolean)[0] || '—';
+  const pol = ctx.policyMap[m.MachinePolicyId];
+  const roles = m.Roles || [];
+  const tNames = (m.TenantIds || []).map(id => ctx.tenantMap[id]).filter(Boolean);
+  const tenant = tNames.length === 0 ? 'No tenants' : (tNames.length === 1 ? tNames[0] : tNames.length + ' tenants');
+  return {
+    id: m.Id, name: m.Name || m.Id, spaceId: ctx.spaceId,
+    kind: kindLabel(ep.CommunicationStyle),
+    comm: commLabel(ep.CommunicationStyle),
+    os: osLabel(ep), osVersion: '—',
+    health: healthLabel(m.HealthStatus), healthKey: healthKey(m.HealthStatus, m.IsDisabled),
+    env, envCat: envCat(env),
+    tag: roles[0] || '—', moreTags: Math.max(0, roles.length - 1),
+    tenant, policy: (pol && pol.Name) || '—',
+    version: extractVersion(ep)
+  };
+}
+
+function buildEstate(perSpace) {
+  const targets = [], workers = [], environments = [], policies = [];
+  perSpace.forEach(s => {
+    const envMap = {}; (s.envs || []).forEach(e => { envMap[e.Id] = e.Name; environments.push({ id:e.Id, name:e.Name, spaceId:s.sp.Id }); });
+    const policyMap = {}; (s.policies || []).forEach(p => { policyMap[p.Id] = p; policies.push(p); });
+    const tenantMap = {}; (s.tenants || []).forEach(t => { tenantMap[t.Id] = t.Name; });
+    const ctx = { envMap, policyMap, tenantMap, spaceId: s.sp.Id, spaceName: s.sp.Name };
+    (s.machines || []).forEach(m => targets.push(machineToTarget(m, ctx)));
+    const poolMap = {}; (s.workerpools || []).forEach(p => poolMap[p.Id] = p.Name);
+    (s.workers || []).forEach(w => {
+      const ep = w.Endpoint || {};
+      workers.push({ id:w.Id, name:w.Name, health:healthLabel(w.HealthStatus),
+        healthKey:healthKey(w.HealthStatus, w.IsDisabled),
+        pool:(w.WorkerPoolIds||[]).map(id=>poolMap[id]).filter(Boolean)[0]||'—',
+        version:extractVersion(ep), kind:kindLabel(ep.CommunicationStyle) });
+    });
+  });
+  return { targets, workers, environments, policies, overview: overviewModel(targets, workers) };
+}
+
+function _count(arr, pred) { return arr.reduce((n,x)=>n+(pred(x)?1:0),0); }
+function overviewModel(targets, workers) {
+  const healthy = _count(targets, t=>t.healthKey==='healthy');
+  const unhealthy = _count(targets, t=>t.healthKey==='unhealthy'||t.healthKey==='unavailable');
+  const disabled = _count(targets, t=>t.healthKey==='disabled');
+  const total = targets.length;
+  const byTypeMap = {};
+  targets.forEach(t => { const k=t.kind; (byTypeMap[k]=byTypeMap[k]||{name:k,healthy:0,unhealthy:0});
+    if (t.healthKey==='healthy') byTypeMap[k].healthy++; else if (t.healthKey!=='disabled') byTypeMap[k].unhealthy++; });
+  const byEnvMap = {};
+  targets.forEach(t => { const k=t.env; const e=(byEnvMap[k]=byEnvMap[k]||{name:k,total:0,healthy:0,unhealthy:0,disabled:0});
+    e.total++; if (t.healthKey==='healthy') e.healthy++; else if (t.healthKey==='disabled') e.disabled++; else e.unhealthy++; });
+  const wHealthy = _count(workers, w=>w.healthKey==='healthy');
+  const poolMap = {}; workers.forEach(w=>{ poolMap[w.pool]=(poolMap[w.pool]||0)+1; });
+  return {
+    total, healthy, unhealthy, disabled,
+    healthyPct: total ? Math.round(healthy/total*100) : 0,
+    byType: Object.values(byTypeMap),
+    byEnv: Object.values(byEnvMap).sort((a,b)=>b.total-a.total),
+    workers: { total: workers.length, healthy: wHealthy, unhealthy: workers.length-wHealthy,
+      pools: Object.entries(poolMap).map(([name,count])=>({name,count})) }
+  };
+}
+
+function _facet(key, label, values) {
+  const counts = {};
+  values.forEach(v => { counts[v.value] = (counts[v.value]||0)+1; if (!counts['_lbl_'+v.value]) counts['_lbl_'+v.value]=v.label; });
+  const options = Object.keys(counts).filter(k=>!k.startsWith('_lbl_'))
+    .map(value => ({ value, label: counts['_lbl_'+value], count: counts[value] }))
+    .sort((a,b)=>b.count-a.count);
+  return { key, label, options };
+}
+function buildFacets(targets) {
+  return [
+    _facet('kind','Type', targets.map(t=>({value:t.kind,label:t.kind}))),
+    _facet('os','Operating system', targets.map(t=>({value:t.os,label:t.os}))),
+    _facet('osVersion','OS version', targets.map(t=>({value:t.osVersion,label:t.osVersion}))),
+    _facet('health','Health', targets.map(t=>({value:t.healthKey,label:t.health}))),
+    _facet('env','Environment', targets.map(t=>({value:t.env,label:t.env}))),
+    _facet('tag','Target tag', targets.map(t=>({value:t.tag,label:t.tag}))),
+    _facet('tenant','Tenant', targets.map(t=>({value:t.tenant,label:t.tenant}))),
+    _facet('policy','Machine policy', targets.map(t=>({value:t.policy,label:t.policy}))),
+    _facet('version','Agent version', targets.map(t=>({value:t.version,label:t.version})))
+  ];
+}
+function applyFilters(targets, filters, search) {
+  const q = (search||'').trim().toLowerCase();
+  // 'health' facet options carry healthKey values (see buildFacets), so the
+  // filter must match against t.healthKey rather than the t.health label.
+  const fieldMap = { health: 'healthKey' };
+  return targets.filter(t => {
+    for (const key in (filters||{})) {
+      const sel = filters[key]; if (!sel || !sel.length) continue;
+      const field = fieldMap[key] || key;
+      if (!sel.includes(t[field])) return false;
+    }
+    if (q && !String(t.name).toLowerCase().includes(q)) return false;
+    return true;
+  });
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate };
+  module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
+    healthLabel, healthKey, commLabel, kindLabel, envCat, extractVersion, osLabel,
+    machineToTarget, buildEstate, overviewModel, buildFacets, applyFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -205,6 +205,38 @@ function overviewModel(targets, workers) {
   };
 }
 
+// FLAG: exact Octopus machine-policy field names are unconfirmed; verify on a live instance.
+// Defensive scan of the candidate locations the Octopus API is believed to use, falling
+// back to '—' when a field is absent, renamed, or shaped differently than expected.
+function _policyFallback(v) {
+  if (typeof v === 'string' && v.trim()) return v;
+  if (typeof v === 'number') return v;
+  return '—';
+}
+function policiesModel(policies, targets) {
+  const list = targets || [];
+  return (policies || []).map(p => {
+    const name = p.Name;
+    const isDefault = p.IsDefault === true || p.Name === 'Default Machine Policy';
+    const description = p.Description || '';
+    const usage = _count(list, t => t.policy === name);
+    const mhcp = p.MachineHealthCheckPolicy || {};
+    const mup = p.MachineUpdatePolicy || {};
+    const mcp = p.MachineConnectivityPolicy || {};
+    const mclp = p.MachineCleanupPolicy || {};
+    return {
+      name, isDefault, description, usage,
+      interval: _policyFallback(mhcp.HealthCheckInterval),
+      healthCheckType: _policyFallback(mhcp.HealthCheckType),
+      tentacle: _policyFallback(mup.TentacleUpgradePolicy),
+      calamari: _policyFallback(mup.CalamariUpdatePolicy),
+      k8s: _policyFallback(mup.KubernetesAgentUpgradePolicy),
+      connectivity: _policyFallback(mcp.MachineConnectivityBehavior),
+      cleanup: _policyFallback(mclp.DeleteMachinesBehavior)
+    };
+  });
+}
+
 function environmentsModel(targets, environments) {
   const map = {};
   (targets || []).forEach(t => {
@@ -261,10 +293,10 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, environmentsModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
+  buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, overviewModel, environmentsModel, buildFacets, applyFilters };
+    machineToTarget, buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -276,6 +276,39 @@ function buildFacets(targets) {
     _facet('version','Agent version', targets.map(t=>({value:t.version,label:t.version})))
   ].filter(f => !_isDeadFacet(f));
 }
+function workersModel(workers) {
+  const list = workers || [];
+  const poolMap = {};
+  list.forEach(w => {
+    const p = (poolMap[w.pool] = poolMap[w.pool] || { name: w.pool, total: 0, healthy: 0, unhealthy: 0 });
+    p.total++;
+    if (w.healthKey === 'healthy') p.healthy++;
+    else if (w.healthKey === 'unhealthy') p.unhealthy++;
+  });
+  const pools = Object.values(poolMap).sort((a, b) => b.total - a.total);
+  return { pools, rows: list };
+}
+function workerFacets(workers) {
+  const list = workers || [];
+  return [
+    _facet('health', 'Health', list.map(w => ({ value: w.healthKey, label: healthKeyLabel(w.healthKey) }))),
+    _facet('pool', 'Pool', list.map(w => ({ value: w.pool, label: w.pool }))),
+    _facet('version', 'Agent version', list.map(w => ({ value: w.version, label: w.version })))
+  ].filter(f => !_isDeadFacet(f));
+}
+function applyWorkerFilters(workers, filters, search) {
+  const q = (search || '').trim().toLowerCase();
+  const fieldMap = { health: 'healthKey' };
+  return (workers || []).filter(w => {
+    for (const key in (filters || {})) {
+      const sel = filters[key]; if (!sel || !sel.length) continue;
+      const field = fieldMap[key] || key;
+      if (!sel.includes(w[field])) return false;
+    }
+    if (q && !String(w.name).toLowerCase().includes(q)) return false;
+    return true;
+  });
+}
 function applyFilters(targets, filters, search) {
   const q = (search||'').trim().toLowerCase();
   // 'health' facet options carry healthKey values (see buildFacets), so the
@@ -293,10 +326,12 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
+  buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters };
+    machineToTarget, buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    workersModel, workerFacets, applyWorkerFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -183,6 +183,54 @@ function buildEstate(perSpace) {
   return { targets, workers, environments, policies, overview: overviewModel(targets, workers) };
 }
 
+/* ─── Agent version model (latest, behind, bands) ────────────────────────
+ * Ported from dashboards/targetagentversions/dashboard.js (vkey, versionBand,
+ * deriveLatest). "Behind" is a MAJOR-version rule, not a full vkey compare:
+ * an agent is behind only if its major version is one or more below the
+ * latest major version for its type — minor/patch lag does not count. */
+function vkey(v) { return String(v || '').split('.').map(n => String(n).padStart(4, '0')).join('.'); }
+function majorVersion(v) {
+  if (!v || v === '—') return NaN;
+  return parseInt(String(v).split('.')[0], 10);
+}
+function versionBand(v) {
+  if (!v || v === '—' || v === '0.0.0') return 'unknown';
+  const major = majorVersion(v);
+  if (isNaN(major)) return 'unknown';
+  if (major <= 4) return 'red';
+  if (major <= 6) return 'yellow';
+  return 'green';
+}
+function deriveLatest(versions) {
+  const pool = (versions || []).filter(v => v && v !== '—');
+  let best = '';
+  pool.forEach(v => { if (!best || vkey(v).localeCompare(vkey(best)) > 0) best = v; });
+  return best || '—';
+}
+function _agentGroup(rows) {
+  const latest = deriveLatest(rows.map(t => t.version));
+  const latestMajor = majorVersion(latest);
+  let upToDate = 0, behind = 0, unknown = 0;
+  const outRows = rows.map(t => {
+    const isUnknown = !t.version || t.version === '—';
+    const isBehind = !isUnknown && majorVersion(t.version) < latestMajor;
+    if (isUnknown) unknown++; else if (isBehind) behind++; else upToDate++;
+    return { name: t.name, env: t.env, version: t.version, band: versionBand(t.version),
+      behind: isBehind, policy: t.policy };
+  });
+  const distMap = {};
+  outRows.forEach(r => { const d = (distMap[r.version] = distMap[r.version] || { version: r.version, count: 0, band: r.band }); d.count++; });
+  const distribution = Object.values(distMap).sort((a, b) => vkey(b.version).localeCompare(vkey(a.version)));
+  return { latest, total: rows.length, upToDate, behind, unknown, rows: outRows, distribution };
+}
+function agentsModel(targets) {
+  const list = targets || [];
+  return {
+    tentacle: _agentGroup(list.filter(t => t.type === 'Tentacle')),
+    kubernetes: _agentGroup(list.filter(t => t.type === 'Kubernetes'))
+  };
+}
+
 function _count(arr, pred) { return arr.reduce((n,x)=>n+(pred(x)?1:0),0); }
 function overviewModel(targets, workers) {
   const healthy = _count(targets, t=>t.healthKey==='healthy');
@@ -197,13 +245,16 @@ function overviewModel(targets, workers) {
     e.total++; if (t.healthKey==='healthy') e.healthy++; else if (t.healthKey==='disabled') e.disabled++; else e.unhealthy++; });
   const wHealthy = _count(workers, w=>w.healthKey==='healthy');
   const poolMap = {}; workers.forEach(w=>{ poolMap[w.pool]=(poolMap[w.pool]||0)+1; });
+  const agents = agentsModel(targets);
   return {
     total, healthy, unhealthy, disabled,
     healthyPct: total ? Math.round(healthy/total*100) : 0,
     byType: Object.values(byTypeMap),
     byEnv: Object.values(byEnvMap).sort((a,b)=>b.total-a.total),
     workers: { total: workers.length, healthy: wHealthy, unhealthy: workers.length-wHealthy,
-      pools: Object.entries(poolMap).map(([name,count])=>({name,count})) }
+      pools: Object.entries(poolMap).map(([name,count])=>({name,count})) },
+    agents: { latest: agents.tentacle.total ? agents.tentacle.latest : agents.kubernetes.latest,
+      behind: agents.tentacle.behind + agents.kubernetes.behind }
   };
 }
 
@@ -330,11 +381,13 @@ function applyFilters(targets, filters, search) {
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
   buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
-  workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
+  workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
+  vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
     machineToTarget, buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
-    workersModel, workerFacets, applyWorkerFilters };
+    workersModel, workerFacets, applyWorkerFilters,
+    vkey, majorVersion, versionBand, deriveLatest, agentsModel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -205,6 +205,23 @@ function overviewModel(targets, workers) {
   };
 }
 
+function environmentsModel(targets, environments) {
+  const map = {};
+  (targets || []).forEach(t => {
+    const name = t.env;
+    const e = (map[name] = map[name] || { name, total: 0, healthy: 0, unhealthy: 0, disabled: 0, targets: [] });
+    e.total++;
+    if (t.healthKey === 'healthy') e.healthy++;
+    else if (t.healthKey === 'disabled') e.disabled++;
+    else e.unhealthy++;
+    e.targets.push({ name: t.name, type: t.type, healthKey: t.healthKey, health: t.health, tag: t.tag, tenant: t.tenant });
+  });
+  (environments || []).forEach(env => {
+    if (!map[env.name]) map[env.name] = { name: env.name, total: 0, healthy: 0, unhealthy: 0, disabled: 0, targets: [] };
+  });
+  return Object.values(map).sort((a, b) => b.total - a.total);
+}
+
 function _facet(key, label, values) {
   const counts = {};
   values.forEach(v => { counts[v.value] = (counts[v.value]||0)+1; if (!counts['_lbl_'+v.value]) counts['_lbl_'+v.value]=v.label; });
@@ -244,10 +261,10 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
+  buildEstate, overviewModel, environmentsModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, overviewModel, buildFacets, applyFilters };
+    machineToTarget, buildEstate, overviewModel, environmentsModel, buildFacets, applyFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -169,6 +169,10 @@ function machineToTarget(m, ctx) {
   };
 }
 
+function isEmptyEstate(estate) {
+  return !estate || ((estate.targets||[]).length === 0 && (estate.workers||[]).length === 0);
+}
+
 function buildEstate(perSpace) {
   const targets = [], workers = [], environments = [], policies = [];
   perSpace.forEach(s => {
@@ -386,14 +390,14 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  buildEstate, isEmptyEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    machineToTarget, buildEstate, isEmptyEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -68,8 +68,12 @@ function healthLabel(api) {
 function healthKey(api, isDisabled) {
   if (isDisabled) return 'disabled';
   if (api === 'Healthy' || api === 'HealthyWithWarnings') return 'healthy';
-  if (api === 'Unhealthy') return 'unhealthy';
-  return 'unavailable';
+  return 'unhealthy'; // Unhealthy, Unavailable, Unknown, null all fold in
+}
+function healthKeyLabel(key) {
+  if (key === 'healthy') return 'Healthy';
+  if (key === 'disabled') return 'Disabled';
+  return 'Unhealthy';
 }
 function commLabel(style) {
   if (style === 'TentacleActive') return 'Polling Tentacle';
@@ -164,12 +168,12 @@ function buildEstate(perSpace) {
 function _count(arr, pred) { return arr.reduce((n,x)=>n+(pred(x)?1:0),0); }
 function overviewModel(targets, workers) {
   const healthy = _count(targets, t=>t.healthKey==='healthy');
-  const unhealthy = _count(targets, t=>t.healthKey==='unhealthy'||t.healthKey==='unavailable');
+  const unhealthy = _count(targets, t=>t.healthKey==='unhealthy');
   const disabled = _count(targets, t=>t.healthKey==='disabled');
   const total = targets.length;
   const byTypeMap = {};
-  targets.forEach(t => { const k=t.kind; (byTypeMap[k]=byTypeMap[k]||{name:k,healthy:0,unhealthy:0});
-    if (t.healthKey==='healthy') byTypeMap[k].healthy++; else if (t.healthKey!=='disabled') byTypeMap[k].unhealthy++; });
+  targets.forEach(t => { const k=t.type || t.kind; (byTypeMap[k]=byTypeMap[k]||{name:k,healthy:0,unhealthy:0});
+    if (t.healthKey==='healthy') byTypeMap[k].healthy++; else if (t.healthKey==='unhealthy') byTypeMap[k].unhealthy++; });
   const byEnvMap = {};
   targets.forEach(t => { const k=t.env; const e=(byEnvMap[k]=byEnvMap[k]||{name:k,total:0,healthy:0,unhealthy:0,disabled:0});
     e.total++; if (t.healthKey==='healthy') e.healthy++; else if (t.healthKey==='disabled') e.disabled++; else e.unhealthy++; });
@@ -195,10 +199,10 @@ function _facet(key, label, values) {
 }
 function buildFacets(targets) {
   return [
-    _facet('kind','Type', targets.map(t=>({value:t.kind,label:t.kind}))),
+    _facet('type','Type', targets.map(t=>({value:t.type,label:t.type}))),
     _facet('os','Operating system', targets.map(t=>({value:t.os,label:t.os}))),
     _facet('osVersion','OS version', targets.map(t=>({value:t.osVersion,label:t.osVersion}))),
-    _facet('health','Health', targets.map(t=>({value:t.healthKey,label:t.health}))),
+    _facet('health','Health', targets.map(t=>({value:t.healthKey,label:healthKeyLabel(t.healthKey)}))),
     _facet('env','Environment', targets.map(t=>({value:t.env,label:t.env}))),
     _facet('tag','Target tag', targets.map(t=>({value:t.tag,label:t.tag}))),
     _facet('tenant','Tenant', targets.map(t=>({value:t.tenant,label:t.tenant}))),
@@ -223,10 +227,10 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget, typeGroup }; }
+  buildEstate, overviewModel, buildFacets, applyFilters, machineToTarget, typeGroup, healthKeyLabel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-    healthLabel, healthKey, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel,
+    healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel,
     machineToTarget, buildEstate, overviewModel, buildFacets, applyFilters };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1,0 +1,5 @@
+'use strict';
+// Estate data layer — populated in Tasks 1 & 2.
+
+const IP_IS_CJS = typeof module !== 'undefined' && typeof module.exports !== 'undefined';
+if (typeof module !== 'undefined') { module.exports = {}; }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1,5 +1,56 @@
 'use strict';
 // Estate data layer — populated in Tasks 1 & 2.
 
-const IP_IS_CJS = typeof module !== 'undefined' && typeof module.exports !== 'undefined';
-if (typeof module !== 'undefined') { module.exports = {}; }
+let _serverUrl = null;
+function setServerUrl(url) { _serverUrl = url; }
+function apiUrl(path) { return new URL(path, _serverUrl).toString(); }
+
+async function fetchJson(path) {
+  const res = await fetch(apiUrl(path), {
+    method: 'GET', credentials: 'include', headers: { Accept: 'application/json' } });
+  if (res.status === 401 || res.status === 403) { const e = new Error('auth'); e.auth = true; throw e; }
+  if (!res.ok) { const e = new Error(res.status + ' ' + res.statusText); e.code = res.status + ' ' + res.statusText; throw e; }
+  return res.json();
+}
+
+function readConfig() {
+  return new Promise(resolve => {
+    if (typeof dashboardGetConfig !== 'function') { resolve({ serverUrl: _serverUrl, context: {} }); return; }
+    dashboardGetConfig(cfg => resolve({
+      serverUrl: (cfg && cfg.lastServerUrl) || _serverUrl,
+      context: (cfg && cfg.context) || {}
+    }));
+  });
+}
+
+async function loadEstate(serverUrl) {
+  setServerUrl(serverUrl);
+  let spaces;
+  try { spaces = await fetchJson('/api/spaces/all'); }
+  catch (e) { return { status: e && e.auth ? 'auth' : 'error', spaces: [], perSpace: [] }; }
+  if (!spaces || !spaces.length) return { status: 'empty', spaces: [], perSpace: [] };
+
+  let anyAuth = false;
+  const perSpace = (await Promise.all(spaces.map(async sp => {
+    try {
+      const [envs, policies, tenants, machines, workerpools, workers] = await Promise.all([
+        fetchJson('/api/' + sp.Id + '/environments/all').catch(() => []),
+        fetchJson('/api/' + sp.Id + '/machinepolicies/all').catch(() => []),
+        fetchJson('/api/' + sp.Id + '/tenants/all').catch(() => []),
+        fetchJson('/api/' + sp.Id + '/machines/all'),
+        fetchJson('/api/' + sp.Id + '/workerpools/all').catch(() => []),
+        fetchJson('/api/' + sp.Id + '/workers/all').catch(() => [])
+      ]);
+      return { sp, envs, policies, tenants, machines, workerpools, workers };
+    } catch (e) { if (e && e.auth) anyAuth = true; return null; }
+  }))).filter(Boolean);
+
+  if (!perSpace.length) return { status: anyAuth ? 'auth' : 'error', spaces, perSpace: [] };
+  const anyMachines = perSpace.some(s => (s.machines || []).length);
+  const anyWorkers = perSpace.some(s => (s.workers || []).length);
+  return { status: (anyMachines || anyWorkers) ? 'ready' : 'empty', spaces, perSpace };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate };
+}

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -30,17 +30,6 @@ function readConfig() {
   });
 }
 
-// Run `fn` over `items` with at most `limit` in flight at once; preserves input order.
-async function _mapLimit(items, limit, fn) {
-  const results = new Array(items.length);
-  let next = 0;
-  async function worker() {
-    while (next < items.length) { const i = next++; results[i] = await fn(items[i], i); }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return results;
-}
-
 // Boot in two steps. The space list is one cheap request; hydrating a space is six.
 // Loading every space up front to display one is the dominant boot cost on a
 // many-space instance, so callers hydrate only what they're about to show.
@@ -531,5 +520,5 @@ if (typeof module !== 'undefined') {
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
     machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
-    vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
+    vkey, majorVersion, versionBand, deriveLatest, agentsModel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -186,18 +186,13 @@ function isEmptyEstate(estate) {
   return !estate || ((estate.targets||[]).length === 0 && (estate.workers||[]).length === 0);
 }
 
-// Views that only make sense once there's infrastructure to look at. Environments and
-// machine policies exist independently of targets — a space can hold nine environments
-// and no machines, and hiding them behind "Set up your infrastructure" tells the user
-// there's nothing here while we're sitting on their data.
-const _TARGET_CENTRIC = ['overview', 'targets', 'workers', 'agents', 'argocd'];
+// Cold-start is a landing screen, not a wall. Overview gets it when there's no
+// infrastructure — that's the "set this up" moment. Every other view renders itself and
+// uses its own empty state, because clicking a nav item and landing on the screen you
+// were already on is a dead end, and a space with no targets can still hold environments,
+// machine policies and a route out via the add-target walkthrough.
 function coldStartApplies(view, estate) {
-  if (view === 'targets/new') return false;          // the walkthrough is the way out of an empty estate
-  if (!isEmptyEstate(estate)) return false;
-  if (_TARGET_CENTRIC.indexOf(view) !== -1) return true;
-  // A wholly bare space has nothing to show anywhere, so cold-start is the honest answer.
-  const e = estate || {};
-  return (e.environments || []).length === 0 && (e.policies || []).length === 0;
+  return view === 'overview' && isEmptyEstate(estate);
 }
 
 // Per-target activity comes from /api/{space}/machines/{id}/tasks — verified against a live

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -41,44 +41,41 @@ async function _mapLimit(items, limit, fn) {
   return results;
 }
 
-async function loadEstate(serverUrl) {
+// Boot in two steps. The space list is one cheap request; hydrating a space is six.
+// Loading every space up front to display one is the dominant boot cost on a
+// many-space instance, so callers hydrate only what they're about to show.
+async function loadSpaces(serverUrl) {
   setServerUrl(serverUrl);
   let spaces;
   try { spaces = await fetchJson('/api/spaces/all'); }
-  catch (e) { return { status: e && e.auth ? 'auth' : 'error', spaces: [], perSpace: [] }; }
-  if (!spaces || !spaces.length) return { status: 'empty', spaces: [], perSpace: [] };
+  catch (e) { return { status: e && e.auth ? 'auth' : 'error', spaces: [] }; }
+  if (!spaces || !spaces.length) return { status: 'empty', spaces: [] };
+  return { status: 'ready', spaces };
+}
 
-  let anyAuth = false;
-  // Cap how many spaces we hydrate at once so a many-space instance doesn't fire
-  // a huge concurrent burst of /all requests on load. Order is preserved.
-  const perSpace = (await _mapLimit(spaces, 4, async sp => {
-    // A resource that fails still yields [] so the rest of the space renders, but the
-    // failure is recorded. Without that record an unreadable endpoint is indistinguishable
-    // from an empty one, and the UI ends up asserting "there are none" about data it
-    // never managed to read.
-    const failed = [];
-    const soft = (name, path) => fetchJson(path).catch(e => {
-      failed.push(name);
-      if (e && e.auth) anyAuth = true;
-      return [];
-    });
-    try {
-      const [envs, policies, tenants, machines, workerpools, workers] = await Promise.all([
-        soft('environments', '/api/' + sp.Id + '/environments/all'),
-        soft('policies',     '/api/' + sp.Id + '/machinepolicies/all'),
-        soft('tenants',      '/api/' + sp.Id + '/tenants/all'),
-        fetchJson('/api/' + sp.Id + '/machines/all'),
-        soft('workerpools',  '/api/' + sp.Id + '/workerpools/all'),
-        soft('workers',      '/api/' + sp.Id + '/workers/all')
-      ]);
-      return { sp, envs, policies, tenants, machines, workerpools, workers, failed };
-    } catch (e) { if (e && e.auth) anyAuth = true; return null; }
-  })).filter(Boolean);
-
-  if (!perSpace.length) return { status: anyAuth ? 'auth' : 'error', spaces, perSpace: [] };
-  const anyMachines = perSpace.some(s => (s.machines || []).length);
-  const anyWorkers = perSpace.some(s => (s.workers || []).length);
-  return { status: (anyMachines || anyWorkers) ? 'ready' : 'empty', spaces, perSpace };
+// One space's payload. A resource that fails still yields [] so the rest of the space
+// renders, but the failure is recorded — without that record an unreadable endpoint is
+// indistinguishable from an empty one. Machines are the exception: if they can't be read
+// there is no estate to show, so the space is dropped entirely (null).
+async function hydrateSpace(sp) {
+  const failed = [];
+  let auth = false;
+  const soft = (name, path) => fetchJson(path).catch(e => {
+    failed.push(name);
+    if (e && e.auth) auth = true;
+    return [];
+  });
+  try {
+    const [envs, policies, tenants, machines, workerpools, workers] = await Promise.all([
+      soft('environments', '/api/' + sp.Id + '/environments/all'),
+      soft('policies',     '/api/' + sp.Id + '/machinepolicies/all'),
+      soft('tenants',      '/api/' + sp.Id + '/tenants/all'),
+      fetchJson('/api/' + sp.Id + '/machines/all'),
+      soft('workerpools',  '/api/' + sp.Id + '/workerpools/all'),
+      soft('workers',      '/api/' + sp.Id + '/workers/all')
+    ]);
+    return { sp, envs, policies, tenants, machines, workerpools, workers, failed, auth };
+  } catch (e) { return null; }
 }
 
 function healthLabel(api) {
@@ -524,13 +521,13 @@ function applyFilters(targets, filters, search) {
   });
 }
 
-if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
+if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
-  module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
+  module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
     machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -186,6 +186,19 @@ function isEmptyEstate(estate) {
   return !estate || ((estate.targets||[]).length === 0 && (estate.workers||[]).length === 0);
 }
 
+// Environments toolbar: free-text search plus one of three mutually exclusive views.
+// "All healthy" includes environments holding nothing at all — an environment with no
+// targets has nothing unhealthy in it, which is what the filter asks.
+function filterEnvRows(rows, query, mode) {
+  const q = String(query || '').trim().toLowerCase();
+  return (rows || []).filter(r => {
+    if (q && String(r.name || '').toLowerCase().indexOf(q) === -1) return false;
+    if (mode === 'attention') return r.unhealthy > 0;
+    if (mode === 'healthy') return !r.unhealthy;
+    return true;
+  });
+}
+
 // Cold-start is a landing screen, not a wall. Overview gets it when there's no
 // infrastructure — that's the "set this up" moment. Every other view renders itself and
 // uses its own empty state, because clicking a nav item and landing on the screen you
@@ -472,14 +485,14 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, isEmptyEstate, coldStartApplies, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -52,16 +52,26 @@ async function loadEstate(serverUrl) {
   // Cap how many spaces we hydrate at once so a many-space instance doesn't fire
   // a huge concurrent burst of /all requests on load. Order is preserved.
   const perSpace = (await _mapLimit(spaces, 4, async sp => {
+    // A resource that fails still yields [] so the rest of the space renders, but the
+    // failure is recorded. Without that record an unreadable endpoint is indistinguishable
+    // from an empty one, and the UI ends up asserting "there are none" about data it
+    // never managed to read.
+    const failed = [];
+    const soft = (name, path) => fetchJson(path).catch(e => {
+      failed.push(name);
+      if (e && e.auth) anyAuth = true;
+      return [];
+    });
     try {
       const [envs, policies, tenants, machines, workerpools, workers] = await Promise.all([
-        fetchJson('/api/' + sp.Id + '/environments/all').catch(() => []),
-        fetchJson('/api/' + sp.Id + '/machinepolicies/all').catch(() => []),
-        fetchJson('/api/' + sp.Id + '/tenants/all').catch(() => []),
+        soft('environments', '/api/' + sp.Id + '/environments/all'),
+        soft('policies',     '/api/' + sp.Id + '/machinepolicies/all'),
+        soft('tenants',      '/api/' + sp.Id + '/tenants/all'),
         fetchJson('/api/' + sp.Id + '/machines/all'),
-        fetchJson('/api/' + sp.Id + '/workerpools/all').catch(() => []),
-        fetchJson('/api/' + sp.Id + '/workers/all').catch(() => [])
+        soft('workerpools',  '/api/' + sp.Id + '/workerpools/all'),
+        soft('workers',      '/api/' + sp.Id + '/workers/all')
       ]);
-      return { sp, envs, policies, tenants, machines, workerpools, workers };
+      return { sp, envs, policies, tenants, machines, workerpools, workers, failed };
     } catch (e) { if (e && e.auth) anyAuth = true; return null; }
   })).filter(Boolean);
 
@@ -285,7 +295,12 @@ function buildEstate(perSpace) {
         version:extractVersion(ep), kind:kindLabel(ep.CommunicationStyle) });
     });
   });
-  return { targets, workers, environments, policies, overview: overviewModel(targets, workers) };
+  // Which resources couldn't be read for the spaces in scope. A view consults this before
+  // telling the user a collection is empty.
+  const failed = { environments:false, policies:false, tenants:false, workerpools:false, workers:false };
+  perSpace.forEach(s => (s.failed || []).forEach(k => { if (k in failed) failed[k] = true; }));
+  return { targets, workers, environments, policies, failed,
+    overview: overviewModel(targets, workers) };
 }
 
 /* ─── Agent version model (latest, behind, bands) ────────────────────────
@@ -342,9 +357,16 @@ function overviewModel(targets, workers) {
   const unhealthy = _count(targets, t=>t.healthKey==='unhealthy');
   const disabled = _count(targets, t=>t.healthKey==='disabled');
   const total = targets.length;
+  // Every target lands in exactly one bucket, so the per-type rows reconcile with the
+  // estate totals above. Counting only healthy/unhealthy silently dropped disabled
+  // targets out of their type row altogether.
   const byTypeMap = {};
-  targets.forEach(t => { const k=t.type || t.kind; (byTypeMap[k]=byTypeMap[k]||{name:k,healthy:0,unhealthy:0});
-    if (t.healthKey==='healthy') byTypeMap[k].healthy++; else if (t.healthKey==='unhealthy') byTypeMap[k].unhealthy++; });
+  targets.forEach(t => { const k=t.type || t.kind;
+    const e = (byTypeMap[k]=byTypeMap[k]||{name:k,healthy:0,unhealthy:0,disabled:0,total:0});
+    e.total++;
+    if (t.healthKey==='healthy') e.healthy++;
+    else if (t.healthKey==='disabled') e.disabled++;
+    else e.unhealthy++; });
   const byEnvMap = {};
   targets.forEach(t => { const k=t.env; const e=(byEnvMap[k]=byEnvMap[k]||{name:k,total:0,healthy:0,unhealthy:0,disabled:0});
     e.total++; if (t.healthKey==='healthy') e.healthy++; else if (t.healthKey==='disabled') e.disabled++; else e.unhealthy++; });

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -186,6 +186,20 @@ function isEmptyEstate(estate) {
   return !estate || ((estate.targets||[]).length === 0 && (estate.workers||[]).length === 0);
 }
 
+// Views that only make sense once there's infrastructure to look at. Environments and
+// machine policies exist independently of targets — a space can hold nine environments
+// and no machines, and hiding them behind "Set up your infrastructure" tells the user
+// there's nothing here while we're sitting on their data.
+const _TARGET_CENTRIC = ['overview', 'targets', 'workers', 'agents', 'argocd'];
+function coldStartApplies(view, estate) {
+  if (view === 'targets/new') return false;          // the walkthrough is the way out of an empty estate
+  if (!isEmptyEstate(estate)) return false;
+  if (_TARGET_CENTRIC.indexOf(view) !== -1) return true;
+  // A wholly bare space has nothing to show anywhere, so cold-start is the honest answer.
+  const e = estate || {};
+  return (e.environments || []).length === 0 && (e.policies || []).length === 0;
+}
+
 // Per-target activity comes from /api/{space}/machines/{id}/tasks — verified against a live
 // instance. Note /api/{space}/tasks?regarding={id} silently IGNORES the filter and returns the
 // whole task list; don't reach for it.
@@ -463,14 +477,14 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, isEmptyEstate, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  buildEstate, isEmptyEstate, coldStartApplies, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, isEmptyEstate, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -186,6 +186,14 @@ function isEmptyEstate(estate) {
   return !estate || ((estate.targets||[]).length === 0 && (estate.workers||[]).length === 0);
 }
 
+// Which empty state a list view should show. "No workers here" and "no workers match your
+// filters" are different facts and want different advice — telling someone to clear filters
+// they never set is the wrong help.
+function emptyKind(total, shown) {
+  if ((shown || 0) > 0) return 'rows';
+  return (total || 0) === 0 ? 'none' : 'nomatch';
+}
+
 function buildEstate(perSpace) {
   const targets = [], workers = [], environments = [], policies = [];
   perSpace.forEach(s => {
@@ -403,14 +411,14 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, isEmptyEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  buildEstate, isEmptyEstate, emptyKind, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, isEmptyEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    machineToTarget, buildEstate, isEmptyEstate, emptyKind, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -186,6 +186,58 @@ function isEmptyEstate(estate) {
   return !estate || ((estate.targets||[]).length === 0 && (estate.workers||[]).length === 0);
 }
 
+// Per-target activity comes from /api/{space}/machines/{id}/tasks — verified against a live
+// instance. Note /api/{space}/tasks?regarding={id} silently IGNORES the filter and returns the
+// whole task list; don't reach for it.
+function taskKind(name) {
+  switch (String(name || '')) {
+    case 'Deploy': return 'deploy';
+    case 'Health': return 'health';
+    case 'Upgrade': return 'upgrade';
+    case 'RunbookRun': return 'runbook';
+    default: return 'other';
+  }
+}
+function machineTaskRow(t) {
+  return {
+    id: t.Id,
+    kind: taskKind(t.Name),
+    name: t.Name || '',
+    // The API's Description already reads as a sentence ("Deploy X release 1.2.3 to Production"),
+    // so we show it rather than parsing project and version back out of it.
+    description: t.Description || t.Name || '',
+    state: t.State || '',
+    success: t.FinishedSuccessfully === true,
+    completed: t.CompletedTime || null,
+    projectId: t.ProjectId || null,
+    deploymentId: (t.Arguments && t.Arguments.DeploymentId) || null
+  };
+}
+// Fetched lazily when the detail route opens — this is the only data the boot payload
+// doesn't already carry. Each half degrades on its own: null means "we couldn't load it",
+// which the view must not render as "there is none".
+async function fetchMachineDetail(spaceId, machineId) {
+  const base = '/api/' + encodeURIComponent(spaceId) + '/machines/' + encodeURIComponent(machineId);
+  const [tasks, connection] = await Promise.all([
+    fetchJson(base + '/tasks?take=30').then(r => (r && r.Items) || []).catch(() => null),
+    fetchJson(base + '/connection').catch(() => null)
+  ]);
+  return { tasks, connection };
+}
+function machineActivityModel(tasks) {
+  const rows = (tasks || []).map(machineTaskRow)
+    .sort((a, b) => String(b.completed || '').localeCompare(String(a.completed || '')));
+  const of = kind => rows.filter(r => r.kind === kind);
+  const deployments = of('deploy');
+  return {
+    all: rows,
+    deployments,
+    runbooks: of('runbook'),
+    health: of('health'),
+    lastSuccessfulDeploy: deployments.find(r => r.success) || null
+  };
+}
+
 // Which empty state a list view should show. "No workers here" and "no workers match your
 // filters" are different facts and want different advice — telling someone to clear filters
 // they never set is the wrong help.
@@ -411,14 +463,14 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, isEmptyEstate, emptyKind, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  buildEstate, isEmptyEstate, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, isEmptyEstate, emptyKind, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    machineToTarget, buildEstate, isEmptyEstate, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -249,12 +249,30 @@ function machineTaskRow(t) {
 // doesn't already carry. Each half degrades on its own: null means "we couldn't load it",
 // which the view must not render as "there is none".
 async function fetchMachineDetail(spaceId, machineId) {
-  const base = '/api/' + encodeURIComponent(spaceId) + '/machines/' + encodeURIComponent(machineId);
-  const [tasks, connection] = await Promise.all([
+  const sp = encodeURIComponent(spaceId);
+  const base = '/api/' + sp + '/machines/' + encodeURIComponent(machineId);
+  // events?regarding= IS honoured, unlike tasks?regarding= — verified on a live instance:
+  // a space holding 159,294 events returns 22 for a machine-scoped query. A zero here is a
+  // real "nothing retained for this target", not a filter that quietly matches nothing.
+  const [tasks, connection, events] = await Promise.all([
     fetchJson(base + '/tasks?take=30').then(r => (r && r.Items) || []).catch(() => null),
-    fetchJson(base + '/connection').catch(() => null)
+    fetchJson(base + '/connection').catch(() => null),
+    fetchJson('/api/' + sp + '/events?regarding=' + encodeURIComponent(machineId) + '&take=20')
+      .then(r => (r && r.Items) || []).catch(() => null)
   ]);
-  return { tasks, connection };
+  return { tasks, connection, events };
+}
+
+// Octopus also returns MessageHtml, which carries anchors. We take the plain Message and
+// escape it at render time rather than injecting markup we didn't build.
+function eventsModel(events) {
+  return (events || []).map(e => ({
+    id: e.Id,
+    category: e.Category || '',
+    who: e.Username || (e.IsService ? 'system' : ''),
+    message: e.Message || '',
+    occurred: e.Occurred || null
+  })).sort((a, b) => String(b.occurred || '').localeCompare(String(a.occurred || '')));
 }
 function machineActivityModel(tasks) {
   const rows = (tasks || []).map(machineTaskRow)
@@ -507,14 +525,14 @@ function applyFilters(targets, filters, search) {
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
-  buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+  buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadEstate,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
-    machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
+    machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -30,6 +30,17 @@ function readConfig() {
   });
 }
 
+// Run `fn` over `items` with at most `limit` in flight at once; preserves input order.
+async function _mapLimit(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) { const i = next++; results[i] = await fn(items[i], i); }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
 async function loadEstate(serverUrl) {
   setServerUrl(serverUrl);
   let spaces;
@@ -38,7 +49,9 @@ async function loadEstate(serverUrl) {
   if (!spaces || !spaces.length) return { status: 'empty', spaces: [], perSpace: [] };
 
   let anyAuth = false;
-  const perSpace = (await Promise.all(spaces.map(async sp => {
+  // Cap how many spaces we hydrate at once so a many-space instance doesn't fire
+  // a huge concurrent burst of /all requests on load. Order is preserved.
+  const perSpace = (await _mapLimit(spaces, 4, async sp => {
     try {
       const [envs, policies, tenants, machines, workerpools, workers] = await Promise.all([
         fetchJson('/api/' + sp.Id + '/environments/all').catch(() => []),
@@ -50,7 +63,7 @@ async function loadEstate(serverUrl) {
       ]);
       return { sp, envs, policies, tenants, machines, workerpools, workers };
     } catch (e) { if (e && e.auth) anyAuth = true; return null; }
-  }))).filter(Boolean);
+  })).filter(Boolean);
 
   if (!perSpace.length) return { status: anyAuth ? 'auth' : 'error', spaces, perSpace: [] };
   const anyMachines = perSpace.some(s => (s.machines || []).length);
@@ -399,5 +412,5 @@ if (typeof module !== 'undefined') {
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
     machineToTarget, buildEstate, isEmptyEstate, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
-    vkey, majorVersion, versionBand, deriveLatest, agentsModel };
+    vkey, majorVersion, versionBand, deriveLatest, agentsModel, _mapLimit };
 }

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Infrastructure (PreAlpha) — Octopus AI Assistant</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="../api.js"></script>
+</head>
+<body>
+  <div class="ip-shell">
+    <!-- icon rail (52px) -->
+    <div class="ip-rail" aria-hidden="true"></div>
+    <!-- sidebar (216px) -->
+    <aside class="ip-sidebar">
+      <div class="ip-sidebar-title">Infrastructure</div>
+      <nav class="ip-nav">
+        <a href="#overview"       class="ip-nav-item" data-view="overview">Overview</a>
+        <a href="#targets"        class="ip-nav-item" data-view="targets">Deployment Targets</a>
+        <a href="#environments"   class="ip-nav-item" data-view="environments">Environments</a>
+        <a href="#machinepolicies" class="ip-nav-item" data-view="machinepolicies">Machine Policies</a>
+        <a href="#workers"        class="ip-nav-item" data-view="workers">Workers &amp; Worker Pools</a>
+        <a href="#agents"         class="ip-nav-item" data-view="agents">Deployment Agents</a>
+        <a href="#argocd"         class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
+      </nav>
+    </aside>
+    <!-- content -->
+    <main class="ip-main"><div id="main-content"></div></main>
+  </div>
+  <script src="data.js"></script>
+  <script src="views.js"></script>
+  <script src="onboarding.js"></script>
+  <script src="router.js"></script>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -13,6 +13,7 @@
     <div class="ip-rail" aria-hidden="true"></div>
     <!-- sidebar (216px) -->
     <aside class="ip-sidebar">
+      <div id="ip-space-switch" class="ip-space-switch"></div>
       <div class="ip-sidebar-title">Infrastructure</div>
       <nav class="ip-nav">
         <a href="#overview"       class="ip-nav-item" data-view="overview">Overview</a>

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -24,6 +24,7 @@
         <a href="#agents"         class="ip-nav-item" data-view="agents">Deployment Agents</a>
         <a href="#argocd"         class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
       </nav>
+      <div id="ip-theme-toggle" class="ip-theme-toggle"></div>
     </aside>
     <!-- content -->
     <main class="ip-main"><div id="main-content"></div></main>

--- a/dashboards/infrastructureprealpha/metadata.json
+++ b/dashboards/infrastructureprealpha/metadata.json
@@ -1,0 +1,3 @@
+{
+  "author_email": "lucy.spence@octopus.com"
+}

--- a/dashboards/infrastructureprealpha/onboarding.js
+++ b/dashboards/infrastructureprealpha/onboarding.js
@@ -17,7 +17,8 @@ const Onboarding = (function () {
       + '</div>'
       + '<section class="ip-card" style="margin-top:16px"><h4>One machine policy is ready to go</h4>'
       +   '<p class="ip-sub">Your Default Machine Policy runs a health check every day. New targets use it automatically — no setup needed.</p>'
-      +   '<a class="ip-link" href="' + Views.escHtml(base + '/machinepolicies') + '" target="_blank" rel="noopener">View policy →</a></section>';
+      +   '<a class="ip-link" href="' + Views.escHtml(base + '/machinepolicies') + '" target="_blank" rel="noopener">View policy →</a></section>'
+      + '<a class="ip-link" href="' + Views.escHtml(base + '/machines') + '" target="_blank" rel="noopener">New to deployment targets? Learn how targets work →</a>';
     document.querySelectorAll('.ip-nav-item').forEach(a => a.classList.remove('active'));
   }
   return { renderFirstRun };

--- a/dashboards/infrastructureprealpha/onboarding.js
+++ b/dashboards/infrastructureprealpha/onboarding.js
@@ -1,24 +1,46 @@
 'use strict';
 const Onboarding = (function () {
-  function card(title, body, cta, href) {
-    return '<section class="ip-setup-card"><h4>' + Views.escHtml(title) + '</h4>'
-      + '<p class="ip-sub">' + Views.escHtml(body) + '</p>'
-      + '<a class="ip-btn" href="' + Views.escHtml(href) + '" target="_blank" rel="noopener">' + Views.escHtml(cta) + '</a></section>';
+  var ICONS = {
+    target: '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="var(--color-blue-600)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="16" height="11" rx="1.5"/><path d="M7 17h6M10 14v3"/></svg>',
+    argo: '<svg width="20" height="20" viewBox="0 0 20 20" fill="var(--color-purple-600)"><path d="M10 2l7 4.5v7L10 18l-7-4.5v-7L10 2z"/></svg>',
+    worker: '<svg width="20" height="20" viewBox="0 0 20 20" fill="var(--fg2)"><rect x="4" y="3" width="4" height="14" rx="1"/><rect x="12" y="3" width="4" height="14" rx="1"/></svg>',
+    doc: '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--fg2)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2h9l5 5v15H6V2z"/><path d="M15 2v5h5"/><path d="M9 8h3M9 12h6M9 16h6"/></svg>',
+    octopus: '<svg viewBox="0 0 40 40" width="44" height="44" fill="var(--ring)"><path d="M32.3 25.9c-2.8-2.4-2.3-4.9-1-8 2.2-5.5-1.5-11.7-6.8-13.3C18.8 2.8 12.5 5.5 10.3 11.3c-.6 1.5-.7 3-.7 4.6.2 1.9 1 3.3 1.5 5 1 3.2-1.8 5.8-4.1 7.4-2.9 1.9-2.3 2.5-.6 2.6 1.5.1 2.8-.3 4-1 .6-.3 2.5-1.2 2.9-1.8-.8 1.7-2.3 4.6-1.4 6.4 1.2 2.3 4.2-2 4.8-2.8.5-.8 2.7-5.1 3.9-2.9 1.2 1.9.6 4.7 2.3 6.5 2 2.1 3.1-1.2 3.2-2.8 0-1-.4-6 1.9-3.8 1.3 1.3 3.2 4.4 5.4 4.2 2.4-.3-1.3-4.3-1.7-5 .3.3 3.3 2.2 3.4.6 0-1.2-1.9-2.2-2.7-2.8Z"/></svg>'
+  };
+
+  function csCard(opts) {
+    var classes = 'ip-cs-card' + (opts.primary ? ' ip-cs-card-primary' : '');
+    var badge = opts.primary ? '<span class="ip-cs-badge">START HERE</span>' : '';
+    var btnClass = opts.primary ? 'ip-btn' : 'ip-btn-secondary';
+    return '<section class="' + classes + '">' + badge
+      + '<div class="ip-cs-icon ip-cs-icon-' + opts.tone + '">' + ICONS[opts.icon] + '</div>'
+      + '<h4>' + Views.escHtml(opts.title) + '</h4>'
+      + '<p class="ip-sub">' + Views.escHtml(opts.body) + '</p>'
+      + '<a class="' + btnClass + '" href="' + Views.escHtml(opts.href) + '" target="_blank" rel="noopener">' + Views.escHtml(opts.cta) + '</a></section>';
   }
+
   function renderFirstRun(IP) {
     const base = String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure';
     document.getElementById('main-content').innerHTML = ''
-      + '<header class="ip-head"><h2>Set up your infrastructure</h2>'
-      +   '<p class="ip-sub">You don\'t have any infrastructure yet. Add a deployment target to give Octopus somewhere to deploy — most teams start here.</p></header>'
-      + '<div class="ip-grid">'
-      +   card('Add a deployment target','Connect a server, Kubernetes cluster, or cloud service where your projects will deploy.','Add target', base + '/machines/new')
-      +   card('Connect Argo CD','Link an externally-run Argo CD instance to track its connection and gateway health.','Connect instance', base)
-      +   card('Add a worker','Set up shared worker infrastructure to run deployment steps outside your targets.','Add worker', base + '/workers/new')
-      + '</div>'
-      + '<section class="ip-card" style="margin-top:16px"><h4>One machine policy is ready to go</h4>'
-      +   '<p class="ip-sub">Your Default Machine Policy runs a health check every day. New targets use it automatically — no setup needed.</p>'
-      +   '<a class="ip-link" href="' + Views.escHtml(base + '/machinepolicies') + '" target="_blank" rel="noopener">View policy →</a></section>'
-      + '<a class="ip-link" href="' + Views.escHtml(base + '/machines') + '" target="_blank" rel="noopener">New to deployment targets? Learn how targets work →</a>';
+      + '<div class="ip-cs">'
+      +   '<div class="ip-cs-header">' + ICONS.octopus
+      +     '<h2>Set up your infrastructure</h2>'
+      +     '<p class="ip-sub">You don\'t have any infrastructure yet. Add a deployment target to give Octopus somewhere to deploy — most teams start here.</p>'
+      +   '</div>'
+      +   '<div class="ip-cs-cards">'
+      +     csCard({primary:true, tone:'blue', icon:'target', title:'Add a deployment target', body:'Connect a server, Kubernetes cluster, or cloud service where your projects will deploy.', cta:'Add target', href: base + '/machines/new'})
+      +     csCard({tone:'purple', icon:'argo', title:'Connect Argo CD', body:'Link an externally-run Argo CD instance to track its connection and gateway health.', cta:'Connect instance', href: base})
+      +     csCard({tone:'slate', icon:'worker', title:'Add a worker', body:'Set up shared worker infrastructure to run deployment steps outside your targets.', cta:'Add worker', href: base + '/workers/new'})
+      +   '</div>'
+      +   '<section class="ip-cs-policy">'
+      +     '<div class="ip-cs-policy-left">' + ICONS.doc
+      +       '<div><h4>One machine policy is ready to go</h4>'
+      +       '<p class="ip-sub">Your Default Machine Policy runs a health check every day. New targets use it automatically — no setup needed.</p></div>'
+      +     '</div>'
+      +     '<a class="ip-link" href="' + Views.escHtml(base + '/machinepolicies') + '" target="_blank" rel="noopener">View policy →</a>'
+      +   '</section>'
+      +   '<a class="ip-link ip-cs-learn" href="' + Views.escHtml(base + '/machines') + '" target="_blank" rel="noopener">New to deployment targets? Learn how targets work →</a>'
+      + '</div>';
     document.querySelectorAll('.ip-nav-item').forEach(a => a.classList.remove('active'));
   }
   return { renderFirstRun };

--- a/dashboards/infrastructureprealpha/onboarding.js
+++ b/dashboards/infrastructureprealpha/onboarding.js
@@ -1,2 +1,25 @@
 'use strict';
-// Populated in later tasks.
+const Onboarding = (function () {
+  function card(title, body, cta, href) {
+    return '<section class="ip-setup-card"><h4>' + Views.escHtml(title) + '</h4>'
+      + '<p class="ip-sub">' + Views.escHtml(body) + '</p>'
+      + '<a class="ip-btn" href="' + Views.escHtml(href) + '" target="_blank" rel="noopener">' + Views.escHtml(cta) + '</a></section>';
+  }
+  function renderFirstRun(IP) {
+    const base = String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure';
+    document.getElementById('main-content').innerHTML = ''
+      + '<header class="ip-head"><h2>Set up your infrastructure</h2>'
+      +   '<p class="ip-sub">You don\'t have any infrastructure yet. Add a deployment target to give Octopus somewhere to deploy — most teams start here.</p></header>'
+      + '<div class="ip-grid">'
+      +   card('Add a deployment target','Connect a server, Kubernetes cluster, or cloud service where your projects will deploy.','Add target', base + '/machines/new')
+      +   card('Connect Argo CD','Link an externally-run Argo CD instance to track its connection and gateway health.','Connect instance', base)
+      +   card('Add a worker','Set up shared worker infrastructure to run deployment steps outside your targets.','Add worker', base + '/workers/new')
+      + '</div>'
+      + '<section class="ip-card" style="margin-top:16px"><h4>One machine policy is ready to go</h4>'
+      +   '<p class="ip-sub">Your Default Machine Policy runs a health check every day. New targets use it automatically — no setup needed.</p>'
+      +   '<a class="ip-link" href="' + Views.escHtml(base + '/machinepolicies') + '" target="_blank" rel="noopener">View policy →</a></section>';
+    document.querySelectorAll('.ip-nav-item').forEach(a => a.classList.remove('active'));
+  }
+  return { renderFirstRun };
+})();
+if (typeof module !== 'undefined') { module.exports = Onboarding; }

--- a/dashboards/infrastructureprealpha/onboarding.js
+++ b/dashboards/infrastructureprealpha/onboarding.js
@@ -1,0 +1,2 @@
+'use strict';
+// Populated in later tasks.

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -1,2 +1,28 @@
 'use strict';
-// Populated in later tasks.
+const Router = (function () {
+  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd'];
+  function setActive(view) {
+    document.querySelectorAll('.ip-nav-item').forEach(a =>
+      a.classList.toggle('active', a.getAttribute('data-view') === view));
+  }
+  function render() {
+    const el = document.getElementById('main-content');
+    const hash = (window.location.hash || '#overview').slice(1);
+    // target detail route: #targets/<id>
+    if (hash.indexOf('targets/') === 0) {
+      IP.detailId = decodeURIComponent(hash.slice('targets/'.length));
+      setActive('targets');
+      el.innerHTML = Views.renderTargetDetail(IP);
+      Views.bindTargetDetail && Views.bindTargetDetail(IP);
+      return;
+    }
+    const view = VIEWS.includes(hash) ? hash : 'overview';
+    setActive(view);
+    if (view === 'overview')  { el.innerHTML = Views.renderOverview(IP.estate.overview, IP.estate); }
+    else if (view === 'targets') { el.innerHTML = Views.renderTargets(IP); Views.bindTargets && Views.bindTargets(IP); }
+    else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
+  }
+  function init() { window.addEventListener('hashchange', render); render(); }
+  return { init, render };
+})();
+if (typeof module !== 'undefined') { module.exports = Router; }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -22,6 +22,7 @@ const Router = (function () {
     if (view === 'overview')  { el.innerHTML = Views.renderOverview(IP.estate.overview, IP.estate); }
     else if (view === 'targets') { el.innerHTML = Views.renderTargets(IP); Views.bindTargets && Views.bindTargets(IP); }
     else if (view === 'environments') { el.innerHTML = Views.renderEnvironments(IP); Views.bindEnvironments && Views.bindEnvironments(IP); }
+    else if (view === 'machinepolicies') { el.innerHTML = Views.renderMachinePolicies(IP); }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
   function init() { window.addEventListener('hashchange', render); render(); }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -24,6 +24,7 @@ const Router = (function () {
     else if (view === 'environments') { el.innerHTML = Views.renderEnvironments(IP); Views.bindEnvironments && Views.bindEnvironments(IP); }
     else if (view === 'machinepolicies') { el.innerHTML = Views.renderMachinePolicies(IP); }
     else if (view === 'workers') { el.innerHTML = Views.renderWorkers(IP); Views.bindWorkers && Views.bindWorkers(IP); }
+    else if (view === 'agents') { el.innerHTML = Views.renderAgents(IP); Views.bindAgents && Views.bindAgents(IP); }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
   function init() { window.addEventListener('hashchange', render); render(); }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -10,7 +10,8 @@ const Router = (function () {
     const hash = (window.location.hash || '#overview').slice(1);
     // target detail route: #targets/<id>
     if (hash.indexOf('targets/') === 0) {
-      IP.detailId = decodeURIComponent(hash.slice('targets/'.length));
+      let raw = hash.slice('targets/'.length);
+      try { IP.detailId = decodeURIComponent(raw); } catch (e) { IP.detailId = raw; }
       setActive('targets');
       el.innerHTML = Views.renderTargetDetail(IP);
       Views.bindTargetDetail && Views.bindTargetDetail(IP);

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -7,6 +7,10 @@ const Router = (function () {
   }
   function render() {
     const el = document.getElementById('main-content');
+    if (typeof Data !== 'undefined' && Data.isEmptyEstate && Data.isEmptyEstate(IP.estate)) {
+      Onboarding.renderFirstRun(IP);
+      return;
+    }
     const hash = (window.location.hash || '#overview').slice(1);
     // target detail route: #targets/<id>
     if (hash.indexOf('targets/') === 0) {

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -21,6 +21,7 @@ const Router = (function () {
     setActive(view);
     if (view === 'overview')  { el.innerHTML = Views.renderOverview(IP.estate.overview, IP.estate); }
     else if (view === 'targets') { el.innerHTML = Views.renderTargets(IP); Views.bindTargets && Views.bindTargets(IP); }
+    else if (view === 'environments') { el.innerHTML = Views.renderEnvironments(IP); Views.bindEnvironments && Views.bindEnvironments(IP); }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
   function init() { window.addEventListener('hashchange', render); render(); }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -25,6 +25,7 @@ const Router = (function () {
     else if (view === 'machinepolicies') { el.innerHTML = Views.renderMachinePolicies(IP); }
     else if (view === 'workers') { el.innerHTML = Views.renderWorkers(IP); Views.bindWorkers && Views.bindWorkers(IP); }
     else if (view === 'agents') { el.innerHTML = Views.renderAgents(IP); Views.bindAgents && Views.bindAgents(IP); }
+    else if (view === 'argocd') { el.innerHTML = Views.renderArgo(IP); }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
   function init() { window.addEventListener('hashchange', render); render(); }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -23,6 +23,7 @@ const Router = (function () {
     else if (view === 'targets') { el.innerHTML = Views.renderTargets(IP); Views.bindTargets && Views.bindTargets(IP); }
     else if (view === 'environments') { el.innerHTML = Views.renderEnvironments(IP); Views.bindEnvironments && Views.bindEnvironments(IP); }
     else if (view === 'machinepolicies') { el.innerHTML = Views.renderMachinePolicies(IP); }
+    else if (view === 'workers') { el.innerHTML = Views.renderWorkers(IP); Views.bindWorkers && Views.bindWorkers(IP); }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
   function init() { window.addEventListener('hashchange', render); render(); }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -1,0 +1,2 @@
+'use strict';
+// Populated in later tasks.

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -7,18 +7,15 @@ const Router = (function () {
   }
   function render() {
     const el = document.getElementById('main-content');
-    // Cold-start is per-view, not per-section. A space with no targets but nine
-    // environments still has something to show on Environments and Machine policies;
-    // blanking those out claims the space is empty when it isn't. Target-centric views
-    // (and a wholly bare space) still get first-run. The add-target walkthrough is never
-    // gated — an empty estate is exactly when it's wanted.
-    const rawHash = (window.location.hash || '#overview').slice(1);
-    const routeKey = rawHash.indexOf('targets/') === 0 && rawHash !== 'targets/new' ? 'targets' : rawHash;
-    if (typeof Data !== 'undefined' && Data.coldStartApplies && Data.coldStartApplies(routeKey, IP.estate)) {
+    const hash = (window.location.hash || '#overview').slice(1);
+    // Cold-start greets you on the landing view when there's no infrastructure; it never
+    // intercepts an explicit nav click. Every other view renders itself and shows its own
+    // empty state, so a space with no targets can still reach its environments, its
+    // machine policies, and the add-target walkthrough.
+    if (typeof Data !== 'undefined' && Data.coldStartApplies && Data.coldStartApplies(hash, IP.estate)) {
       Onboarding.renderFirstRun(IP);
       return;
     }
-    const hash = (window.location.hash || '#overview').slice(1);
     // add-target walkthrough: #targets/new — must be tested before the detail route below,
     // which would otherwise treat "new" as a machine id and render "target not found".
     if (hash === 'targets/new') {

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -7,6 +7,9 @@ const Router = (function () {
   }
   function render() {
     const el = document.getElementById('main-content');
+    // A space that failed to hydrate has no estate to route over, and rendering views
+    // against it would show zeros as though the space were empty.
+    if (IP.spaceError) { el.innerHTML = Views.stateView('error', IP.spaceError); return; }
     const hash = (window.location.hash || '#overview').slice(1);
     // Cold-start greets you on the landing view when there's no infrastructure; it never
     // intercepts an explicit nav click. Every other view renders itself and shows its own

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -7,11 +7,14 @@ const Router = (function () {
   }
   function render() {
     const el = document.getElementById('main-content');
-    // An empty scope shows cold-start for every route except the add-target walkthrough —
-    // an empty estate is precisely when someone wants that, so it must not bounce back.
+    // Cold-start is per-view, not per-section. A space with no targets but nine
+    // environments still has something to show on Environments and Machine policies;
+    // blanking those out claims the space is empty when it isn't. Target-centric views
+    // (and a wholly bare space) still get first-run. The add-target walkthrough is never
+    // gated — an empty estate is exactly when it's wanted.
     const rawHash = (window.location.hash || '#overview').slice(1);
-    if (rawHash !== 'targets/new'
-        && typeof Data !== 'undefined' && Data.isEmptyEstate && Data.isEmptyEstate(IP.estate)) {
+    const routeKey = rawHash.indexOf('targets/') === 0 && rawHash !== 'targets/new' ? 'targets' : rawHash;
+    if (typeof Data !== 'undefined' && Data.coldStartApplies && Data.coldStartApplies(routeKey, IP.estate)) {
       Onboarding.renderFirstRun(IP);
       return;
     }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -7,11 +7,23 @@ const Router = (function () {
   }
   function render() {
     const el = document.getElementById('main-content');
-    if (typeof Data !== 'undefined' && Data.isEmptyEstate && Data.isEmptyEstate(IP.estate)) {
+    // An empty scope shows cold-start for every route except the add-target walkthrough —
+    // an empty estate is precisely when someone wants that, so it must not bounce back.
+    const rawHash = (window.location.hash || '#overview').slice(1);
+    if (rawHash !== 'targets/new'
+        && typeof Data !== 'undefined' && Data.isEmptyEstate && Data.isEmptyEstate(IP.estate)) {
       Onboarding.renderFirstRun(IP);
       return;
     }
     const hash = (window.location.hash || '#overview').slice(1);
+    // add-target walkthrough: #targets/new — must be tested before the detail route below,
+    // which would otherwise treat "new" as a machine id and render "target not found".
+    if (hash === 'targets/new') {
+      setActive('targets');
+      el.innerHTML = Views.renderAddTarget(IP);
+      Views.bindAddTarget && Views.bindAddTarget(IP);
+      return;
+    }
     // target detail route: #targets/<id>
     if (hash.indexOf('targets/') === 0) {
       let raw = hash.slice('targets/'.length);

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -31,6 +31,16 @@ const Router = (function () {
       setActive('targets');
       el.innerHTML = Views.renderTargetDetail(IP);
       Views.bindTargetDetail && Views.bindTargetDetail(IP);
+      // Per-target tasks and connection aren't in the boot payload, so fetch them now and
+      // fill the cards when they land. The id is re-checked on resolve — by then the user
+      // may have navigated to a different target, or away entirely.
+      const wanted = IP.detailId;
+      const target = (IP.estate.targets || []).find(x => x.id === wanted);
+      if (target && Data.fetchMachineDetail) {
+        Data.fetchMachineDetail(target.spaceId, target.id)
+          .then(detail => { if (IP.detailId === wanted) Views.fillTargetDetail(IP, detail); })
+          .catch(() => { if (IP.detailId === wanted) Views.fillTargetDetail(IP, { tasks: null, connection: null }); });
+      }
       return;
     }
     const view = VIEWS.includes(hash) ? hash : 'overview';

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -245,3 +245,41 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-heat{text-align:center;font-variant-numeric:tabular-nums}
 .ip-hbar{display:flex;height:8px;border-radius:4px;overflow:hidden;flex:1}
 .ip-hbar span{display:block}
+
+/* Task B2 — unified Overview panel: donut + legend, health-by-type bars, environment heatmap */
+.ip-ov-panel{margin-bottom:16px}
+.ip-card-head{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px;margin-bottom:20px}
+.ip-card-head h4{margin:0;display:flex;align-items:baseline;gap:8px}
+.ip-count-inline{color:var(--fg2);font-weight:500;font-size:14px}
+.ip-card-actions{display:flex;align-items:center;gap:16px}
+.ip-card-actions .ip-link{margin-top:0}
+.ip-panel-cols{display:grid;grid-template-columns:minmax(240px,1fr) minmax(320px,1.4fr);gap:32px;
+  padding-bottom:20px;margin-bottom:20px;border-bottom:1px solid var(--border)}
+.ip-panel-left{display:flex;align-items:center;gap:28px;flex-wrap:wrap}
+.ip-donut-wrap{flex:0 0 auto}
+.ip-legend-big{display:flex;gap:24px;flex-wrap:wrap}
+.ip-legend-stat{display:flex;flex-direction:column;gap:6px}
+.ip-legend-label{display:flex;align-items:center;gap:6px;color:var(--fg2);font-size:13px}
+.ip-dot{width:8px;height:8px;border-radius:50%;display:inline-block;flex:0 0 auto}
+.ip-dot-healthy{background:var(--color-green-400)}
+.ip-dot-unhealthy{background:var(--color-red-400)}
+.ip-dot-disabled{background:var(--color-slate-300)}
+.ip-legend-num{font-size:28px;font-weight:600}
+.ip-num-healthy{color:var(--color-green-600)}
+.ip-num-unhealthy{color:var(--color-red-500)}
+.ip-num-disabled{color:var(--fg2)}
+.ip-subhead{margin:0 0 12px;font-size:13px;font-weight:600;color:var(--fg2);
+  text-transform:uppercase;letter-spacing:0.02em}
+.ip-type-rows{display:flex;flex-direction:column;gap:10px}
+.ip-type-row{display:flex;align-items:center;gap:12px}
+.ip-type-name{flex:0 0 110px;font-size:13px}
+.ip-type-bar{flex:1;min-width:0}
+.ip-type-bar .ip-bar{margin-bottom:0}
+.ip-type-counts{flex:0 0 auto;display:flex;gap:10px;min-width:44px;justify-content:flex-end;
+  font-size:13px;font-variant-numeric:tabular-nums}
+.ip-heatmap-head{display:flex;align-items:baseline;justify-content:space-between}
+.ip-heatmap-head .ip-subhead{margin:0}
+.ip-caption{font-size:12px;color:var(--fg2)}
+.ip-heatmap th,.ip-heatmap td{text-align:center}
+.ip-heatmap th:first-child,.ip-heatmap td:first-child{text-align:left}
+.ip-grid-below{margin-top:16px}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -187,9 +187,10 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border-radius:50%;animation:ip-spin 0.8s linear infinite;margin:0 auto 12px}
 @keyframes ip-spin{to{transform:rotate(360deg)}}
 
-.ip-head{margin-bottom:20px;display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap}
+.ip-head{margin-bottom:20px}
 .ip-head h2{margin:0 0 4px}
 .ip-sub{color:var(--fg2);margin:0}
+.ip-head-actions{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap}
 .ip-head-pill{display:inline-flex;align-items:center;gap:4px;flex-shrink:0;padding:6px 12px;
   border:1px solid var(--border);border-radius:999px;background:var(--secondary);
   color:var(--fg1);font-size:13px;font-weight:500;text-decoration:none;white-space:nowrap}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -315,3 +315,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-policy-usage{color:var(--fg2);font-size:13px;margin:0 0 10px}
 .ip-policy-kv{display:flex;flex-direction:column}
 .ip-policy-kv .ip-kv{font-size:12px}
+
+/* Task C3 — workers: worker-pool summary cards above a faceted worker list, mirroring targets */
+.ip-pool-grid{grid-template-columns:repeat(auto-fill,minmax(220px,1fr));margin-bottom:16px}
+.ip-pool-card .ip-card-head{margin-bottom:8px}
+.ip-chipx-pool{background:var(--color-purple-100);border-color:var(--color-purple-200);color:var(--color-purple-700)}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -167,6 +167,11 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rail{background:var(--chrome-bg);border-right:1px solid var(--border)}
 .ip-sidebar{background:var(--chrome-bg);border-right:1px solid var(--border);
   padding:12px 8px;overflow-y:auto}
+.ip-space-switch{padding:0 2px 12px;border-bottom:1px solid var(--border);margin-bottom:8px}
+.ip-space-lbl{display:block;font-size:11px;font-weight:600;text-transform:uppercase;
+  letter-spacing:.02em;color:var(--fg2);padding:0 8px 4px}
+.ip-space-select{width:100%;font-size:13px;padding:6px 8px;border-radius:var(--radius-sm);
+  border:1px solid var(--border);background:var(--background);color:var(--fg1)}
 .ip-sidebar-title{font-weight:600;font-size:13px;color:var(--fg2);
   padding:6px 10px 10px}
 .ip-nav{display:flex;flex-direction:column;gap:2px}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -233,3 +233,15 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-setup-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:20px}
 .ip-setup-card h4{margin:0 0 6px}
 .ip-setup-card .ip-btn{margin-top:12px;display:inline-block}
+
+.ip-pill{display:inline-block;padding:2px 8px;border-radius:10px;font-size:12px;font-weight:500}
+.ip-pill-healthy{background:var(--color-green-200);color:var(--color-green-700)}
+.ip-pill-unhealthy{background:var(--color-red-200);color:var(--color-red-700)}
+.ip-pill-disabled{background:var(--muted);color:var(--fg2)}
+.ip-chipx{display:inline-block;padding:2px 8px;border:1px solid var(--border);border-radius:12px;font-size:12px;color:var(--fg1);background:var(--card)}
+.ip-chipx-env{background:var(--color-blue-100);border-color:var(--color-blue-200);color:var(--color-blue-700)}
+.ip-donut-pct{font-size:22px;font-weight:600;fill:var(--fg1)}
+.ip-donut-sub{font-size:11px;fill:var(--fg2)}
+.ip-heat{text-align:center;font-variant-numeric:tabular-nums}
+.ip-hbar{display:flex;height:8px;border-radius:4px;overflow:hidden;flex:1}
+.ip-hbar span{display:block}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -307,3 +307,11 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-env-sub .ip-env-targets{margin:4px 0 10px 26px;width:calc(100% - 26px);font-size:12px;background:var(--card)}
 .ip-env-sub .ip-env-targets th,.ip-env-sub .ip-env-targets td{padding:5px 8px}
 .ip-env-sub .ip-env-targets .ip-sub{padding:12px 8px;text-align:center}
+
+/* Task C2 — machine policies: one card per policy, Default badge, governed settings as key/value rows */
+.ip-policy-grid{grid-template-columns:repeat(auto-fill,minmax(280px,1fr))}
+.ip-policy-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
+.ip-policy-head h4{margin:0}
+.ip-policy-usage{color:var(--fg2);font-size:13px;margin:0 0 10px}
+.ip-policy-kv{display:flex;flex-direction:column}
+.ip-policy-kv .ip-kv{font-size:12px}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -336,3 +336,20 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pool-grid{grid-template-columns:repeat(auto-fill,minmax(220px,1fr));margin-bottom:16px}
 .ip-pool-card .ip-card-head{margin-bottom:8px}
 .ip-chipx-pool{background:var(--color-purple-100);border-color:var(--color-purple-200);color:var(--color-purple-700)}
+
+/* Task P3-2 — Deployment agents: Tentacle/Kubernetes tabs, KPI row, version distribution bars */
+.ip-tabs{display:flex;gap:4px;margin-bottom:20px;border-bottom:1px solid var(--border)}
+.ip-tab{background:none;border:0;padding:8px 14px;font-size:13px;font-weight:500;
+  color:var(--fg2);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
+.ip-tab:hover{color:var(--fg1)}
+.ip-tab-active{color:var(--fg1);border-bottom-color:var(--ring);font-weight:600}
+.ip-kpi-grid{grid-template-columns:repeat(4,1fr);margin-bottom:16px}
+.ip-dist-card{margin-bottom:16px}
+.ip-dist-rows{display:flex;flex-direction:column;gap:8px}
+.ip-dist-row{display:flex;align-items:center;gap:12px}
+.ip-dist-label{flex:0 0 100px;font-size:13px;font-variant-numeric:tabular-nums;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.ip-dist-bar{flex:1;height:10px;border-radius:5px;background:var(--muted);overflow:hidden}
+.ip-dist-bar span{display:block;height:100%;border-radius:5px}
+.ip-dist-count{flex:0 0 auto;min-width:32px;text-align:right;font-size:13px;
+  color:var(--fg2);font-variant-numeric:tabular-nums}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -187,9 +187,13 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border-radius:50%;animation:ip-spin 0.8s linear infinite;margin:0 auto 12px}
 @keyframes ip-spin{to{transform:rotate(360deg)}}
 
-.ip-head{margin-bottom:20px}
+.ip-head{margin-bottom:20px;display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap}
 .ip-head h2{margin:0 0 4px}
 .ip-sub{color:var(--fg2);margin:0}
+.ip-head-pill{display:inline-flex;align-items:center;gap:4px;flex-shrink:0;padding:6px 12px;
+  border:1px solid var(--border);border-radius:999px;background:var(--secondary);
+  color:var(--fg1);font-size:13px;font-weight:500;text-decoration:none;white-space:nowrap}
+.ip-head-pill:hover{border-color:var(--ring);color:var(--ring)}
 .ip-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}
 .ip-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:16px;box-shadow:var(--shadow-xs)}
 .ip-card-wide{grid-column:1/-1}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -359,6 +359,40 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-dist-count{flex:0 0 auto;min-width:32px;text-align:right;font-size:13px;
   color:var(--fg2);font-variant-numeric:tabular-nums}
 
+/* Task S2 — cold-start restyle: centred column, icon cards, primary/secondary buttons */
+.ip-cs{max-width:1100px;margin:0 auto}
+.ip-cs-header{text-align:center;margin-bottom:28px}
+.ip-cs-header svg{display:block;margin:0 auto 12px}
+.ip-cs-header h2{margin:0 0 6px}
+.ip-cs-header .ip-sub{max-width:560px;margin:0 auto}
+.ip-cs-cards{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-bottom:16px}
+@media (max-width:760px){.ip-cs-cards{grid-template-columns:1fr}}
+.ip-cs-card{position:relative;background:var(--card);border:1px solid var(--border);
+  border-radius:var(--radius-lg);padding:20px 24px;box-shadow:var(--shadow-xs);text-align:left}
+.ip-cs-card h4{margin:0 0 6px}
+.ip-cs-card .ip-sub{margin:0 0 14px}
+.ip-cs-card-primary{border-color:var(--ring);box-shadow:0 0 0 1px var(--ring),var(--shadow-xs)}
+.ip-cs-badge{display:inline-block;margin-bottom:10px;padding:2px 8px;border-radius:10px;
+  font-size:11px;font-weight:600;letter-spacing:0.03em;text-transform:uppercase;
+  background:var(--color-green-200);color:var(--color-green-700)}
+.ip-cs-icon{width:40px;height:40px;border-radius:var(--radius-md);display:flex;
+  align-items:center;justify-content:center;margin-bottom:14px}
+.ip-cs-icon-blue{background:var(--color-blue-200)}
+.ip-cs-icon-purple{background:var(--color-purple-200)}
+.ip-cs-icon-slate{background:var(--muted)}
+.ip-btn-secondary{display:inline-block;background:transparent;color:var(--fg1);
+  border:1px solid var(--input);padding:6px 12px;border-radius:var(--radius-sm);text-decoration:none}
+.ip-btn-secondary:hover{background:var(--secondary);text-decoration:none}
+.ip-cs-policy{display:flex;align-items:center;justify-content:space-between;gap:16px;
+  flex-wrap:wrap;background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);
+  padding:20px 24px;box-shadow:var(--shadow-xs);margin-bottom:20px}
+.ip-cs-policy-left{display:flex;align-items:center;gap:16px}
+.ip-cs-policy-left svg{flex:0 0 auto}
+.ip-cs-policy-left h4{margin:0 0 4px}
+.ip-cs-policy-left .ip-sub{margin:0}
+.ip-cs-policy .ip-link{margin-top:0;white-space:nowrap}
+.ip-cs-learn{display:block;text-align:center}
+
 /* Task S1 — dark/light theme toggle: compact control pinned to the sidebar bottom */
 .ip-theme-toggle{margin-top:auto;padding-top:12px;border-top:1px solid var(--border)}
 .ip-theme-btn{display:flex;align-items:center;gap:8px;width:100%;padding:7px 10px;

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -1,0 +1,177 @@
+/* ============================================================================
+   Octopus design tokens — ported from the Claude Design source colors_and_type.css.
+   Product UI uses --font-sans (system fonts). The source's @font-face Inter rule
+   was intentionally dropped: this dashboard ships no font files and uses system
+   fonts for product surfaces (Inter is brand/marketing only in the source).
+   Paste this block at the TOP of styles.css.
+   ============================================================================ */
+:root {
+  --font-sans:  BlinkMacSystemFont, -apple-system, "Segoe UI", "Oxygen Sans",
+                Ubuntu, sans-serif, "Apple Color Emoji",
+                "Segoe UI Emoji", "Segoe UI Symbol";
+  --font-brand: BlinkMacSystemFont, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:  ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono",
+                "Oxygen Mono", "Ubuntu Mono", monospace;
+
+  --fs-xs:   12px;  --fs-sm:   14px;  --fs-base: 16px;  --fs-md:   18px;
+  --fs-lg:   20px;  --fs-xl:   24px;  --fs-2xl:  28px;  --fs-3xl:  32px;
+  --fs-4xl:  40px;  --fs-5xl:  48px;
+
+  --fw-regular: 400; --fw-medium: 500; --fw-semibold: 600; --fw-bold: 700;
+  --lh-tight: 1.2; --lh-snug: 1.35; --lh-base: 1.5; --lh-loose: 1.7;
+
+  --color-blue-100:  #F2F8FD;  --color-blue-200:  #CDE4F7;  --color-blue-300:  #87BFEC;
+  --color-blue-400:  #449BE1;  --color-blue-500:  #1A77CA;  --color-blue-600:  #155EA0;
+  --color-blue-700:  #0F4778;  --color-blue-800:  #093051;  --color-blue-900:  #041A2D;
+
+  --color-green-100: #EEFAF5;  --color-green-200: #B8E7D3;  --color-green-300: #5ECD9E;
+  --color-green-400: #00AB62;  --color-green-500: #00874D;  --color-green-600: #006A3D;
+  --color-green-700: #00502E;  --color-green-800: #00361F;  --color-green-900: #001E11;
+
+  --color-red-100:   #FFF3F3;  --color-red-200:   #FFD8D8;  --color-red-300:   #FF9F9F;
+  --color-red-400:   #FF5D5D;  --color-red-500:   #D63D3D;  --color-red-600:   #AA3030;
+  --color-red-700:   #802424;  --color-red-800:   #571818;  --color-red-900:   #310E0E;
+
+  --color-orange-100:#FFF5ED;  --color-orange-200:#FFDABF;  --color-orange-300:#FFA461;
+  --color-orange-400:#EA7325;  --color-orange-500:#C45317;  --color-orange-600:#A13C14;
+  --color-orange-700:#7E2812;  --color-orange-800:#59170D;  --color-orange-900:#340B07;
+
+  --color-yellow-100:#FFF7D9;  --color-yellow-200:#FFDF62;  --color-yellow-300:#E5B203;
+  --color-yellow-400:#B98F02;  --color-yellow-500:#927002;  --color-yellow-600:#745801;
+  --color-yellow-700:#584201;  --color-yellow-800:#3B2C00;  --color-yellow-900:#201800;
+
+  --color-purple-100:#F8F5FD;  --color-purple-200:#E7DEF8;  --color-purple-300:#C5AEEE;
+  --color-purple-400:#A683E5;  --color-purple-500:#895ED3;  --color-purple-600:#7043B7;
+  --color-purple-700:#572B97;  --color-purple-800:#3B1D66;  --color-purple-900:#21103A;
+
+  --color-slate-100: #F5F6F8;  --color-slate-200: #DEE1E6;  --color-slate-300: #B2B9C5;
+  --color-slate-400: #8A96A7;  --color-slate-500: #68778D;  --color-slate-600: #515D70;
+  --color-slate-700: #3D4653;  --color-slate-800: #282F38;  --color-slate-900: #16191F;
+
+  --color-navy-100:  #F4F6F8;  --color-navy-200:  #DAE2E9;  --color-navy-300:  #A9BBCB;
+  --color-navy-400:  #7C98B4;  --color-navy-500:  #557999;  --color-navy-600:  #3E607D;
+  --color-navy-700:  #2E475D;  --color-navy-800:  #1F303F;  --color-navy-900:  #111A23;
+
+  --color-grey-100:  #F7F7F7;  --color-grey-200:  #E1E1E1;  --color-grey-300:  #B9B9B9;
+  --color-grey-400:  #959595;  --color-grey-500:  #757575;  --color-grey-600:  #5C5C5C;
+  --color-grey-700:  #454545;  --color-grey-800:  #2E2E2E;  --color-grey-900:  #191919;
+
+  --background:         #FFFFFF;
+  --foreground:         #282F38;
+  --fg1:                #282F38;
+  --fg2:                #68778D;
+  --fg3:                #8A96A7;
+  --card:               #FFFFFF;
+  --card-foreground:    #282F38;
+  --popover:            #FFFFFF;
+  --primary:            #00874D;
+  --primary-foreground: #FFFFFF;
+  --secondary:          #F5F6F8;
+  --muted:              #DEE1E6;
+  --muted-foreground:   #68778D;
+  --accent:             #F5F6F8;
+  --destructive:        #D63D3D;
+  --border:             #DEE1E6;
+  --input:              #B2B9C5;
+  --ring:               #1A77CA;
+  --chrome-bg:          #F5F6F8;
+  --chrome-active:      #449BE1;
+
+  --radius:             0.375rem;
+  --radius-sm:          calc(var(--radius) * 0.6);
+  --radius-md:          calc(var(--radius) * 0.8);
+  --radius-lg:          var(--radius);
+  --radius-xl:          calc(var(--radius) * 1.4);
+  --radius-2xl:         calc(var(--radius) * 1.8);
+
+  --shadow-xs:      0 2px 4px rgba(0,0,0,0.10), 0 2px 12px rgba(0,0,0,0.06);
+  --shadow-sm:      0 4px 8px rgba(0,0,0,0.10), 0 2px 8px rgba(0,0,0,0.06);
+  --shadow-md:      0 6px 12px rgba(0,0,0,0.10), 0 2px 12px rgba(0,0,0,0.06);
+  --shadow-lg:      0 12px 24px -4px rgba(0,0,0,0.10), 0 4px 16px rgba(0,0,0,0.08);
+  --shadow-drawer:  -12px 4px 24px -4px rgba(0,0,0,0.10), -4px 0 16px rgba(0,0,0,0.08);
+  --shadow-focus:   0 0 0 1px #1A77CA, 0 0 0 5px rgba(26,119,202,0.32);
+
+  --space-1:  4px;  --space-2:  8px;  --space-3:  12px; --space-4:  16px;
+  --space-5:  20px; --space-6:  24px; --space-8:  32px; --space-10: 40px;
+  --space-12: 48px; --space-16: 64px;
+}
+
+.dark {
+  --background:         #111A23;
+  --foreground:         #F4F6F8;
+  --fg1:                #F4F6F8;
+  --fg2:                #A9BBCB;
+  --fg3:                #7C98B4;
+  --card:               #1F303F;
+  --card-foreground:    #F4F6F8;
+  --popover:            #111A23;
+  --primary:            #00874D;
+  --secondary:          #1F303F;
+  --muted:              #2E475D;
+  --muted-foreground:   #7C98B4;
+  --accent:             #2E475D;
+  --destructive:        #D63D3D;
+  --border:             #2E475D;
+  --input:              #2E475D;
+  --ring:               #449BE1;
+  --chrome-bg:          #192A3A;
+  --chrome-active:      #449BE1;
+}
+
+html, body {
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  line-height: var(--lh-base);
+  color: var(--fg1);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, .h1 { font-size: var(--fs-4xl); font-weight: var(--fw-semibold); line-height: var(--lh-tight); letter-spacing: -0.02em; color: var(--fg1); }
+h2, .h2 { font-size: var(--fs-3xl); font-weight: var(--fw-semibold); line-height: var(--lh-tight); letter-spacing: -0.015em; color: var(--fg1); }
+h3, .h3 { font-size: var(--fs-2xl); font-weight: var(--fw-semibold); line-height: var(--lh-snug);  color: var(--fg1); }
+h4, .h4 { font-size: var(--fs-xl);  font-weight: var(--fw-semibold); line-height: var(--lh-snug);  color: var(--fg1); }
+h5, .h5 { font-size: var(--fs-lg);  font-weight: var(--fw-semibold); line-height: var(--lh-snug);  color: var(--fg1); }
+h6, .h6 { font-size: var(--fs-md);  font-weight: var(--fw-semibold); line-height: var(--lh-snug);  color: var(--fg1); }
+
+p,  .body  { font-size: var(--fs-base); line-height: var(--lh-base); color: var(--fg1); }
+.small     { font-size: var(--fs-sm);   line-height: var(--lh-base); color: var(--fg2); }
+.caption   { font-size: var(--fs-xs);   line-height: var(--lh-base); color: var(--fg2); letter-spacing: 0.01em; }
+.lead      { font-size: var(--fs-lg);   line-height: var(--lh-snug); color: var(--fg1); }
+
+code, .code, kbd, pre {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--secondary);
+  color: var(--fg1);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+pre { padding: var(--space-4); overflow-x: auto; line-height: var(--lh-snug); }
+
+a, .link { color: var(--ring); text-decoration: none; transition: color 120ms ease; }
+a:hover, .link:hover { color: #155EA0; text-decoration: underline; }
+.dark a:hover, .dark .link:hover { color: #87BFEC; }
+
+.font-brand { font-family: var(--font-brand); }
+.font-sans  { font-family: var(--font-sans); }
+.font-mono  { font-family: var(--font-mono); }
+
+hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--space-4) 0; }
+
+.ip-shell{height:100vh;display:grid;grid-template-columns:52px 216px 1fr;
+  background:var(--background);color:var(--fg1);font-family:var(--font-sans);
+  font-size:14px;overflow:hidden}
+.ip-rail{background:var(--chrome-bg);border-right:1px solid var(--border)}
+.ip-sidebar{background:var(--chrome-bg);border-right:1px solid var(--border);
+  padding:12px 8px;overflow-y:auto}
+.ip-sidebar-title{font-weight:600;font-size:13px;color:var(--fg2);
+  padding:6px 10px 10px}
+.ip-nav{display:flex;flex-direction:column;gap:2px}
+.ip-nav-item{display:block;padding:7px 10px;border-radius:var(--radius-sm);
+  color:var(--fg1);text-decoration:none;font-size:13px}
+.ip-nav-item:hover{background:var(--secondary);text-decoration:none}
+.ip-nav-item.active{background:var(--secondary);color:var(--fg1);font-weight:600}
+.ip-main{overflow-y:auto;padding:24px 28px}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -181,3 +181,23 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-spinner{width:28px;height:28px;border:3px solid var(--muted);border-top-color:var(--ring);
   border-radius:50%;animation:ip-spin 0.8s linear infinite;margin:0 auto 12px}
 @keyframes ip-spin{to{transform:rotate(360deg)}}
+
+.ip-head{margin-bottom:20px}
+.ip-head h2{margin:0 0 4px}
+.ip-sub{color:var(--fg2);margin:0}
+.ip-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}
+.ip-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:16px;box-shadow:var(--shadow-xs)}
+.ip-card-wide{grid-column:1/-1}
+.ip-card h4{margin:0 0 12px}
+.ip-big{font-size:32px;font-weight:600}
+.ip-pct{color:var(--fg2);margin-bottom:8px}
+.ip-bar{display:flex;height:8px;border-radius:4px;overflow:hidden;margin-bottom:10px}
+.ip-bar span{display:block}
+.ip-legend{list-style:none;padding:0;margin:0;display:flex;gap:16px;color:var(--fg2);font-size:13px}
+.ip-pools{list-style:none;padding:0;margin:10px 0 0}
+.ip-pools li{display:flex;justify-content:space-between;padding:4px 0;border-top:1px solid var(--border)}
+.ip-table{width:100%;border-collapse:collapse;font-size:13px}
+.ip-table th,.ip-table td{text-align:left;padding:6px 8px;border-bottom:1px solid var(--border)}
+.ip-table th{color:var(--fg2);font-weight:600}
+.ip-link{display:inline-block;margin-top:10px;color:var(--ring)}
+.ip-tag{font-size:11px;background:var(--color-purple-200);color:var(--color-purple-700);padding:2px 6px;border-radius:4px;vertical-align:middle}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -296,3 +296,14 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-targets td{white-space:nowrap}
 .ip-group td{background:var(--secondary);color:var(--fg2);font-weight:600;font-size:11px;
   letter-spacing:0.04em;padding:8px}
+
+/* Task C1 — environments heatmap: expandable rows with a nested targets sub-table */
+.ip-env-heatmap{width:100%}
+.ip-env-row{cursor:pointer}
+.ip-env-row:hover{background:var(--secondary)}
+.ip-env-row-open{background:var(--secondary);font-weight:600}
+.ip-env-toggle{display:inline-block;width:14px;color:var(--fg2)}
+.ip-env-sub td{padding:0;border-bottom:1px solid var(--border)}
+.ip-env-sub .ip-env-targets{margin:4px 0 10px 26px;width:calc(100% - 26px);font-size:12px;background:var(--card)}
+.ip-env-sub .ip-env-targets th,.ip-env-sub .ip-env-targets td{padding:5px 8px}
+.ip-env-sub .ip-env-targets .ip-sub{padding:12px 8px;text-align:center}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -225,3 +225,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-empty h3{color:var(--fg1)}
 .ip-pager{display:flex;align-items:center;gap:8px;margin-top:12px;color:var(--fg2)}
 .ip-pager button{padding:4px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--card);cursor:pointer}
+
+.ip-kv{display:flex;justify-content:space-between;padding:5px 0;border-top:1px solid var(--border);font-size:13px}
+.ip-kv:first-of-type{border-top:0}
+.ip-kv span{color:var(--fg2)}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -316,6 +316,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-env-row{cursor:pointer}
 .ip-env-row:hover{background:var(--secondary)}
 .ip-env-row-open{background:var(--secondary);font-weight:600}
+.ip-env-cell{cursor:pointer}
+.ip-env-cell:hover{outline:1px solid var(--ring);outline-offset:-1px}
 .ip-env-toggle{display:inline-block;width:14px;color:var(--fg2)}
 .ip-env-sub td{padding:0;border-bottom:1px solid var(--border)}
 .ip-env-sub .ip-env-targets{margin:4px 0 10px 26px;width:calc(100% - 26px);font-size:12px;background:var(--card)}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -285,8 +285,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-heatmap-head{display:flex;align-items:baseline;justify-content:space-between}
 .ip-heatmap-head .ip-subhead{margin:0}
 .ip-caption{font-size:12px;color:var(--fg2)}
+.ip-heatmap{table-layout:fixed}
 .ip-heatmap th,.ip-heatmap td{text-align:center}
 .ip-heatmap th:first-child,.ip-heatmap td:first-child{text-align:left}
+/* Task R3 — shared column widths so the Overview and Environments heatmaps line up row-for-row */
+.ip-heatmap th:nth-child(1),.ip-heatmap td:nth-child(1){width:36%}
+.ip-heatmap th:nth-child(2),.ip-heatmap td:nth-child(2){width:16%}
+.ip-heatmap th:nth-child(3),.ip-heatmap td:nth-child(3){width:16%}
+.ip-heatmap th:nth-child(4),.ip-heatmap td:nth-child(4){width:16%}
+.ip-heatmap th:nth-child(5),.ip-heatmap td:nth-child(5){width:16%}
+.ip-heatmap td:first-child a{color:inherit;text-decoration:none}
+.ip-heatmap td:first-child a:hover{text-decoration:underline}
 .ip-grid-below{margin-top:16px}
 
 /* Task B3 — targets list: name link, tag chip tone, health-grouped rows, column widths */

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -175,3 +175,9 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-nav-item:hover{background:var(--secondary);text-decoration:none}
 .ip-nav-item.active{background:var(--secondary);color:var(--fg1);font-weight:600}
 .ip-main{overflow-y:auto;padding:24px 28px}
+
+.ip-state{max-width:520px;margin:64px auto;text-align:center;color:var(--fg2)}
+.ip-state h3{color:var(--fg1);margin-bottom:8px}
+.ip-spinner{width:28px;height:28px;border:3px solid var(--muted);border-top-color:var(--ring);
+  border-radius:50%;animation:ip-spin 0.8s linear infinite;margin:0 auto 12px}
+@keyframes ip-spin{to{transform:rotate(360deg)}}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -152,8 +152,8 @@ code, .code, kbd, pre {
 pre { padding: var(--space-4); overflow-x: auto; line-height: var(--lh-snug); }
 
 a, .link { color: var(--ring); text-decoration: none; transition: color 120ms ease; }
-a:hover, .link:hover { color: #155EA0; text-decoration: underline; }
-.dark a:hover, .dark .link:hover { color: #87BFEC; }
+a:hover, .link:hover { color: var(--color-blue-600); text-decoration: underline; }
+.dark a:hover, .dark .link:hover { color: var(--color-blue-300); }
 
 .font-brand { font-family: var(--font-brand); }
 .font-sans  { font-family: var(--font-sans); }
@@ -166,7 +166,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   font-size:14px;overflow:hidden}
 .ip-rail{background:var(--chrome-bg);border-right:1px solid var(--border)}
 .ip-sidebar{background:var(--chrome-bg);border-right:1px solid var(--border);
-  padding:12px 8px;overflow-y:auto}
+  padding:12px 8px;overflow-y:auto;display:flex;flex-direction:column;min-height:0}
 .ip-space-switch{padding:0 2px 12px;border-bottom:1px solid var(--border);margin-bottom:8px}
 .ip-space-lbl{display:block;font-size:11px;font-weight:600;text-transform:uppercase;
   letter-spacing:.02em;color:var(--fg2);padding:0 8px 4px}
@@ -358,3 +358,12 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-dist-bar span{display:block;height:100%;border-radius:5px}
 .ip-dist-count{flex:0 0 auto;min-width:32px;text-align:right;font-size:13px;
   color:var(--fg2);font-variant-numeric:tabular-nums}
+
+/* Task S1 — dark/light theme toggle: compact control pinned to the sidebar bottom */
+.ip-theme-toggle{margin-top:auto;padding-top:12px;border-top:1px solid var(--border)}
+.ip-theme-btn{display:flex;align-items:center;gap:8px;width:100%;padding:7px 10px;
+  border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--background);
+  color:var(--fg1);font-size:13px;font-family:inherit;cursor:pointer}
+.ip-theme-btn:hover{background:var(--secondary);border-color:var(--ring)}
+.ip-theme-btn svg{flex:0 0 auto;color:var(--fg2)}
+.ip-theme-btn-label{flex:1;text-align:left}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -229,3 +229,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-kv{display:flex;justify-content:space-between;padding:5px 0;border-top:1px solid var(--border);font-size:13px}
 .ip-kv:first-of-type{border-top:0}
 .ip-kv span{color:var(--fg2)}
+
+.ip-setup-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);padding:20px}
+.ip-setup-card h4{margin:0 0 6px}
+.ip-setup-card .ip-btn{margin-top:12px;display:inline-block}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -283,3 +283,16 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-heatmap th,.ip-heatmap td{text-align:center}
 .ip-heatmap th:first-child,.ip-heatmap td:first-child{text-align:left}
 .ip-grid-below{margin-top:16px}
+
+/* Task B3 — targets list: name link, tag chip tone, health-grouped rows, column widths */
+.ip-target-link{color:var(--ring);font-weight:600;text-decoration:none}
+.ip-target-link:hover{text-decoration:underline}
+.ip-chipx-tag{background:var(--color-purple-100);border-color:var(--color-purple-200);color:var(--color-purple-700)}
+.ip-targets-scroll{overflow-x:auto}
+.ip-targets{table-layout:auto;width:100%}
+.ip-targets th:nth-child(1),.ip-targets td:nth-child(1){min-width:160px}
+.ip-targets th:nth-child(3),.ip-targets td:nth-child(3),
+.ip-targets th:nth-child(4),.ip-targets td:nth-child(4){white-space:nowrap}
+.ip-targets td{white-space:nowrap}
+.ip-group td{background:var(--secondary);color:var(--fg2);font-weight:600;font-size:11px;
+  letter-spacing:0.04em;padding:8px}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -201,3 +201,27 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-table th{color:var(--fg2);font-weight:600}
 .ip-link{display:inline-block;margin-top:10px;color:var(--ring)}
 .ip-tag{font-size:11px;background:var(--color-purple-200);color:var(--color-purple-700);padding:2px 6px;border-radius:4px;vertical-align:middle}
+
+.ip-targets-wrap{display:grid;grid-template-columns:240px 1fr;gap:20px}
+.ip-facets{font-size:13px}
+.ip-facet-title{font-weight:600;margin-bottom:8px}
+.ip-facet{margin-bottom:14px}
+.ip-facet-h{color:var(--fg2);font-weight:600;margin-bottom:4px}
+.ip-opt{display:flex;align-items:center;gap:6px;padding:3px 0;cursor:pointer}
+.ip-opt span{flex:1}
+.ip-opt b{color:var(--fg2);font-weight:500}
+.ip-chips{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px}
+.ip-chip{border:1px solid var(--border);background:var(--secondary);border-radius:12px;padding:2px 8px;cursor:pointer;font-size:12px}
+.ip-clear{border:0;background:none;color:var(--ring);cursor:pointer}
+.ip-toolbar{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+.ip-search{flex:1;padding:7px 10px;border:1px solid var(--input);border-radius:var(--radius-sm)}
+.ip-count{color:var(--fg2)}
+.ip-btn{background:var(--primary);color:var(--primary-foreground);padding:7px 12px;border-radius:var(--radius-sm);text-decoration:none}
+.ip-btn:hover{text-decoration:none}
+.ip-row{cursor:pointer}
+.ip-row:hover{background:var(--secondary)}
+.ip-row-sub{color:var(--fg2);font-size:12px}
+.ip-empty{text-align:center;color:var(--fg2);padding:48px}
+.ip-empty h3{color:var(--fg1)}
+.ip-pager{display:flex;align-items:center;gap:8px;margin-top:12px;color:var(--fg2)}
+.ip-pager button{padding:4px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--card);cursor:pointer}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -461,3 +461,4 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-env-icon{vertical-align:-2px;margin-right:6px}
 .ip-env-name{vertical-align:middle}
 .ip-btn-secondary{background:transparent;color:var(--ring);border:1px solid var(--ring)}
+.ip-env-cell:focus-visible,.ip-heat:focus-visible{outline:none;box-shadow:var(--shadow-focus);position:relative;z-index:1}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -447,3 +447,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-prev-pool-n{font-size:var(--fs-2xl);color:var(--fg1);margin:8px 0}
 .ip-prev-pool-n span{font-size:var(--fs-sm);color:var(--fg2)}
 .ip-prev-pool-bar{height:4px;border-radius:2px;background:var(--color-green-400)}
+
+/* ── Environments toolbar ─────────────────────────────────────────────────── */
+.ip-env-toolbar{display:flex;align-items:center;gap:12px;margin:16px 0 8px}
+.ip-env-search{flex:0 1 420px}
+.ip-segs{display:flex;gap:8px}
+.ip-seg{background:transparent;border:1px solid var(--border);color:var(--fg2);
+  padding:6px 12px;border-radius:var(--radius-sm);cursor:pointer;font:inherit;font-size:var(--fs-sm)}
+.ip-seg:hover{border-color:var(--input)}
+.ip-seg.active{border-color:var(--ring);color:var(--ring)}
+.ip-env-toolbar .ip-count{margin-left:auto}
+.ip-env-caption{justify-content:flex-end;margin-bottom:6px}
+.ip-env-icon{vertical-align:-2px;margin-right:6px}
+.ip-env-name{vertical-align:middle}
+.ip-btn-secondary{background:transparent;color:var(--ring);border:1px solid var(--ring)}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -235,6 +235,19 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-empty h3{color:var(--fg1)}
 .ip-empty p{margin:8px auto 16px;max-width:44ch}
 .ip-empty .ip-btn{display:inline-block}
+
+/* Add-target walkthrough */
+.ip-type-grid{grid-template-columns:repeat(3,minmax(220px,1fr));margin-top:8px}
+.ip-type-card{display:block;text-align:left;font:inherit;color:inherit;cursor:pointer}
+.ip-type-card:hover{border-color:var(--ring)}
+.ip-type-card h4{margin:0 0 6px}
+.ip-type-dir{display:block;margin-top:10px;font-size:12px;color:var(--fg2);border-top:1px solid var(--border);padding-top:8px}
+.ip-addtarget{max-width:640px}
+.ip-addtarget h4{margin:16px 0 6px}
+.ip-addtarget h4:first-child{margin-top:0}
+.ip-needs{margin:0 0 4px;padding-left:20px;color:var(--fg1)}
+.ip-needs li{margin:4px 0}
+.ip-addtarget .ip-btn{display:inline-block;margin-top:12px}
 .ip-pager{display:flex;align-items:center;gap:8px;margin-top:12px;color:var(--fg2)}
 .ip-pager button{padding:4px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--card);cursor:pointer}
 

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -462,3 +462,4 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-env-name{vertical-align:middle}
 .ip-btn-secondary{background:transparent;color:var(--ring);border:1px solid var(--ring)}
 .ip-env-cell:focus-visible,.ip-heat:focus-visible{outline:none;box-shadow:var(--shadow-focus);position:relative;z-index:1}
+.ip-ev-who{color:var(--fg2);white-space:nowrap;text-align:right}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -233,6 +233,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-row-sub{color:var(--fg2);font-size:12px}
 .ip-empty{text-align:center;color:var(--fg2);padding:48px}
 .ip-empty h3{color:var(--fg1)}
+.ip-empty p{margin:8px auto 16px;max-width:44ch}
+.ip-empty .ip-btn{display:inline-block}
 .ip-pager{display:flex;align-items:center;gap:8px;margin-top:12px;color:var(--fg2)}
 .ip-pager button{padding:4px 10px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--card);cursor:pointer}
 

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -421,3 +421,29 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-card-wide{grid-column:1 / -1}
 .ip-card-wide .ip-table td{padding:6px 8px;vertical-align:top}
 .ip-when{color:var(--fg2);white-space:nowrap;text-align:right}
+
+/* ── Designed zero states ─────────────────────────────────────────────────── */
+.ip-zero{background:var(--card);border:1px solid var(--border);border-radius:var(--radius-lg);
+  padding:56px 24px;text-align:center;display:flex;flex-direction:column;align-items:center;gap:0}
+.ip-zero-icon{width:56px;height:56px;border-radius:var(--radius-lg);background:var(--secondary);
+  display:flex;align-items:center;justify-content:center;margin-bottom:20px}
+.ip-zero h3{font-size:var(--fs-xl);margin:0 0 8px}
+.ip-zero-body{color:var(--fg2);max-width:60ch;margin:0 0 20px}
+.ip-zero .ip-btn{display:inline-block}
+.ip-zero-learn{margin-top:14px}
+
+/* Sample content, deliberately muted and labelled so it can't read as real data. */
+.ip-preview{margin-top:28px;opacity:.62}
+.ip-preview-head{border-top:1px solid var(--border);margin-bottom:10px;padding-top:12px}
+.ip-preview-label{font-size:var(--fs-xs);letter-spacing:.08em;text-transform:uppercase;color:var(--fg2)}
+.ip-preview .ip-sub{margin:0 0 12px}
+.ip-prev-table{width:100%}
+.ip-prev-group td{background:var(--secondary);font-size:var(--fs-xs);letter-spacing:.06em;
+  text-transform:uppercase;color:var(--fg2)}
+.ip-prev-name{color:var(--ring)}
+.ip-prev-sub{color:var(--fg2);font-size:var(--fs-xs)}
+.ip-prev-pools{grid-template-columns:repeat(3,1fr)}
+.ip-prev-pool-name{display:flex;align-items:center;gap:8px;color:var(--fg1);font-weight:var(--fw-medium)}
+.ip-prev-pool-n{font-size:var(--fs-2xl);color:var(--fg1);margin:8px 0}
+.ip-prev-pool-n span{font-size:var(--fs-sm);color:var(--fg2)}
+.ip-prev-pool-bar{height:4px;border-radius:2px;background:var(--color-green-400)}

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -416,3 +416,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-theme-btn:hover{background:var(--secondary);border-color:var(--ring)}
 .ip-theme-btn svg{flex:0 0 auto;color:var(--fg2)}
 .ip-theme-btn-label{flex:1;text-align:left}
+
+/* Target-detail activity cards */
+.ip-card-wide{grid-column:1 / -1}
+.ip-card-wide .ip-table td{padding:6px 8px;vertical-align:top}
+.ip-when{color:var(--fg2);white-space:nowrap;text-align:right}

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1,2 +1,13 @@
 'use strict';
-// Populated in later tasks.
+const Views = (function () {
+  function escHtml(s) { return String(s == null ? '' : s)
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+  function stateView(kind, detail) {
+    if (kind === 'loading') return '<div class="ip-state"><div class="ip-spinner"></div><p>Loading your infrastructure…</p></div>';
+    if (kind === 'auth') return '<div class="ip-state"><h3>Sign in to Octopus</h3>'
+      + '<p>Your session isn\'t authenticated. Open your Octopus instance, sign in, then reopen this dashboard.</p></div>';
+    return '<div class="ip-state"><h3>Couldn\'t load infrastructure</h3><p>' + escHtml(detail || 'Unknown error') + '</p></div>';
+  }
+  return { escHtml, stateView };
+})();
+if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -8,6 +8,47 @@ const Views = (function () {
       + '<p>Your session isn\'t authenticated. Open your Octopus instance, sign in, then reopen this dashboard.</p></div>';
     return '<div class="ip-state"><h3>Couldn\'t load infrastructure</h3><p>' + escHtml(detail || 'Unknown error') + '</p></div>';
   }
-  return { escHtml, stateView };
+  function bar(healthy, unhealthy, disabled) {
+    const t = healthy + unhealthy + disabled || 1;
+    const pc = n => (n / t * 100).toFixed(1) + '%';
+    return '<div class="ip-bar">'
+      + '<span style="width:' + pc(healthy) + ';background:var(--color-green-400)"></span>'
+      + '<span style="width:' + pc(unhealthy) + ';background:var(--color-red-400)"></span>'
+      + '<span style="width:' + pc(disabled) + ';background:var(--color-slate-300)"></span></div>';
+  }
+  function renderOverview(ov, estate) {
+    const typeRows = ov.byType.map(r =>
+      '<tr><td>' + escHtml(r.name) + '</td><td>' + r.healthy + '</td><td>' + r.unhealthy + '</td></tr>').join('');
+    const envRows = ov.byEnv.slice(0,5).map(r =>
+      '<tr><td>' + escHtml(r.name) + '</td><td>' + r.total + '</td><td>' + r.healthy + '</td><td>'
+      + r.unhealthy + '</td><td>' + r.disabled + '</td></tr>').join('');
+    const pools = ov.workers.pools.map(p =>
+      '<li><span>' + escHtml(p.name) + '</span><b>' + p.count + '</b></li>').join('');
+    return ''
+      + '<header class="ip-head"><h2>Infrastructure overview</h2>'
+      + '<p class="ip-sub">A diagnostic snapshot of your deployment estate.</p></header>'
+      + '<div class="ip-grid">'
+      +   '<section class="ip-card"><h4>Deployment targets</h4>'
+      +     '<div class="ip-big">' + ov.total + '</div>'
+      +     '<div class="ip-pct">' + ov.healthyPct + '% healthy</div>'
+      +     bar(ov.healthy, ov.unhealthy, ov.disabled)
+      +     '<ul class="ip-legend"><li>Healthy ' + ov.healthy + '</li>'
+      +       '<li>Unhealthy ' + ov.unhealthy + '</li><li>Disabled ' + ov.disabled + '</li></ul>'
+      +     '<a class="ip-link" href="#targets">Open list →</a></section>'
+      +   '<section class="ip-card"><h4>Health by target type</h4>'
+      +     '<table class="ip-table"><thead><tr><th>Type</th><th>Healthy</th><th>Unhealthy</th></tr></thead>'
+      +     '<tbody>' + (typeRows || '<tr><td colspan="3">No targets</td></tr>') + '</tbody></table></section>'
+      +   '<section class="ip-card ip-card-wide"><h4>Health by environment</h4>'
+      +     '<table class="ip-table"><thead><tr><th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>'
+      +     '<tbody>' + (envRows || '<tr><td colspan="5">No environments</td></tr>') + '</tbody></table>'
+      +     '<a class="ip-link" href="#environments">View all environments →</a></section>'
+      +   '<section class="ip-card"><h4>Workers</h4><div class="ip-big">' + ov.workers.total + '</div>'
+      +     '<ul class="ip-legend"><li>' + ov.workers.healthy + ' Healthy</li><li>' + ov.workers.unhealthy + ' Unhealthy</li></ul>'
+      +     '<ul class="ip-pools">' + pools + '</ul><a class="ip-link" href="#workers">Open →</a></section>'
+      +   '<section class="ip-card"><h4>Argo CD <span class="ip-tag">Early access</span></h4>'
+      +     '<p class="ip-sub">Wired in a later phase. Shows connections, gateway health, and managed apps when the instance exposes Argo CD.</p></section>'
+      + '</div>';
+  }
+  return { escHtml, stateView, renderOverview };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -228,6 +228,61 @@ const Views = (function () {
       + '</div>';
   }
   function bindTargetDetail(IP) { /* back link is a plain hash anchor; nothing to wire yet */ }
+  function _envAddUrl() {
+    let base = '';
+    try { base = (typeof IP !== 'undefined' && IP && IP.serverUrl) || ''; } catch (e) { base = ''; }
+    return String(base).replace(/\/$/, '') + '/app#/infrastructure/environments/create';
+  }
+  function _envTargetRow(t) {
+    return '<tr class="ip-row-static">'
+      + '<td>' + escHtml(t.name) + '</td>'
+      + '<td>' + escHtml(t.type) + '</td>'
+      + '<td>' + pill(t.healthKey, t.health) + '</td>'
+      + '<td>' + chip(t.tag, 'tag') + '</td>'
+      + '<td>' + escHtml(t.tenant) + '</td></tr>';
+  }
+  function _envRow(r, maxHealthy, maxUnhealthy, expanded) {
+    const sub = expanded
+      ? '<tr class="ip-env-sub"><td colspan="5"><table class="ip-table ip-env-targets"><thead><tr>'
+        + '<th>Deployment target</th><th>Type</th><th>Health</th><th>Target tag</th><th>Tenant</th></tr></thead><tbody>'
+        + (r.targets.length ? r.targets.map(_envTargetRow).join('') : '<tr><td colspan="5" class="ip-sub">No targets in this environment</td></tr>')
+        + '</tbody></table></td></tr>'
+      : '';
+    return '<tr class="ip-row ip-env-row' + (expanded ? ' ip-env-row-open' : '') + '" data-env="' + escHtml(r.name) + '">'
+      + '<td><span class="ip-env-toggle">' + (expanded ? '▾' : '▸') + '</span>' + escHtml(r.name) + '</td>'
+      + '<td>' + r.total + '</td>'
+      + heatCell(r.healthy, maxHealthy, 'good')
+      + heatCell(r.unhealthy, maxUnhealthy, 'bad')
+      + '<td>' + r.disabled + '</td></tr>' + sub;
+  }
+  function renderEnvironments(IP) {
+    const rows = Data.environmentsModel(IP.estate.targets, IP.estate.environments);
+    const maxHealthy = rows.reduce((m, r) => Math.max(m, r.healthy), 0);
+    const maxUnhealthy = rows.reduce((m, r) => Math.max(m, r.unhealthy), 0);
+    IP.envExpanded = IP.envExpanded || {};
+    const body = rows.map(r => _envRow(r, maxHealthy, maxUnhealthy, !!IP.envExpanded[r.name])).join('');
+    return ''
+      + '<header class="ip-head"><h2>Environments</h2>'
+      +   '<p class="ip-sub">Infrastructure through the lens of your deployment pipeline. Expand an environment to see its targets.</p></header>'
+      + '<section class="ip-card">'
+      +   '<div class="ip-card-head"><h4>Environments <span class="ip-count-inline">' + rows.length + '</span></h4>'
+      +     '<div class="ip-card-actions"><a class="ip-link" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>'
+      +   '</div>'
+      +   '<table class="ip-table ip-heatmap ip-env-heatmap"><thead><tr>'
+      +     '<th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>'
+      +   '<tbody>' + (body || '<tr><td colspan="5">No environments</td></tr>') + '</tbody></table>'
+      + '</section>';
+  }
+  function bindEnvironments(IP) {
+    const root = document.getElementById('main-content');
+    root.querySelectorAll('.ip-env-row').forEach(r => r.addEventListener('click', () => {
+      const name = r.getAttribute('data-env');
+      IP.envExpanded = IP.envExpanded || {};
+      IP.envExpanded[name] = !IP.envExpanded[name];
+      root.innerHTML = renderEnvironments(IP);
+      bindEnvironments(IP);
+    }));
+  }
   function bindTargets(IP) {
     const root = document.getElementById('main-content');
     const rerender = () => { root.innerHTML = renderTargets(IP); bindTargets(IP); };
@@ -255,6 +310,7 @@ const Views = (function () {
     }));
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
+    renderEnvironments, bindEnvironments,
     pill, chip, healthBar, donut, heatCell };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -560,6 +560,34 @@ const Views = (function () {
       +   '<a class="ip-link" href="' + escHtml(infraUrl) + '" target="_blank" rel="noopener">Open Infrastructure in Octopus →</a>'
       + '</section>';
   }
+  // Inline sun/moon glyphs — no icon fonts/external resources. The button always shows the icon
+  // for the mode you'd switch TO (sun while dark, moon while light), matching common toggle UX.
+  const _sunSvg = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" '
+    + 'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<circle cx="12" cy="12" r="4"></circle>'
+    + '<path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2'
+    + 'M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path></svg>';
+  const _moonSvg = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" '
+    + 'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>';
+  function renderThemeToggle(IP) {
+    const dark = IP.theme === 'dark';
+    const icon = dark ? _sunSvg : _moonSvg;
+    const label = dark ? 'Switch to light mode' : 'Switch to dark mode';
+    return '<button type="button" id="ip-theme-btn" class="ip-theme-btn" aria-label="' + escHtml(label) + '">'
+      + icon + '<span class="ip-theme-btn-label">' + escHtml(dark ? 'Light mode' : 'Dark mode') + '</span></button>';
+  }
+  function bindThemeToggle(IP) {
+    const el = document.getElementById('ip-theme-btn');
+    if (!el) return;
+    el.addEventListener('click', () => {
+      IP.theme = IP.theme === 'dark' ? 'light' : 'dark';
+      document.documentElement.classList.toggle('dark', IP.theme === 'dark');
+      try { localStorage.setItem('iprealpha:theme', IP.theme); } catch (e) { /* ignore persistence failures */ }
+      const container = document.getElementById('ip-theme-toggle');
+      if (container) { container.innerHTML = renderThemeToggle(IP); bindThemeToggle(IP); }
+    });
+  }
   function renderSpaceSwitch(IP) {
     const opts = ['<option value=""' + (!IP.spaceId ? ' selected' : '') + '>All spaces</option>']
       .concat((IP.spaces || []).map(s => '<option value="' + escHtml(s.Id) + '"'
@@ -582,6 +610,7 @@ const Views = (function () {
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo,
-    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch };
+    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,
+    renderThemeToggle, bindThemeToggle };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -62,6 +62,8 @@ const Views = (function () {
     return String(base).replace(/\/$/, '') + '/app#/infrastructure/machines';
   }
   function renderOverview(ov, estate) {
+    const ab = (ov.agents && ov.agents.behind) || 0;
+    const agentsPillText = ab === 0 ? 'all up to date' : ab + ' behind';
     const typeRows = ov.byType.map(r =>
       '<div class="ip-type-row">'
       + '<div class="ip-type-name">' + escHtml(r.name) + '</div>'
@@ -79,8 +81,11 @@ const Views = (function () {
     const pools = ov.workers.pools.map(p =>
       '<li><span>' + escHtml(p.name) + '</span><b>' + p.count + '</b></li>').join('');
     return ''
-      + '<header class="ip-head"><h2>Infrastructure overview</h2>'
-      + '<p class="ip-sub">A diagnostic snapshot of your deployment estate.</p></header>'
+      + '<header class="ip-head">'
+      +   '<div class="ip-head-text"><h2>Infrastructure overview</h2>'
+      +     '<p class="ip-sub">A diagnostic snapshot of your deployment estate.</p></div>'
+      +   '<a class="ip-head-pill" href="#agents">Deployment agent versions (Tentacles &amp; K8s) · ' + agentsPillText + ' →</a>'
+      + '</header>'
       + '<section class="ip-card ip-ov-panel">'
       +   '<div class="ip-card-head">'
       +     '<h4>Deployment targets <span class="ip-count-inline">' + ov.total + '</span></h4>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -45,32 +45,69 @@ const Views = (function () {
     const base = tone === 'bad' ? '214,61,61' : '0,171,98'; // red / green rgb
     return '<td class="ip-heat" style="background:rgba(' + base + ',' + (0.12 + a * 0.7).toFixed(2) + ')">' + value + '</td>';
   }
+  // The infrastructure machines page lives on the Octopus instance itself, whose base URL isn't
+  // part of the overviewModel shape (ov, estate) this view is contracted to accept. dashboard.js
+  // sets a global `IP.serverUrl` once config is read, well before any view renders, so this reads
+  // it defensively rather than widening renderOverview's signature.
+  function _octopusMachinesUrl() {
+    let base = '';
+    try { base = (typeof IP !== 'undefined' && IP && IP.serverUrl) || ''; } catch (e) { base = ''; }
+    return String(base).replace(/\/$/, '') + '/app#/infrastructure/machines';
+  }
   function renderOverview(ov, estate) {
     const typeRows = ov.byType.map(r =>
-      '<tr><td>' + escHtml(r.name) + '</td><td>' + r.healthy + '</td><td>' + r.unhealthy + '</td></tr>').join('');
-    const envRows = ov.byEnv.slice(0,5).map(r =>
-      '<tr><td>' + escHtml(r.name) + '</td><td>' + r.total + '</td><td>' + r.healthy + '</td><td>'
-      + r.unhealthy + '</td><td>' + r.disabled + '</td></tr>').join('');
+      '<div class="ip-type-row">'
+      + '<div class="ip-type-name">' + escHtml(r.name) + '</div>'
+      + '<div class="ip-type-bar">' + healthBar(r.healthy, r.unhealthy, 0) + '</div>'
+      + '<div class="ip-type-counts"><span class="ip-num-healthy">' + r.healthy + '</span>'
+      +   '<span class="ip-num-unhealthy">' + r.unhealthy + '</span></div></div>').join('');
+    const envTop = ov.byEnv.slice(0,5);
+    const maxHealthy = envTop.reduce((m,r)=>Math.max(m, r.healthy), 0);
+    const maxUnhealthy = envTop.reduce((m,r)=>Math.max(m, r.unhealthy), 0);
+    const envRows = envTop.map(r =>
+      '<tr><td>' + escHtml(r.name) + '</td><td>' + r.total + '</td>'
+      + heatCell(r.healthy, maxHealthy, 'good')
+      + heatCell(r.unhealthy, maxUnhealthy, 'bad')
+      + '<td>' + r.disabled + '</td></tr>').join('');
     const pools = ov.workers.pools.map(p =>
       '<li><span>' + escHtml(p.name) + '</span><b>' + p.count + '</b></li>').join('');
     return ''
       + '<header class="ip-head"><h2>Infrastructure overview</h2>'
       + '<p class="ip-sub">A diagnostic snapshot of your deployment estate.</p></header>'
-      + '<div class="ip-grid">'
-      +   '<section class="ip-card"><h4>Deployment targets</h4>'
-      +     '<div class="ip-big">' + ov.total + '</div>'
-      +     '<div class="ip-pct">' + ov.healthyPct + '% healthy</div>'
-      +     bar(ov.healthy, ov.unhealthy, ov.disabled)
-      +     '<ul class="ip-legend"><li>Healthy ' + ov.healthy + '</li>'
-      +       '<li>Unhealthy ' + ov.unhealthy + '</li><li>Disabled ' + ov.disabled + '</li></ul>'
-      +     '<a class="ip-link" href="#targets">Open list →</a></section>'
-      +   '<section class="ip-card"><h4>Health by target type</h4>'
-      +     '<table class="ip-table"><thead><tr><th>Type</th><th>Healthy</th><th>Unhealthy</th></tr></thead>'
-      +     '<tbody>' + (typeRows || '<tr><td colspan="3">No targets</td></tr>') + '</tbody></table></section>'
-      +   '<section class="ip-card ip-card-wide"><h4>Health by environment</h4>'
-      +     '<table class="ip-table"><thead><tr><th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>'
+      + '<section class="ip-card ip-ov-panel">'
+      +   '<div class="ip-card-head">'
+      +     '<h4>Deployment targets <span class="ip-count-inline">' + ov.total + '</span></h4>'
+      +     '<div class="ip-card-actions">'
+      +       '<a class="ip-link" href="' + escHtml(_octopusMachinesUrl()) + '" target="_blank" rel="noopener">Re-run health checks</a>'
+      +       '<a class="ip-link" href="#targets">Open list →</a>'
+      +     '</div>'
+      +   '</div>'
+      +   '<div class="ip-panel-cols">'
+      +     '<div class="ip-panel-left">'
+      +       '<div class="ip-donut-wrap">' + donut(ov.healthyPct) + '</div>'
+      +       '<div class="ip-legend-big">'
+      +         '<div class="ip-legend-stat"><div class="ip-legend-label"><span class="ip-dot ip-dot-healthy"></span>Healthy</div>'
+      +           '<div class="ip-legend-num ip-num-healthy">' + ov.healthy + '</div></div>'
+      +         '<div class="ip-legend-stat"><div class="ip-legend-label"><span class="ip-dot ip-dot-unhealthy"></span>Unhealthy</div>'
+      +           '<div class="ip-legend-num ip-num-unhealthy">' + ov.unhealthy + '</div></div>'
+      +         '<div class="ip-legend-stat"><div class="ip-legend-label"><span class="ip-dot ip-dot-disabled"></span>Disabled</div>'
+      +           '<div class="ip-legend-num ip-num-disabled">' + ov.disabled + '</div></div>'
+      +       '</div>'
+      +     '</div>'
+      +     '<div class="ip-panel-right">'
+      +       '<h5 class="ip-subhead">Health by target type</h5>'
+      +       '<div class="ip-type-rows">' + (typeRows || '<p class="ip-sub">No targets</p>') + '</div>'
+      +     '</div>'
+      +   '</div>'
+      +   '<div class="ip-heatmap-block">'
+      +     '<div class="ip-heatmap-head"><h5 class="ip-subhead">Health by environment</h5>'
+      +       '<span class="ip-caption">Cell intensity = share of estate</span></div>'
+      +     '<table class="ip-table ip-heatmap"><thead><tr><th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>'
       +     '<tbody>' + (envRows || '<tr><td colspan="5">No environments</td></tr>') + '</tbody></table>'
-      +     '<a class="ip-link" href="#environments">View all environments →</a></section>'
+      +     '<a class="ip-link" href="#environments">View all environments →</a>'
+      +   '</div>'
+      + '</section>'
+      + '<div class="ip-grid ip-grid-below">'
       +   '<section class="ip-card"><h4>Workers</h4><div class="ip-big">' + ov.workers.total + '</div>'
       +     '<ul class="ip-legend"><li>' + ov.workers.healthy + ' Healthy</li><li>' + ov.workers.unhealthy + ' Unhealthy</li></ul>'
       +     '<ul class="ip-pools">' + pools + '</ul><a class="ip-link" href="#workers">Open →</a></section>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -21,6 +21,30 @@ const Views = (function () {
       + '<span style="width:' + pc(unhealthy) + ';background:var(--color-red-400)"></span>'
       + '<span style="width:' + pc(disabled) + ';background:var(--color-slate-300)"></span></div>';
   }
+  // Shared render helpers (Task B1) — consumed by B2/B3/C1-C3.
+  function healthBar(healthy, unhealthy, disabled) { return bar(healthy, unhealthy, disabled); }
+  function pill(kind, text) {
+    return '<span class="ip-pill ip-pill-' + escHtml(kind) + '">' + escHtml(text) + '</span>';
+  }
+  function chip(text, tone) {
+    return '<span class="ip-chipx ip-chipx-' + escHtml(tone || 'neutral') + '">' + escHtml(text) + '</span>';
+  }
+  function donut(pct) {
+    const p = Math.max(0, Math.min(100, Math.round(pct || 0)));
+    const R = 52, C = 2 * Math.PI * R, off = C * (1 - p / 100);
+    return '<svg class="ip-donut" viewBox="0 0 128 128" width="128" height="128">'
+      + '<circle cx="64" cy="64" r="' + R + '" fill="none" stroke="var(--muted)" stroke-width="14"/>'
+      + '<circle cx="64" cy="64" r="' + R + '" fill="none" stroke="var(--color-green-400)" stroke-width="14"'
+      + ' stroke-linecap="round" stroke-dasharray="' + C.toFixed(1) + '" stroke-dashoffset="' + off.toFixed(1) + '"'
+      + ' transform="rotate(-90 64 64)"/>'
+      + '<text x="64" y="60" text-anchor="middle" class="ip-donut-pct">' + p + '%</text>'
+      + '<text x="64" y="80" text-anchor="middle" class="ip-donut-sub">healthy</text></svg>';
+  }
+  function heatCell(value, max, tone) {
+    const a = max > 0 ? (value / max) : 0;
+    const base = tone === 'bad' ? '214,61,61' : '0,171,98'; // red / green rgb
+    return '<td class="ip-heat" style="background:rgba(' + base + ',' + (0.12 + a * 0.7).toFixed(2) + ')">' + value + '</td>';
+  }
   function renderOverview(ov, estate) {
     const typeRows = ov.byType.map(r =>
       '<tr><td>' + escHtml(r.name) + '</td><td>' + r.healthy + '</td><td>' + r.unhealthy + '</td></tr>').join('');
@@ -55,7 +79,7 @@ const Views = (function () {
       + '</div>';
   }
   const IP_PAGE_SIZE = 100;
-  function chip(key, value, label) {
+  function filterChip(key, value, label) {
     return '<button class="ip-chip" data-key="' + escHtml(key) + '" data-value="' + escHtml(value) + '">'
       + escHtml(label) + ' ✕</button>';
   }
@@ -70,7 +94,7 @@ const Views = (function () {
     const chips = [];
     Object.keys(IP.filters||{}).forEach(k => (IP.filters[k]||[]).forEach(v => {
       const f = facets.find(x=>x.key===k); const o = f && f.options.find(x=>x.value===v);
-      chips.push(chip(k, v, (f?f.label:k) + ': ' + (o?o.label:v)));
+      chips.push(filterChip(k, v, (f?f.label:k) + ': ' + (o?o.label:v)));
     }));
 
     const facetHtml = facets.map(f => f.options.length ? '<div class="ip-facet"><div class="ip-facet-h">'
@@ -158,6 +182,7 @@ const Views = (function () {
       window.location.hash = '#targets/' + encodeURIComponent(r.getAttribute('data-id'));
     }));
   }
-  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail };
+  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
+    pill, chip, healthBar, donut, heatCell };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -468,6 +468,80 @@ const Views = (function () {
       window.location.hash = '#targets/' + encodeURIComponent(r.getAttribute('data-id'));
     }));
   }
+  // ─── Deployment agents (Task P3-2) ──────────────────────────────────────
+  function _agentTabBar(tab) {
+    return '<div class="ip-tabs">'
+      + '<button type="button" class="ip-tab' + (tab === 'tentacle' ? ' ip-tab-active' : '') + '" data-tab="tentacle">Tentacle</button>'
+      + '<button type="button" class="ip-tab' + (tab === 'kubernetes' ? ' ip-tab-active' : '') + '" data-tab="kubernetes">Kubernetes</button>'
+      + '</div>';
+  }
+  function _bandColor(band) {
+    if (band === 'green') return 'var(--color-green-400)';
+    if (band === 'yellow') return 'var(--color-yellow-300)';
+    if (band === 'red') return 'var(--color-red-400)';
+    return 'var(--color-slate-300)';
+  }
+  function _distRow(d, max) {
+    const pct = max > 0 ? Math.max(2, Math.round(d.count / max * 100)) : 0;
+    return '<div class="ip-dist-row">'
+      + '<div class="ip-dist-label">' + escHtml(d.version) + '</div>'
+      + '<div class="ip-dist-bar"><span style="width:' + pct + '%;background:' + _bandColor(d.band) + '"></span></div>'
+      + '<div class="ip-dist-count">' + d.count + '</div></div>';
+  }
+  // Row model (from Data.agentsModel) has no machine id, only name/env/version/band/behind/policy,
+  // so "Upgrade" links out to the general Octopus machines list rather than a specific machine —
+  // consistent with the read-only, no-mutation contract for this dashboard.
+  function _agentRow(r) {
+    const status = r.band === 'unknown'
+      ? pill('disabled', 'Unknown')
+      : pill(r.behind ? 'unhealthy' : 'healthy', r.behind ? 'Behind' : 'Up to date');
+    return '<tr class="ip-row-static">'
+      + '<td>' + escHtml(r.name) + '</td>'
+      + '<td>' + chip(r.env, 'env') + '</td>'
+      + '<td>' + escHtml(r.version) + '</td>'
+      + '<td>' + status + '</td>'
+      + '<td>' + escHtml(r.policy) + '</td>'
+      + '<td><a class="ip-link" href="' + escHtml(_octopusMachinesUrl()) + '" target="_blank" rel="noopener">Upgrade →</a></td></tr>';
+  }
+  function renderAgents(IP) {
+    IP.agentTab = IP.agentTab === 'kubernetes' ? 'kubernetes' : 'tentacle';
+    const agents = Data.agentsModel(IP.estate.targets);
+    const G = agents[IP.agentTab];
+    const maxDist = G.distribution.reduce((m, d) => Math.max(m, d.count), 0);
+    const distHtml = G.distribution.map(d => _distRow(d, maxDist)).join('');
+    const rowsHtml = G.rows.map(_agentRow).join('');
+    const body = G.rows.length
+      ? '<div class="ip-targets-scroll"><table class="ip-table ip-targets"><thead><tr>'
+        + '<th>Agent name</th><th>Environment</th><th>Version</th><th>Status</th><th>Machine policy</th><th></th>'
+        + '</tr></thead><tbody>' + rowsHtml + '</tbody></table></div>'
+      : '<div class="ip-empty"><h3>No ' + escHtml(IP.agentTab) + ' agents</h3>'
+        + '<p>No matching deployment targets in this estate.</p></div>';
+    return ''
+      + '<header class="ip-head"><h2>Deployment agents</h2>'
+      +   '<p class="ip-sub">Review agent versions across the estate and upgrade what\'s fallen behind. '
+      +   'Latest available ' + escHtml(G.latest) + '.</p></header>'
+      + _agentTabBar(IP.agentTab)
+      + '<div class="ip-grid ip-kpi-grid">'
+      +   '<section class="ip-card"><h4>Total</h4><div class="ip-big">' + G.total + '</div></section>'
+      +   '<section class="ip-card"><h4>Up to date</h4><div class="ip-big ip-num-healthy">' + G.upToDate + '</div></section>'
+      +   '<section class="ip-card"><h4>Behind</h4><div class="ip-big ip-num-unhealthy">' + G.behind + '</div></section>'
+      +   '<section class="ip-card"><h4>Unknown</h4><div class="ip-big">' + G.unknown + '</div></section>'
+      + '</div>'
+      + '<section class="ip-card ip-dist-card"><h4>Version distribution</h4>'
+      +   '<div class="ip-dist-rows">' + (distHtml || '<p class="ip-sub">No versions reported</p>') + '</div></section>'
+      + '<section class="ip-card">'
+      +   '<div class="ip-card-head"><h4>Agents <span class="ip-count-inline">' + G.total + '</span></h4></div>'
+      +   body
+      + '</section>';
+  }
+  function bindAgents(IP) {
+    const root = document.getElementById('main-content');
+    root.querySelectorAll('.ip-tab').forEach(btn => btn.addEventListener('click', () => {
+      IP.agentTab = btn.getAttribute('data-tab') === 'kubernetes' ? 'kubernetes' : 'tentacle';
+      root.innerHTML = renderAgents(IP);
+      bindAgents(IP);
+    }));
+  }
   function renderSpaceSwitch(IP) {
     const opts = ['<option value=""' + (!IP.spaceId ? ' selected' : '') + '>All spaces</option>']
       .concat((IP.spaces || []).map(s => '<option value="' + escHtml(s.Id) + '"'
@@ -489,6 +563,7 @@ const Views = (function () {
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
+    renderAgents, bindAgents,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -316,6 +316,98 @@ const Views = (function () {
       +     '" target="_blank" rel="noopener">Create machine policy</a></div></div>'
       + '<div class="ip-grid ip-policy-grid">' + (cards || '<p class="ip-sub">No machine policies</p>') + '</div>';
   }
+  function _workerPoolCard(p) {
+    return '<section class="ip-card ip-pool-card">'
+      + '<div class="ip-card-head"><h4>' + escHtml(p.name) + '</h4>'
+      +   '<span class="ip-count-inline">' + p.total + ' worker' + (p.total === 1 ? '' : 's') + '</span></div>'
+      + '<ul class="ip-legend"><li class="ip-num-healthy">' + p.healthy + ' Healthy</li>'
+      +   '<li class="ip-num-unhealthy">' + p.unhealthy + ' Unhealthy</li></ul></section>';
+  }
+  function _workerRow(w) {
+    return '<tr class="ip-row-static">'
+      + '<td>' + escHtml(w.name) + '</td>'
+      + '<td>' + pill(w.healthKey, w.health) + '</td>'
+      + '<td>' + chip(w.pool, 'pool') + '</td>'
+      + '<td>' + escHtml(w.version) + '</td></tr>';
+  }
+  function _workerAddUrl() {
+    let base = '';
+    try { base = (typeof IP !== 'undefined' && IP && IP.serverUrl) || ''; } catch (e) { base = ''; }
+    return String(base).replace(/\/$/, '') + '/app#/infrastructure/workers/new';
+  }
+  function renderWorkers(IP) {
+    IP.wFilters = IP.wFilters || {}; IP.wSearch = IP.wSearch || ''; IP.wPage = IP.wPage || 1;
+    const all = IP.estate.workers || [];
+    const model = Data.workersModel(all);
+    const facets = Data.workerFacets(all);
+    const rows = Data.applyWorkerFilters(all, IP.wFilters, IP.wSearch);
+
+    const pages = Math.max(1, Math.ceil(rows.length / IP_PAGE_SIZE));
+    const page = Math.min(IP.wPage || 1, pages);
+    const pageStart = (page - 1) * IP_PAGE_SIZE, pageEnd = page * IP_PAGE_SIZE;
+    const pageRows = rows.slice(pageStart, pageEnd);
+
+    const chips = [];
+    Object.keys(IP.wFilters || {}).forEach(k => (IP.wFilters[k] || []).forEach(v => {
+      const f = facets.find(x => x.key === k); const o = f && f.options.find(x => x.value === v);
+      chips.push(filterChip(k, v, (f ? f.label : k) + ': ' + (o ? o.label : v)));
+    }));
+
+    const facetHtml = facets.map(f => f.options.length ? '<div class="ip-facet"><div class="ip-facet-h">'
+      + escHtml(f.label) + '</div>' + f.options.slice(0, 12).map(o => {
+        const on = (IP.wFilters[f.key] || []).includes(o.value);
+        return '<label class="ip-opt"><input type="checkbox" data-key="' + escHtml(f.key) + '" data-value="'
+          + escHtml(o.value) + '"' + (on ? ' checked' : '') + '> <span>' + escHtml(o.label)
+          + '</span><b>' + o.count + '</b></label>';
+      }).join('') + '</div>' : '').join('');
+
+    const poolCards = model.pools.map(_workerPoolCard).join('');
+
+    const body = rows.length
+      ? '<div class="ip-targets-scroll"><table class="ip-table ip-targets"><thead><tr>'
+        + '<th>Worker</th><th>Health</th><th>Pool</th><th>Agent version</th>'
+        + '</tr></thead><tbody>' + pageRows.map(_workerRow).join('') + '</tbody></table></div>'
+        + (pages > 1 ? '<div class="ip-pager" data-pages="' + pages + '" data-page="' + page + '">Page ' + page + ' of ' + pages
+          + ' <button class="ip-page-prev"' + (page <= 1 ? ' disabled' : '') + '>Prev</button>'
+          + '<button class="ip-page-next"' + (page >= pages ? ' disabled' : '') + '>Next</button></div>' : '')
+      : '<div class="ip-empty"><h3>No workers match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
+
+    return '<header class="ip-head"><h2>Workers</h2>'
+      +   '<p class="ip-sub">A separate class of infrastructure — organised into shared pools, not tenant-scoped.</p></header>'
+      + '<div class="ip-grid ip-pool-grid">' + (poolCards || '<p class="ip-sub">No worker pools</p>') + '</div>'
+      + '<div class="ip-targets-wrap">'
+      +   '<div class="ip-facets"><div class="ip-facet-title">Filters</div>'
+      +     (chips.length ? '<div class="ip-chips">' + chips.join('') + '<button class="ip-clear">Clear all</button></div>' : '')
+      +     facetHtml + '</div>'
+      +   '<div class="ip-targets-main">'
+      +     '<div class="ip-toolbar"><input class="ip-search" type="search" placeholder="Search workers…" value="'
+      +       escHtml(IP.wSearch || '') + '"><span class="ip-count">' + rows.length + ' of ' + all.length + '</span>'
+      +       '<a class="ip-btn" href="' + escHtml(_workerAddUrl()) + '" target="_blank" rel="noopener">Add worker</a></div>'
+      +     body + '</div></div>';
+  }
+  function bindWorkers(IP) {
+    const root = document.getElementById('main-content');
+    const rerender = () => { root.innerHTML = renderWorkers(IP); bindWorkers(IP); };
+    const search = root.querySelector('.ip-search');
+    if (search) search.addEventListener('input', e => { IP.wSearch = e.target.value; IP.wPage = 1;
+      const val = e.target.value; rerender(); const s = document.querySelector('.ip-search');
+      if (s) { s.focus(); s.value = val; s.setSelectionRange(val.length, val.length); } });
+    root.querySelectorAll('.ip-opt input').forEach(cb => cb.addEventListener('change', e => {
+      const k = e.target.getAttribute('data-key'), v = e.target.getAttribute('data-value');
+      IP.wFilters[k] = IP.wFilters[k] || [];
+      if (e.target.checked) IP.wFilters[k].push(v); else IP.wFilters[k] = IP.wFilters[k].filter(x => x !== v);
+      IP.wPage = 1; rerender();
+    }));
+    root.querySelectorAll('.ip-chip').forEach(c => c.addEventListener('click', e => {
+      const k = c.getAttribute('data-key'), v = c.getAttribute('data-value');
+      IP.wFilters[k] = (IP.wFilters[k] || []).filter(x => x !== v); IP.wPage = 1; rerender();
+    }));
+    const clr = root.querySelector('.ip-clear');
+    if (clr) clr.addEventListener('click', () => { IP.wFilters = {}; IP.wSearch = ''; IP.wPage = 1; rerender(); });
+    const prev = root.querySelector('.ip-page-prev'), next = root.querySelector('.ip-page-next');
+    if (prev) prev.addEventListener('click', () => { IP.wPage = Math.max(1, (IP.wPage || 1) - 1); rerender(); });
+    if (next) next.addEventListener('click', () => { IP.wPage = (IP.wPage || 1) + 1; rerender(); });
+  }
   function bindTargets(IP) {
     const root = document.getElementById('main-content');
     const rerender = () => { root.innerHTML = renderTargets(IP); bindTargets(IP); };
@@ -343,7 +435,7 @@ const Views = (function () {
     }));
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
-    renderEnvironments, bindEnvironments, renderMachinePolicies,
+    renderEnvironments, bindEnvironments, renderMachinePolicies, renderWorkers, bindWorkers,
     pill, chip, healthBar, donut, heatCell };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -120,13 +120,40 @@ const Views = (function () {
     return '<button class="ip-chip" data-key="' + escHtml(key) + '" data-value="' + escHtml(value) + '">'
       + escHtml(label) + ' ✕</button>';
   }
+  const IP_TARGETS_COLS = 10;
+  const IP_HEALTH_GROUP_ORDER = ['unhealthy', 'healthy', 'disabled'];
+  function _targetRow(t) {
+    return '<tr class="ip-row" data-id="' + escHtml(t.id) + '">'
+      + '<td><a class="ip-target-link" href="#targets/' + escHtml(encodeURIComponent(t.id)) + '">' + escHtml(t.name) + '</a></td>'
+      + '<td>' + escHtml(t.type) + '</td>'
+      + '<td>' + escHtml(t.os) + '</td>'
+      + '<td>' + escHtml(t.osVersion) + '</td>'
+      + '<td>' + pill(t.healthKey, t.health) + '</td>'
+      + '<td>' + chip(t.env, 'env') + '</td>'
+      + '<td>' + chip(t.tag, 'tag') + '</td>'
+      + '<td>' + escHtml(t.tenant) + '</td>'
+      + '<td>' + escHtml(t.policy) + '</td>'
+      + '<td>' + escHtml(t.version) + '</td></tr>';
+  }
   function renderTargets(IP) {
     const all = IP.estate.targets;
     const facets = Data.buildFacets(all);
     const rows = Data.applyFilters(all, IP.filters, IP.search);
-    const pages = Math.max(1, Math.ceil(rows.length / IP_PAGE_SIZE));
+
+    // Group by health (Unhealthy → Healthy → Disabled), then paginate the
+    // flattened, grouped sequence by DATA rows only — group header rows are
+    // inserted per-page around whichever slice of a group lands there, and
+    // don't count toward the 100/page budget. A group whose rows straddle a
+    // page boundary contributes to both pages (its header repeats on the
+    // continuation page) rather than ever dropping a target.
+    const groups = IP_HEALTH_GROUP_ORDER
+      .map(key => ({ key, items: rows.filter(t => t.healthKey === key) }))
+      .filter(g => g.items.length);
+    const groupedRows = groups.reduce((acc, g) => acc.concat(g.items), []);
+
+    const pages = Math.max(1, Math.ceil(groupedRows.length / IP_PAGE_SIZE));
     const page = Math.min(IP.page || 1, pages);
-    const slice = rows.slice((page-1)*IP_PAGE_SIZE, page*IP_PAGE_SIZE);
+    const pageStart = (page - 1) * IP_PAGE_SIZE, pageEnd = page * IP_PAGE_SIZE;
 
     const chips = [];
     Object.keys(IP.filters||{}).forEach(k => (IP.filters[k]||[]).forEach(v => {
@@ -142,15 +169,23 @@ const Views = (function () {
           + '</span><b>' + o.count + '</b></label>';
       }).join('') + '</div>' : '').join('');
 
-    const rowHtml = slice.map(t =>
-      '<tr class="ip-row" data-id="' + escHtml(t.id) + '">'
-      + '<td><b>' + escHtml(t.name) + '</b><div class="ip-row-sub">' + escHtml(t.kind) + '</div></td>'
-      + '<td>' + escHtml(t.health) + '</td><td>' + escHtml(t.env) + '</td>'
-      + '<td>' + escHtml(t.tag) + '</td><td>' + escHtml(t.tenant) + '</td>'
-      + '<td>' + escHtml(t.policy) + '</td><td>' + escHtml(t.version) + '</td></tr>').join('');
+    let _offset = 0;
+    const rowHtml = groups.map(g => {
+      const groupStart = _offset, groupEnd = _offset + g.items.length;
+      _offset = groupEnd;
+      const visStart = Math.max(0, pageStart - groupStart);
+      const visEnd = Math.min(g.items.length, pageEnd - groupStart);
+      if (visEnd <= visStart) return '';
+      const header = '<tr class="ip-group"><td colspan="' + IP_TARGETS_COLS + '">'
+        + escHtml(g.key.toUpperCase()) + ' ' + g.items.length + '</td></tr>';
+      return header + g.items.slice(visStart, visEnd).map(_targetRow).join('');
+    }).join('');
 
     const body = rows.length
-      ? '<table class="ip-table ip-targets"><thead><tr><th>Deployment target</th><th>Health</th><th>Environment</th><th>Target tag</th><th>Tenant</th><th>Machine policy</th><th>Agent version</th></tr></thead><tbody>' + rowHtml + '</tbody></table>'
+      ? '<div class="ip-targets-scroll"><table class="ip-table ip-targets"><thead><tr>'
+        + '<th>Deployment target</th><th>Type</th><th>Operating system</th><th>OS version</th>'
+        + '<th>Health</th><th>Environment</th><th>Target tag</th><th>Tenant</th><th>Machine policy</th><th>Agent version</th>'
+        + '</tr></thead><tbody>' + rowHtml + '</tbody></table></div>'
         + (pages>1 ? '<div class="ip-pager" data-pages="'+pages+'" data-page="'+page+'">Page ' + page + ' of ' + pages
           + ' <button class="ip-page-prev"' + (page<=1?' disabled':'') + '>Prev</button>'
           + '<button class="ip-page-next"' + (page>=pages?' disabled':'') + '>Next</button></div>' : '')

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -102,6 +102,31 @@ const Views = (function () {
       +     '<a class="ip-btn" href="' + escHtml(String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/new') + '" target="_blank" rel="noopener">Add deployment target</a></div>'
       +   body + '</div></div>';
   }
+  function _row(k,v){ return '<div class="ip-kv"><span>' + escHtml(k) + '</span><b>' + escHtml(v) + '</b></div>'; }
+  function renderTargetDetail(IP) {
+    const t = (IP.estate.targets||[]).find(x => x.id === IP.detailId);
+    if (!t) return '<div class="ip-state"><h3>Target not found</h3><a class="ip-link" href="#targets">← Back to targets</a></div>';
+    const machineUrl = String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/' + encodeURIComponent(t.id);
+    const placeholder = title => '<section class="ip-card"><h4>' + title + '</h4>'
+      + '<p class="ip-sub">Not available in PreAlpha — view on the <a class="ip-link" href="'
+      + escHtml(machineUrl) + '" target="_blank" rel="noopener">target page in Octopus</a>.</p></section>';
+    return ''
+      + '<a class="ip-link" href="#targets">← Deployment targets</a>'
+      + '<header class="ip-head"><h2>' + escHtml(t.name) + '</h2>'
+      +   '<p class="ip-sub">' + escHtml(t.kind) + ' · ' + escHtml(t.health) + '</p></header>'
+      + '<div class="ip-grid">'
+      +   '<section class="ip-card"><h4>Connectivity</h4>' + _row('Communication', t.comm) + _row('Health', t.health) + '</section>'
+      +   '<section class="ip-card"><h4>Tentacle version</h4>' + _row('Installed', t.version)
+      +     '<p class="ip-sub">Upgrades are governed by the ' + escHtml(t.policy) + ' machine policy.</p></section>'
+      +   '<section class="ip-card"><h4>Settings</h4>' + _row('Environment', t.env) + _row('Target tag', t.tag)
+      +     _row('Tenant', t.tenant) + _row('Machine policy', t.policy) + '</section>'
+      +   placeholder('Projects &amp; last release')
+      +   placeholder('Recent deployments')
+      +   '<section class="ip-card"><h4>Runbook runs</h4><p class="ip-sub">No runbook runs yet — this target hasn\'t been part of a runbook run.</p></section>'
+      +   placeholder('Events')
+      + '</div>';
+  }
+  function bindTargetDetail(IP) { /* back link is a plain hash anchor; nothing to wire yet */ }
   function bindTargets(IP) {
     const root = document.getElementById('main-content');
     const rerender = () => { root.innerHTML = renderTargets(IP); bindTargets(IP); };
@@ -128,6 +153,6 @@ const Views = (function () {
       window.location.hash = '#targets/' + encodeURIComponent(r.getAttribute('data-id'));
     }));
   }
-  return { escHtml, stateView, renderOverview, renderTargets, bindTargets };
+  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -41,9 +41,16 @@ const Views = (function () {
       + '<text x="64" y="80" text-anchor="middle" class="ip-donut-sub">healthy</text></svg>';
   }
   function heatCell(value, max, tone) {
+    if (value === 0) return '<td class="ip-heat">0</td>';
     const a = max > 0 ? (value / max) : 0;
     const base = tone === 'bad' ? '214,61,61' : '0,171,98'; // red / green rgb
     return '<td class="ip-heat" style="background:rgba(' + base + ',' + (0.12 + a * 0.7).toFixed(2) + ')">' + value + '</td>';
+  }
+  // Shared Environment/Total/Healthy/Unhealthy/Disabled header — single source of truth so the
+  // Overview "Health by environment" heatmap and the Environments view heatmap always carry the
+  // same <th> set, in the same order, and stay column-aligned (see .ip-heatmap CSS).
+  function _envHeatHead() {
+    return '<thead><tr><th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>';
   }
   // The infrastructure machines page lives on the Octopus instance itself, whose base URL isn't
   // part of the overviewModel shape (ov, estate) this view is contracted to accept. dashboard.js
@@ -65,7 +72,7 @@ const Views = (function () {
     const maxHealthy = envTop.reduce((m,r)=>Math.max(m, r.healthy), 0);
     const maxUnhealthy = envTop.reduce((m,r)=>Math.max(m, r.unhealthy), 0);
     const envRows = envTop.map(r =>
-      '<tr><td>' + escHtml(r.name) + '</td><td>' + r.total + '</td>'
+      '<tr><td><a href="#environments">' + escHtml(r.name) + '</a></td><td>' + r.total + '</td>'
       + heatCell(r.healthy, maxHealthy, 'good')
       + heatCell(r.unhealthy, maxUnhealthy, 'bad')
       + '<td>' + r.disabled + '</td></tr>').join('');
@@ -102,7 +109,7 @@ const Views = (function () {
       +   '<div class="ip-heatmap-block">'
       +     '<div class="ip-heatmap-head"><h5 class="ip-subhead">Health by environment</h5>'
       +       '<span class="ip-caption">Cell intensity = share of estate</span></div>'
-      +     '<table class="ip-table ip-heatmap"><thead><tr><th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>'
+      +     '<table class="ip-table ip-heatmap">' + _envHeatHead()
       +     '<tbody>' + (envRows || '<tr><td colspan="5">No environments</td></tr>') + '</tbody></table>'
       +     '<a class="ip-link" href="#environments">View all environments →</a>'
       +   '</div>'
@@ -268,8 +275,7 @@ const Views = (function () {
       +   '<div class="ip-card-head"><h4>Environments <span class="ip-count-inline">' + rows.length + '</span></h4>'
       +     '<div class="ip-card-actions"><a class="ip-link" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>'
       +   '</div>'
-      +   '<table class="ip-table ip-heatmap ip-env-heatmap"><thead><tr>'
-      +     '<th>Environment</th><th>Total</th><th>Healthy</th><th>Unhealthy</th><th>Disabled</th></tr></thead>'
+      +   '<table class="ip-table ip-heatmap ip-env-heatmap">' + _envHeatHead()
       +   '<tbody>' + (body || '<tr><td colspan="5">No environments</td></tr>') + '</tbody></table>'
       + '</section>';
   }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1,0 +1,2 @@
+'use strict';
+// Populated in later tasks.

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -248,26 +248,49 @@ const Views = (function () {
       + '<td>' + chip(t.tag, 'tag') + '</td>'
       + '<td>' + escHtml(t.tenant) + '</td></tr>';
   }
-  function _envRow(r, maxHealthy, maxUnhealthy, expanded) {
-    const sub = expanded
+  // Pure filter used by the expanded sub-list: 'all' passes everything through,
+  // any other key is a healthKey to match exactly. Missing targets → [].
+  function filterEnvTargets(targets, key) {
+    const list = targets || [];
+    return key === 'all' ? list : list.filter(t => t.healthKey === key);
+  }
+  // Env heat cells carry data-env/data-health so a click can identify which environment and
+  // which filter was clicked. This is a local twin of heatCell(), not a change to it — heatCell
+  // is shared with Overview's read-only heatmap, which must stay non-interactive and unchanged.
+  function _envHeatCell(value, max, tone, name, key) {
+    const attrs = ' class="ip-heat ip-env-cell" data-env="' + escHtml(name) + '" data-health="' + escHtml(key) + '"';
+    if (value === 0) return '<td' + attrs + '>0</td>';
+    const a = max > 0 ? (value / max) : 0;
+    const base = tone === 'bad' ? '214,61,61' : '0,171,98'; // red / green rgb
+    return '<td' + attrs + ' style="background:rgba(' + base + ',' + (0.12 + a * 0.7).toFixed(2) + ')">' + value + '</td>';
+  }
+  function _envRow(r, maxHealthy, maxUnhealthy, expandedKey) {
+    const open = !!expandedKey;
+    const shown = open ? filterEnvTargets(r.targets, expandedKey) : [];
+    const emptyMsg = expandedKey === 'healthy' ? 'No healthy targets in this environment'
+      : expandedKey === 'unhealthy' ? 'No unhealthy targets in this environment'
+      : expandedKey === 'disabled' ? 'No disabled targets in this environment'
+      : 'No targets in this environment';
+    const sub = open
       ? '<tr class="ip-env-sub"><td colspan="5"><table class="ip-table ip-env-targets"><thead><tr>'
         + '<th>Deployment target</th><th>Type</th><th>Health</th><th>Target tag</th><th>Tenant</th></tr></thead><tbody>'
-        + (r.targets.length ? r.targets.map(_envTargetRow).join('') : '<tr><td colspan="5" class="ip-sub">No targets in this environment</td></tr>')
+        + (shown.length ? shown.map(_envTargetRow).join('') : '<tr><td colspan="5" class="ip-sub">' + escHtml(emptyMsg) + '</td></tr>')
         + '</tbody></table></td></tr>'
       : '';
-    return '<tr class="ip-row ip-env-row' + (expanded ? ' ip-env-row-open' : '') + '" data-env="' + escHtml(r.name) + '">'
-      + '<td><span class="ip-env-toggle">' + (expanded ? '▾' : '▸') + '</span>' + escHtml(r.name) + '</td>'
-      + '<td>' + r.total + '</td>'
-      + heatCell(r.healthy, maxHealthy, 'good')
-      + heatCell(r.unhealthy, maxUnhealthy, 'bad')
-      + '<td>' + r.disabled + '</td></tr>' + sub;
+    const envAttr = ' data-env="' + escHtml(r.name) + '"';
+    return '<tr class="ip-row ip-env-row' + (open ? ' ip-env-row-open' : '') + '"' + envAttr + '>'
+      + '<td class="ip-env-cell"' + envAttr + ' data-health="all"><span class="ip-env-toggle">' + (open ? '▾' : '▸') + '</span>' + escHtml(r.name) + '</td>'
+      + '<td class="ip-env-cell"' + envAttr + ' data-health="all">' + r.total + '</td>'
+      + _envHeatCell(r.healthy, maxHealthy, 'good', r.name, 'healthy')
+      + _envHeatCell(r.unhealthy, maxUnhealthy, 'bad', r.name, 'unhealthy')
+      + '<td class="ip-env-cell"' + envAttr + ' data-health="disabled">' + r.disabled + '</td></tr>' + sub;
   }
   function renderEnvironments(IP) {
     const rows = Data.environmentsModel(IP.estate.targets, IP.estate.environments);
     const maxHealthy = rows.reduce((m, r) => Math.max(m, r.healthy), 0);
     const maxUnhealthy = rows.reduce((m, r) => Math.max(m, r.unhealthy), 0);
     IP.envExpanded = IP.envExpanded || {};
-    const body = rows.map(r => _envRow(r, maxHealthy, maxUnhealthy, !!IP.envExpanded[r.name])).join('');
+    const body = rows.map(r => _envRow(r, maxHealthy, maxUnhealthy, IP.envExpanded[r.name])).join('');
     return ''
       + '<header class="ip-head"><h2>Environments</h2>'
       +   '<p class="ip-sub">Infrastructure through the lens of your deployment pipeline. Expand an environment to see its targets.</p></header>'
@@ -281,10 +304,15 @@ const Views = (function () {
   }
   function bindEnvironments(IP) {
     const root = document.getElementById('main-content');
-    root.querySelectorAll('.ip-env-row').forEach(r => r.addEventListener('click', () => {
-      const name = r.getAttribute('data-env');
+    // Each clickable cell (name, Total, Healthy, Unhealthy, Disabled) carries its own
+    // data-env/data-health pair, so binding per-cell (not per-row) means a single click
+    // fires exactly one handler — no row-level listener to double-fire alongside it.
+    root.querySelectorAll('.ip-env-row [data-health]').forEach(cell => cell.addEventListener('click', () => {
+      const name = cell.getAttribute('data-env');
+      const key = cell.getAttribute('data-health');
       IP.envExpanded = IP.envExpanded || {};
-      IP.envExpanded[name] = !IP.envExpanded[name];
+      if (IP.envExpanded[name] === key) delete IP.envExpanded[name];
+      else IP.envExpanded[name] = key;
       root.innerHTML = renderEnvironments(IP);
       bindEnvironments(IP);
     }));
@@ -460,7 +488,7 @@ const Views = (function () {
     });
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
-    renderEnvironments, bindEnvironments, renderMachinePolicies, renderWorkers, bindWorkers,
+    renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -434,8 +434,27 @@ const Views = (function () {
       window.location.hash = '#targets/' + encodeURIComponent(r.getAttribute('data-id'));
     }));
   }
+  function renderSpaceSwitch(IP) {
+    const opts = ['<option value=""' + (!IP.spaceId ? ' selected' : '') + '>All spaces</option>']
+      .concat((IP.spaces || []).map(s => '<option value="' + escHtml(s.Id) + '"'
+        + (IP.spaceId === s.Id ? ' selected' : '') + '>' + escHtml(s.Name) + '</option>'));
+    return '<label class="ip-space-lbl">Space</label>'
+      + '<select id="ip-space-select" class="ip-space-select">' + opts.join('') + '</select>';
+  }
+  function bindSpaceSwitch(IP) {
+    const el = document.getElementById('ip-space-select');
+    if (!el) return;
+    el.addEventListener('change', e => {
+      IP.spaceId = e.target.value || null;
+      if (typeof IP.rescope === 'function') IP.rescope();
+      IP.filters = {}; IP.search = ''; IP.page = 1;
+      IP.wFilters = {}; IP.wSearch = ''; IP.wPage = 1;
+      IP.envExpanded = {};
+      Router.render();
+    });
+  }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
     renderEnvironments, bindEnvironments, renderMachinePolicies, renderWorkers, bindWorkers,
-    pill, chip, healthBar, donut, heatCell };
+    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -49,6 +49,85 @@ const Views = (function () {
       +     '<p class="ip-sub">Wired in a later phase. Shows connections, gateway health, and managed apps when the instance exposes Argo CD.</p></section>'
       + '</div>';
   }
-  return { escHtml, stateView, renderOverview };
+  const IP_PAGE_SIZE = 100;
+  function chip(key, value, label) {
+    return '<button class="ip-chip" data-key="' + escHtml(key) + '" data-value="' + escHtml(value) + '">'
+      + escHtml(label) + ' ✕</button>';
+  }
+  function renderTargets(IP) {
+    const all = IP.estate.targets;
+    const facets = Data.buildFacets(all);
+    const rows = Data.applyFilters(all, IP.filters, IP.search);
+    const pages = Math.max(1, Math.ceil(rows.length / IP_PAGE_SIZE));
+    const page = Math.min(IP.page || 1, pages);
+    const slice = rows.slice((page-1)*IP_PAGE_SIZE, page*IP_PAGE_SIZE);
+
+    const chips = [];
+    Object.keys(IP.filters||{}).forEach(k => (IP.filters[k]||[]).forEach(v => {
+      const f = facets.find(x=>x.key===k); const o = f && f.options.find(x=>x.value===v);
+      chips.push(chip(k, v, (f?f.label:k) + ': ' + (o?o.label:v)));
+    }));
+
+    const facetHtml = facets.map(f => f.options.length ? '<div class="ip-facet"><div class="ip-facet-h">'
+      + escHtml(f.label) + '</div>' + f.options.slice(0,12).map(o => {
+        const on = (IP.filters[f.key]||[]).includes(o.value);
+        return '<label class="ip-opt"><input type="checkbox" data-key="' + escHtml(f.key) + '" data-value="'
+          + escHtml(o.value) + '"' + (on?' checked':'') + '> <span>' + escHtml(o.label)
+          + '</span><b>' + o.count + '</b></label>';
+      }).join('') + '</div>' : '').join('');
+
+    const rowHtml = slice.map(t =>
+      '<tr class="ip-row" data-id="' + escHtml(t.id) + '">'
+      + '<td><b>' + escHtml(t.name) + '</b><div class="ip-row-sub">' + escHtml(t.kind) + '</div></td>'
+      + '<td>' + escHtml(t.health) + '</td><td>' + escHtml(t.env) + '</td>'
+      + '<td>' + escHtml(t.tag) + '</td><td>' + escHtml(t.tenant) + '</td>'
+      + '<td>' + escHtml(t.policy) + '</td><td>' + escHtml(t.version) + '</td></tr>').join('');
+
+    const body = rows.length
+      ? '<table class="ip-table ip-targets"><thead><tr><th>Deployment target</th><th>Health</th><th>Environment</th><th>Target tag</th><th>Tenant</th><th>Machine policy</th><th>Agent version</th></tr></thead><tbody>' + rowHtml + '</tbody></table>'
+        + (pages>1 ? '<div class="ip-pager" data-pages="'+pages+'" data-page="'+page+'">Page ' + page + ' of ' + pages
+          + ' <button class="ip-page-prev"' + (page<=1?' disabled':'') + '>Prev</button>'
+          + '<button class="ip-page-next"' + (page>=pages?' disabled':'') + '>Next</button></div>' : '')
+      : '<div class="ip-empty"><h3>No targets match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
+
+    return '<div class="ip-targets-wrap">'
+      + '<div class="ip-facets"><div class="ip-facet-title">Filters</div>'
+      +   (chips.length ? '<div class="ip-chips">' + chips.join('') + '<button class="ip-clear">Clear all</button></div>' : '')
+      +   facetHtml + '</div>'
+      + '<div class="ip-targets-main">'
+      +   '<header class="ip-head"><h2>Deployment targets</h2>'
+      +     '<p class="ip-sub">Assess health across the estate and drill in with fast, faceted filters.</p></header>'
+      +   '<div class="ip-toolbar"><input class="ip-search" type="search" placeholder="Search targets…" value="'
+      +     escHtml(IP.search||'') + '"><span class="ip-count">' + rows.length + ' of ' + all.length + '</span>'
+      +     '<a class="ip-btn" href="' + escHtml(String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/new') + '" target="_blank" rel="noopener">Add deployment target</a></div>'
+      +   body + '</div></div>';
+  }
+  function bindTargets(IP) {
+    const root = document.getElementById('main-content');
+    const rerender = () => { root.innerHTML = renderTargets(IP); bindTargets(IP); };
+    const search = root.querySelector('.ip-search');
+    if (search) search.addEventListener('input', e => { IP.search = e.target.value; IP.page = 1;
+      const val = e.target.value; rerender(); const s = document.querySelector('.ip-search');
+      if (s) { s.focus(); s.value = val; s.setSelectionRange(val.length, val.length); } });
+    root.querySelectorAll('.ip-opt input').forEach(cb => cb.addEventListener('change', e => {
+      const k = e.target.getAttribute('data-key'), v = e.target.getAttribute('data-value');
+      IP.filters[k] = IP.filters[k] || [];
+      if (e.target.checked) IP.filters[k].push(v); else IP.filters[k] = IP.filters[k].filter(x=>x!==v);
+      IP.page = 1; rerender();
+    }));
+    root.querySelectorAll('.ip-chip').forEach(c => c.addEventListener('click', e => {
+      const k = c.getAttribute('data-key'), v = c.getAttribute('data-value');
+      IP.filters[k] = (IP.filters[k]||[]).filter(x=>x!==v); IP.page = 1; rerender();
+    }));
+    const clr = root.querySelector('.ip-clear');
+    if (clr) clr.addEventListener('click', () => { IP.filters = {}; IP.search=''; IP.page=1; rerender(); });
+    const prev = root.querySelector('.ip-page-prev'), next = root.querySelector('.ip-page-next');
+    if (prev) prev.addEventListener('click', () => { IP.page = Math.max(1,(IP.page||1)-1); rerender(); });
+    if (next) next.addEventListener('click', () => { IP.page = (IP.page||1)+1; rerender(); });
+    root.querySelectorAll('.ip-row').forEach(r => r.addEventListener('click', () => {
+      window.location.hash = '#targets/' + encodeURIComponent(r.getAttribute('data-id'));
+    }));
+  }
+  return { escHtml, stateView, renderOverview, renderTargets, bindTargets };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -283,6 +283,39 @@ const Views = (function () {
       bindEnvironments(IP);
     }));
   }
+  function _policyCreateUrl() {
+    let base = '';
+    try { base = (typeof IP !== 'undefined' && IP && IP.serverUrl) || ''; } catch (e) { base = ''; }
+    return String(base).replace(/\/$/, '') + '/app#/infrastructure/machinepolicies/create';
+  }
+  function _policyCard(p) {
+    return '<section class="ip-card ip-policy-card">'
+      + '<div class="ip-policy-head"><h4>' + escHtml(p.name) + '</h4>'
+      +   (p.isDefault ? '<span class="ip-tag">Default</span>' : '') + '</div>'
+      + (p.description ? '<p class="ip-sub">' + escHtml(p.description) + '</p>' : '')
+      + '<p class="ip-policy-usage">' + p.usage + ' target' + (p.usage === 1 ? '' : 's') + '</p>'
+      + '<div class="ip-policy-kv">'
+      +   _row('Health check interval', p.interval)
+      +   _row('Health check type', p.healthCheckType)
+      +   _row('Tentacle updates', p.tentacle)
+      +   _row('Calamari updates', p.calamari)
+      +   _row('Kubernetes agent', p.k8s)
+      +   _row('Connectivity', p.connectivity)
+      +   _row('Clean up machines', p.cleanup)
+      + '</div></section>';
+  }
+  function renderMachinePolicies(IP) {
+    const rows = Data.policiesModel(IP.estate.policies, IP.estate.targets);
+    const cards = rows.map(_policyCard).join('');
+    return ''
+      + '<header class="ip-head"><h2>Machine policies</h2>'
+      +   '<p class="ip-sub">Govern targets collectively — health-check schedules and the tentacle upgrade '
+      +   'behaviour that drives version state across the estate.</p></header>'
+      + '<div class="ip-card-head"><h4>Machine policies <span class="ip-count-inline">' + rows.length + '</span></h4>'
+      +   '<div class="ip-card-actions"><a class="ip-link" href="' + escHtml(_policyCreateUrl())
+      +     '" target="_blank" rel="noopener">Create machine policy</a></div></div>'
+      + '<div class="ip-grid ip-policy-grid">' + (cards || '<p class="ip-sub">No machine policies</p>') + '</div>';
+  }
   function bindTargets(IP) {
     const root = document.getElementById('main-content');
     const rerender = () => { root.innerHTML = renderTargets(IP); bindTargets(IP); };
@@ -310,7 +343,7 @@ const Views = (function () {
     }));
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
-    renderEnvironments, bindEnvironments,
+    renderEnvironments, bindEnvironments, renderMachinePolicies,
     pill, chip, healthBar, donut, heatCell };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -124,7 +124,7 @@ const Views = (function () {
       +     '<ul class="ip-legend"><li>' + ov.workers.healthy + ' Healthy</li><li>' + ov.workers.unhealthy + ' Unhealthy</li></ul>'
       +     '<ul class="ip-pools">' + pools + '</ul><a class="ip-link" href="#workers">Open →</a></section>'
       +   '<section class="ip-card"><h4>Argo CD <span class="ip-tag">Early access</span></h4>'
-      +     '<p class="ip-sub">Wired in a later phase. Shows connections, gateway health, and managed apps when the instance exposes Argo CD.</p></section>'
+      +     '<p class="ip-sub">Not available via the Octopus API yet. Shows connections, gateway health, and managed apps when the instance exposes Argo CD.</p></section>'
       + '</div>';
   }
   const IP_PAGE_SIZE = 100;
@@ -547,6 +547,19 @@ const Views = (function () {
       bindAgents(IP);
     }));
   }
+  function renderArgo(IP) {
+    const base = String((IP && IP.serverUrl) || '').replace(/\/$/, '');
+    const infraUrl = base + '/app#/infrastructure';
+    return ''
+      + '<header class="ip-head"><h2>Argo CD Instances <span class="ip-tag">Early access</span></h2>'
+      +   '<p class="ip-sub">GitOps delivery alongside your Octopus-managed infrastructure.</p></header>'
+      + '<section class="ip-card ip-state">'
+      +   '<h3>Not available through the Octopus API yet</h3>'
+      +   '<p>Argo CD connections aren\'t available through the Octopus API yet, so this view can\'t show live data. '
+      +   'When Octopus exposes Argo CD over the API, this will list connections, gateway health, and managed applications.</p>'
+      +   '<a class="ip-link" href="' + escHtml(infraUrl) + '" target="_blank" rel="noopener">Open Infrastructure in Octopus →</a>'
+      + '</section>';
+  }
   function renderSpaceSwitch(IP) {
     const opts = ['<option value=""' + (!IP.spaceId ? ' selected' : '') + '>All spaces</option>']
       .concat((IP.spaces || []).map(s => '<option value="' + escHtml(s.Id) + '"'
@@ -568,7 +581,7 @@ const Views = (function () {
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
-    renderAgents, bindAgents,
+    renderAgents, bindAgents, renderArgo,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -6,6 +6,11 @@ const Views = (function () {
     if (kind === 'loading') return '<div class="ip-state"><div class="ip-spinner"></div><p>Loading your infrastructure…</p></div>';
     if (kind === 'auth') return '<div class="ip-state"><h3>Sign in to Octopus</h3>'
       + '<p>Your session isn\'t authenticated. Open your Octopus instance, sign in, then reopen this dashboard.</p></div>';
+    if (kind === 'noconfig') return '<div class="ip-state"><h3>Open from the Octopus AI Assistant</h3>'
+      + '<p>This dashboard reads its configuration from the extension, so it can\'t run when opened directly as a local file. '
+      + 'Load the unpacked extension, then open it from the AI Assistant — or run '
+      + '<code>showDashboard(&#123; dashboardFile: "infrastructureprealpha/index.html", serverUrl: "https://your-instance.octopus.app/", context: &#123;&#125; &#125;)</code> '
+      + 'from the extension service worker console.</p></div>';
     return '<div class="ip-state"><h3>Couldn\'t load infrastructure</h3><p>' + escHtml(detail || 'Unknown error') + '</p></div>';
   }
   function bar(healthy, unhealthy, disabled) {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -81,7 +81,7 @@ const Views = (function () {
     const pools = ov.workers.pools.map(p =>
       '<li><span>' + escHtml(p.name) + '</span><b>' + p.count + '</b></li>').join('');
     return ''
-      + '<header class="ip-head">'
+      + '<header class="ip-head ip-head-actions">'
       +   '<div class="ip-head-text"><h2>Infrastructure overview</h2>'
       +     '<p class="ip-sub">A diagnostic snapshot of your deployment estate.</p></div>'
       +   '<a class="ip-head-pill" href="#agents">Deployment agent versions (Tentacles &amp; K8s) · ' + agentsPillText + ' →</a>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -349,6 +349,25 @@ const Views = (function () {
     return _activityCard('Runbook runs', activity.runbooks, raw, t, serverUrl,
       'No runbook runs against this target in the retained task history.');
   }
+  function eventsCardHtml(t, rows, raw, serverUrl) {
+    const body = raw === null
+      ? '<p class="ip-sub">Couldn\'t load events from the Octopus API. Try again, or open the '
+        + '<a class="ip-link" href="' + escHtml(String(serverUrl||'').replace(/\/$/,'')
+        + '/app#/infrastructure/machines/' + encodeURIComponent(t.id)) + '" target="_blank" rel="noopener">'
+        + 'target page in Octopus</a>.</p>'
+      : !rows.length
+        // The query succeeded and matched nothing. Octopus prunes events, so an
+        // untouched target legitimately has none — say that rather than implying
+        // nothing has ever happened to it.
+        ? '<p class="ip-sub">No events retained for this target. Octopus prunes its event '
+          + 'history, so a target that has been quiet for a while will show none.</p>'
+        : '<table class="ip-table"><tbody>' + rows.map(r =>
+            '<tr><td class="ip-when">' + escHtml(_when(r.occurred)) + '</td>'
+            + '<td>' + escHtml(r.message) + '</td>'
+            + '<td class="ip-ev-who">' + escHtml(r.who) + '</td></tr>').join('')
+          + '</tbody></table>';
+    return '<section class="ip-card ip-card-wide"><h4>Events</h4>' + body + '</section>';
+  }
   function connectivityCardHtml(t, connection) {
     const rows = connection
       ? _row('Status', connection.Status || '—')
@@ -374,6 +393,7 @@ const Views = (function () {
       +     _row('Tenant', t.tenant) + _row('Machine policy', t.policy) + '</section>'
       +   '<div id="ip-td-deploys"><section class="ip-card ip-card-wide"><h4>Deployments</h4>' + loading + '</section></div>'
       +   '<div id="ip-td-runbooks"><section class="ip-card"><h4>Runbook runs</h4>' + loading + '</section></div>'
+      +   '<div id="ip-td-events"><section class="ip-card ip-card-wide"><h4>Events</h4>' + loading + '</section></div>'
       + '</div>';
   }
   // Called once the per-target fetch resolves. The rest of the detail view is already on
@@ -386,6 +406,7 @@ const Views = (function () {
     set('ip-td-conn', connectivityCardHtml(t, detail.connection));
     set('ip-td-deploys', deploymentsCardHtml(t, activity, detail.tasks, IP.serverUrl));
     set('ip-td-runbooks', runbooksCardHtml(t, activity, detail.tasks, IP.serverUrl));
+    set('ip-td-events', eventsCardHtml(t, Data.eventsModel(detail.events), detail.events, IP.serverUrl));
   }
   function bindTargetDetail(IP) { /* back link is a plain hash anchor; nothing to wire yet */ }
 
@@ -918,7 +939,7 @@ const Views = (function () {
       Router.render();
     });
   }
-  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml,
+  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1,7 +1,7 @@
 'use strict';
 const Views = (function () {
   function escHtml(s) { return String(s == null ? '' : s)
-    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
   function stateView(kind, detail) {
     if (kind === 'loading') return '<div class="ip-state"><div class="ip-spinner"></div><p>Loading your infrastructure…</p></div>';
     if (kind === 'auth') return '<div class="ip-state"><h3>Sign in to Octopus</h3>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -921,22 +921,35 @@ const Views = (function () {
     });
   }
   function renderSpaceSwitch(IP) {
-    const opts = ['<option value=""' + (!IP.spaceId ? ' selected' : '') + '>All spaces</option>']
-      .concat((IP.spaces || []).map(s => '<option value="' + escHtml(s.Id) + '"'
-        + (IP.spaceId === s.Id ? ' selected' : '') + '>' + escHtml(s.Name) + '</option>'));
+    // One space at a time, matching the Octopus UI — there is no all-spaces view there,
+    // and offering one would mean hydrating every space to populate it.
+    const opts = (IP.spaces || []).map(s => '<option value="' + escHtml(s.Id) + '"'
+      + (IP.spaceId === s.Id ? ' selected' : '') + '>' + escHtml(s.Name) + '</option>');
     return '<label class="ip-space-lbl">Space</label>'
       + '<select id="ip-space-select" class="ip-space-select">' + opts.join('') + '</select>';
   }
   function bindSpaceSwitch(IP) {
     const el = document.getElementById('ip-space-select');
     if (!el) return;
-    el.addEventListener('change', e => {
-      IP.spaceId = e.target.value || null;
-      if (typeof IP.rescope === 'function') IP.rescope();
+    el.addEventListener('change', async e => {
+      IP.spaceId = e.target.value;
       IP.filters = {}; IP.search = ''; IP.page = 1;
       IP.wFilters = {}; IP.wSearch = ''; IP.wPage = 1;
       IP.envExpanded = {};
-      Router.render();
+      // Spaces are hydrated on demand now, so switching to one not seen before hits the
+      // network. Show the loading state rather than leaving the previous space's data on
+      // screen under the new space's name.
+      const main = document.getElementById('main-content');
+      if (main) main.innerHTML = stateView('loading');
+      el.disabled = true;
+      try {
+        if (typeof IP.rescope === 'function') await IP.rescope();
+        Router.render();
+      } catch (err) {
+        if (main) main.innerHTML = stateView('error', (err && err.message) || 'Could not load that space');
+      } finally {
+        el.disabled = false;
+      }
     });
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -201,7 +201,11 @@ const Views = (function () {
         + (pages>1 ? '<div class="ip-pager" data-pages="'+pages+'" data-page="'+page+'">Page ' + page + ' of ' + pages
           + ' <button class="ip-page-prev"' + (page<=1?' disabled':'') + '>Prev</button>'
           + '<button class="ip-page-next"' + (page>=pages?' disabled':'') + '>Next</button></div>' : '')
-      : '<div class="ip-empty"><h3>No targets match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
+      : Data.emptyKind(all.length, rows.length) === 'none'
+        ? '<div class="ip-empty"><h3>No deployment targets in this space</h3>'
+          + '<p>Targets are the machines and services Octopus deploys to. Add one to get started.</p>'
+          + '<a class="ip-btn" href="' + escHtml(String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/new') + '" target="_blank" rel="noopener">Add deployment target</a></div>'
+        : '<div class="ip-empty"><h3>No targets match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
 
     return '<div class="ip-targets-wrap">'
       + '<div class="ip-facets"><div class="ip-facet-title">Filters</div>'
@@ -235,7 +239,7 @@ const Views = (function () {
       +     _row('Tenant', t.tenant) + _row('Machine policy', t.policy) + '</section>'
       +   placeholder('Projects &amp; last release')
       +   placeholder('Recent deployments')
-      +   '<section class="ip-card"><h4>Runbook runs</h4><p class="ip-sub">No runbook runs yet — this target hasn\'t been part of a runbook run.</p></section>'
+      +   placeholder('Runbook runs')
       +   placeholder('Events')
       + '</div>';
   }
@@ -303,8 +307,12 @@ const Views = (function () {
       +   '<div class="ip-card-head"><h4>Environments <span class="ip-count-inline">' + rows.length + '</span></h4>'
       +     '<div class="ip-card-actions"><a class="ip-link" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>'
       +   '</div>'
-      +   '<table class="ip-table ip-heatmap ip-env-heatmap">' + _envHeatHead()
-      +   '<tbody>' + (body || '<tr><td colspan="5">No environments</td></tr>') + '</tbody></table>'
+      +   (rows.length
+            ? '<table class="ip-table ip-heatmap ip-env-heatmap">' + _envHeatHead()
+              + '<tbody>' + body + '</tbody></table>'
+            : '<div class="ip-empty"><h3>No environments in this space</h3>'
+              + '<p>Environments are the stages a release moves through — Dev, Test, Production.</p>'
+              + '<a class="ip-btn" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>')
       + '</section>';
   }
   function bindEnvironments(IP) {
@@ -409,7 +417,11 @@ const Views = (function () {
         + (pages > 1 ? '<div class="ip-pager" data-pages="' + pages + '" data-page="' + page + '">Page ' + page + ' of ' + pages
           + ' <button class="ip-page-prev"' + (page <= 1 ? ' disabled' : '') + '>Prev</button>'
           + '<button class="ip-page-next"' + (page >= pages ? ' disabled' : '') + '>Next</button></div>' : '')
-      : '<div class="ip-empty"><h3>No workers match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
+      : Data.emptyKind(all.length, rows.length) === 'none'
+        ? '<div class="ip-empty"><h3>No workers in this space</h3>'
+          + '<p>Workers run deployment steps that don\'t execute on a target — script steps, cloud API calls, package pushes.</p>'
+          + '<a class="ip-btn" href="' + escHtml(_workerAddUrl()) + '" target="_blank" rel="noopener">Add worker</a></div>'
+        : '<div class="ip-empty"><h3>No workers match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
 
     return '<header class="ip-head"><h2>Workers</h2>'
       +   '<p class="ip-sub">A separate class of infrastructure — organised into shared pools, not tenant-scoped.</p></header>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -204,7 +204,7 @@ const Views = (function () {
       : Data.emptyKind(all.length, rows.length) === 'none'
         ? '<div class="ip-empty"><h3>No deployment targets in this space</h3>'
           + '<p>Targets are the machines and services Octopus deploys to. Add one to get started.</p>'
-          + '<a class="ip-btn" href="' + escHtml(String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/new') + '" target="_blank" rel="noopener">Add deployment target</a></div>'
+          + '<a class="ip-btn" href="#targets/new">Add deployment target</a></div>'
         : '<div class="ip-empty"><h3>No targets match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
 
     return '<div class="ip-targets-wrap">'
@@ -216,7 +216,7 @@ const Views = (function () {
       +     '<p class="ip-sub">Assess health across the estate and drill in with fast, faceted filters.</p></header>'
       +   '<div class="ip-toolbar"><input class="ip-search" type="search" placeholder="Search targets…" value="'
       +     escHtml(IP.search||'') + '"><span class="ip-count">' + rows.length + ' of ' + all.length + '</span>'
-      +     '<a class="ip-btn" href="' + escHtml(String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/new') + '" target="_blank" rel="noopener">Add deployment target</a></div>'
+      +     '<a class="ip-btn" href="#targets/new">Add deployment target</a></div>'
       +   body + '</div></div>';
   }
   function _row(k,v){ return '<div class="ip-kv"><span>' + escHtml(k) + '</span><b>' + escHtml(v) + '</b></div>'; }
@@ -244,6 +244,93 @@ const Views = (function () {
       + '</div>';
   }
   function bindTargetDetail(IP) { /* back link is a plain hash anchor; nothing to wire yet */ }
+
+  // Add-target walkthrough. PreAlpha is read-only, so this explains the choice and the
+  // prerequisites, then hands off to Octopus to do the actual creation. The value is the
+  // decision (which connection direction suits this machine?), which is the part the real
+  // Octopus flow makes you resolve after you've already committed to a type.
+  const ADD_TARGET_TYPES = [
+    { key: 'listening', name: 'Listening Tentacle',
+      when: 'Machines on a network the Octopus Server can reach directly.',
+      direction: 'Octopus opens the connection to the machine.',
+      needs: ['Tentacle installed on the machine',
+              'Inbound TCP 10933 open from Octopus to the machine',
+              'The machine’s thumbprint, to trust it'] },
+    { key: 'polling', name: 'Polling Tentacle',
+      when: 'Machines behind NAT, a firewall, or in someone else’s network — anywhere Octopus can’t dial in.',
+      direction: 'The machine opens the connection to Octopus.',
+      needs: ['Tentacle installed on the machine',
+              'Outbound TCP 10943 from the machine to Octopus',
+              'The Octopus Server thumbprint'] },
+    { key: 'kubernetes', name: 'Kubernetes agent',
+      when: 'Deploying into a Kubernetes cluster.',
+      direction: 'The agent runs inside the cluster and polls Octopus.',
+      needs: ['Helm access to the cluster',
+              'Outbound access from the cluster to Octopus',
+              'A namespace for the agent to live in'] },
+    { key: 'ssh', name: 'SSH connection',
+      when: 'Linux and Unix machines you reach over SSH.',
+      direction: 'Octopus opens an SSH connection to the machine.',
+      needs: ['An SSH account — key pair or username and password',
+              'Inbound SSH (usually port 22) from Octopus',
+              'A supported shell on the machine'] },
+    { key: 'cloud', name: 'Azure, AWS or GCP service',
+      when: 'Deploying to a managed cloud service rather than a machine you run.',
+      direction: 'Octopus authenticates against the cloud provider’s API.',
+      needs: ['An Octopus account for the provider',
+              'Permissions on the target service',
+              'Nothing to install — there’s no agent'] }
+  ];
+  function _newTargetUrl(IP) {
+    return String((IP && IP.serverUrl) || '').replace(/\/$/, '') + '/app#/infrastructure/machines/new';
+  }
+  function _addTypeCard(t) {
+    return '<button class="ip-card ip-type-card" data-type="' + escHtml(t.key) + '">'
+      + '<h4>' + escHtml(t.name) + '</h4>'
+      + '<p class="ip-sub">' + escHtml(t.when) + '</p>'
+      + '<span class="ip-type-dir">' + escHtml(t.direction) + '</span></button>';
+  }
+  function renderAddTarget(IP) {
+    const chosen = ADD_TARGET_TYPES.find(t => t.key === (IP && IP.addTargetType));
+    const head = '<a class="ip-link" href="#targets">← Deployment targets</a>'
+      + '<header class="ip-head"><h2>Add a deployment target</h2>';
+    if (!chosen) {
+      return head
+        + '<p class="ip-sub">Step 1 of 2 — choose how Octopus should reach this machine.</p></header>'
+        + '<div class="ip-grid ip-type-grid">' + ADD_TARGET_TYPES.map(_addTypeCard).join('') + '</div>';
+    }
+    return head
+      + '<p class="ip-sub">Step 2 of 2 — ' + escHtml(chosen.name) + '</p></header>'
+      + '<div class="ip-addtarget">'
+      +   '<section class="ip-card">'
+      +     '<h4>How the connection works</h4>'
+      +     '<p class="ip-sub">' + escHtml(chosen.direction) + '</p>'
+      +     '<h4>What you’ll need</h4><ul class="ip-needs">'
+      +       chosen.needs.map(n => '<li>' + escHtml(n) + '</li>').join('')
+      +     '</ul>'
+      +     '<p class="ip-sub">This preview doesn’t create anything. Octopus does the setup — '
+      +       'it’ll ask for these details as you go.</p>'
+      +     '<a class="ip-btn" href="' + escHtml(_newTargetUrl(IP)) + '" target="_blank" rel="noopener">Continue in Octopus →</a>'
+      +     ' <a class="ip-link" href="#targets/new">← Pick a different type</a>'
+      +   '</section></div>';
+  }
+  function bindAddTarget(IP) {
+    const root = document.getElementById('main-content');
+    if (!root) return;
+    root.querySelectorAll('.ip-type-card').forEach(card => card.addEventListener('click', () => {
+      IP.addTargetType = card.getAttribute('data-type');
+      root.innerHTML = renderAddTarget(IP);
+      bindAddTarget(IP);
+    }));
+    // "Pick a different type" keeps the hash unchanged, so clear the state and re-render here.
+    const back = root.querySelector('a[href="#targets/new"]');
+    if (back) back.addEventListener('click', e => {
+      e.preventDefault();
+      IP.addTargetType = null;
+      root.innerHTML = renderAddTarget(IP);
+      bindAddTarget(IP);
+    });
+  }
   function _envAddUrl() {
     let base = '';
     try { base = (typeof IP !== 'undefined' && IP && IP.serverUrl) || ''; } catch (e) { base = ''; }
@@ -621,7 +708,7 @@ const Views = (function () {
   }
   return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
-    renderAgents, bindAgents, renderArgo,
+    renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,
     renderThemeToggle, bindThemeToggle };
 })();

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -220,28 +220,86 @@ const Views = (function () {
       +   body + '</div></div>';
   }
   function _row(k,v){ return '<div class="ip-kv"><span>' + escHtml(k) + '</span><b>' + escHtml(v) + '</b></div>'; }
+  function _when(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10);
+  }
+  function _taskUrl(serverUrl, spaceId, taskId) {
+    return String(serverUrl || '').replace(/\/$/, '')
+      + '/app#/' + encodeURIComponent(spaceId || '') + '/tasks/' + encodeURIComponent(taskId || '');
+  }
+  // `raw` is the unnormalised fetch result: null means the request failed, [] means the
+  // target genuinely has none. Collapsing those two into one message is the failure mode
+  // this card exists to avoid.
+  function _activityCard(title, rows, raw, t, serverUrl, emptyMsg) {
+    const body = raw === null
+      ? '<p class="ip-sub">Couldn\'t load this from the Octopus API. Try again, or open the '
+        + '<a class="ip-link" href="' + escHtml(String(serverUrl||'').replace(/\/$/,'')
+        + '/app#/infrastructure/machines/' + encodeURIComponent(t.id)) + '" target="_blank" rel="noopener">'
+        + 'target page in Octopus</a>.</p>'
+      : !rows.length
+        ? '<p class="ip-sub">' + escHtml(emptyMsg) + '</p>'
+        : '<table class="ip-table"><tbody>' + rows.map(r =>
+            '<tr><td>' + pill(r.success ? 'healthy' : 'unhealthy', r.state) + '</td>'
+            + '<td><a class="ip-link" href="' + escHtml(_taskUrl(serverUrl, t.spaceId, r.id))
+            + '" target="_blank" rel="noopener">' + escHtml(r.description) + '</a></td>'
+            + '<td class="ip-when">' + escHtml(_when(r.completed)) + '</td></tr>').join('')
+          + '</tbody></table>';
+    return '<section class="ip-card ip-card-wide"><h4>' + escHtml(title) + '</h4>' + body + '</section>';
+  }
+  function deploymentsCardHtml(t, activity, raw, serverUrl) {
+    const last = activity.lastSuccessfulDeploy;
+    const lead = raw === null || !activity.deployments.length ? ''
+      : last
+        ? '<p class="ip-sub">Last successful: ' + escHtml(last.description)
+          + (last.completed ? ' (' + escHtml(_when(last.completed)) + ')' : '') + '</p>'
+        : '<p class="ip-sub">No deployment to this target has succeeded yet.</p>';
+    const card = _activityCard('Deployments', activity.deployments, raw, t, serverUrl,
+      'No deployments to this target in the retained task history.');
+    return card.replace('</h4>', '</h4>' + lead);
+  }
+  function runbooksCardHtml(t, activity, raw, serverUrl) {
+    return _activityCard('Runbook runs', activity.runbooks, raw, t, serverUrl,
+      'No runbook runs against this target in the retained task history.');
+  }
+  function connectivityCardHtml(t, connection) {
+    const rows = connection
+      ? _row('Status', connection.Status || '—')
+        + _row('Communication', t.comm)
+        + _row('Tentacle version', connection.CurrentTentacleVersion || t.version)
+        + (connection.LastChecked ? _row('Last checked', _when(connection.LastChecked)) : '')
+      : _row('Communication', t.comm) + _row('Health', t.health);
+    return '<section class="ip-card"><h4>Connectivity</h4>' + rows + '</section>';
+  }
   function renderTargetDetail(IP) {
     const t = (IP.estate.targets||[]).find(x => x.id === IP.detailId);
     if (!t) return '<div class="ip-state"><h3>Target not found</h3><a class="ip-link" href="#targets">← Back to targets</a></div>';
-    const machineUrl = String(IP.serverUrl||'').replace(/\/$/,'') + '/app#/infrastructure/machines/' + encodeURIComponent(t.id);
-    const placeholder = title => '<section class="ip-card"><h4>' + title + '</h4>'
-      + '<p class="ip-sub">Not available in PreAlpha — view on the <a class="ip-link" href="'
-      + escHtml(machineUrl) + '" target="_blank" rel="noopener">target page in Octopus</a>.</p></section>';
+    const loading = '<p class="ip-sub">Loading…</p>';
     return ''
       + '<a class="ip-link" href="#targets">← Deployment targets</a>'
       + '<header class="ip-head"><h2>' + escHtml(t.name) + '</h2>'
       +   '<p class="ip-sub">' + escHtml(t.kind) + ' · ' + escHtml(t.health) + '</p></header>'
       + '<div class="ip-grid">'
-      +   '<section class="ip-card"><h4>Connectivity</h4>' + _row('Communication', t.comm) + _row('Health', t.health) + '</section>'
+      +   '<div id="ip-td-conn">' + connectivityCardHtml(t, null) + '</div>'
       +   '<section class="ip-card"><h4>Tentacle version</h4>' + _row('Installed', t.version)
       +     '<p class="ip-sub">Upgrades are governed by the ' + escHtml(t.policy) + ' machine policy.</p></section>'
       +   '<section class="ip-card"><h4>Settings</h4>' + _row('Environment', t.env) + _row('Target tag', t.tag)
       +     _row('Tenant', t.tenant) + _row('Machine policy', t.policy) + '</section>'
-      +   placeholder('Projects &amp; last release')
-      +   placeholder('Recent deployments')
-      +   placeholder('Runbook runs')
-      +   placeholder('Events')
+      +   '<div id="ip-td-deploys"><section class="ip-card ip-card-wide"><h4>Deployments</h4>' + loading + '</section></div>'
+      +   '<div id="ip-td-runbooks"><section class="ip-card"><h4>Runbook runs</h4>' + loading + '</section></div>'
       + '</div>';
+  }
+  // Called once the per-target fetch resolves. The rest of the detail view is already on
+  // screen by then, so a slow or failing tasks call never blocks it.
+  function fillTargetDetail(IP, detail) {
+    const t = (IP.estate.targets||[]).find(x => x.id === IP.detailId);
+    if (!t || !detail) return;
+    const activity = Data.machineActivityModel(detail.tasks);
+    const set = (id, html) => { const el = document.getElementById(id); if (el) el.innerHTML = html; };
+    set('ip-td-conn', connectivityCardHtml(t, detail.connection));
+    set('ip-td-deploys', deploymentsCardHtml(t, activity, detail.tasks, IP.serverUrl));
+    set('ip-td-runbooks', runbooksCardHtml(t, activity, detail.tasks, IP.serverUrl));
   }
   function bindTargetDetail(IP) { /* back link is a plain hash anchor; nothing to wire yet */ }
 
@@ -706,7 +764,7 @@ const Views = (function () {
       Router.render();
     });
   }
-  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail,
+  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -149,6 +149,8 @@ const Views = (function () {
   }
   function renderTargets(IP) {
     const all = IP.estate.targets;
+    // Nothing to filter, so the facet rail and toolbar would be furniture around a void.
+    if (!all.length) return renderTargetsZero(IP);
     const facets = Data.buildFacets(all);
     const rows = Data.applyFilters(all, IP.filters, IP.search);
 
@@ -218,6 +220,78 @@ const Views = (function () {
       +     escHtml(IP.search||'') + '"><span class="ip-count">' + rows.length + ' of ' + all.length + '</span>'
       +     '<a class="ip-btn" href="#targets/new">Add deployment target</a></div>'
       +   body + '</div></div>';
+  }
+  // ── Designed zero states ──────────────────────────────────────────────────────
+  // A view with nothing in it gets the prototype's treatment: one centred card that
+  // explains what the thing is and how to add one, then a dimmed PREVIEW of what the
+  // populated view will look like. The preview is sample content, so it's labelled and
+  // muted — it has to be impossible to read as this estate's real data.
+  const ZERO_ICON = {
+    target: '<svg width="28" height="28" viewBox="0 0 20 20" fill="none" stroke="var(--color-blue-600)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="16" height="11" rx="1.5"/><path d="M7 17h6M10 14v3"/></svg>',
+    worker: '<svg width="28" height="28" viewBox="0 0 20 20" fill="var(--fg2)"><rect x="4" y="3" width="4" height="14" rx="1"/><rect x="12" y="3" width="4" height="14" rx="1"/></svg>'
+  };
+  function _zeroCard(icon, title, body, actionHref, actionLabel, learnHref, learnLabel) {
+    return '<section class="ip-zero">'
+      + '<div class="ip-zero-icon">' + icon + '</div>'
+      + '<h3>' + escHtml(title) + '</h3>'
+      + '<p class="ip-zero-body">' + escHtml(body) + '</p>'
+      + '<a class="ip-btn" href="' + escHtml(actionHref) + '">+ ' + escHtml(actionLabel) + '</a>'
+      + '<a class="ip-link ip-zero-learn" href="' + escHtml(learnHref) + '" target="_blank" rel="noopener">'
+      +   escHtml(learnLabel) + ' →</a>'
+      + '</section>';
+  }
+  function _previewBlock(caption, inner) {
+    return '<div class="ip-preview" aria-hidden="true">'
+      + '<div class="ip-preview-head"><span class="ip-preview-label">Preview</span></div>'
+      + '<p class="ip-sub">' + escHtml(caption) + '</p>'
+      + inner + '</div>';
+  }
+  function renderTargetsZero(IP) {
+    const rows = [
+      { name:'web-prod-public-api-01', sub:'Tentacle (Listening) · Windows Server 2022',
+        env:'Production', policy:'Auto-upgrade', version:'8.3.0' },
+      { name:'k8s-prod-worker-02', sub:'Kubernetes Agent · Linux',
+        env:'Production', policy:'Default', version:'2.6.0' }
+    ].map(r => '<tr><td><div class="ip-prev-name">' + escHtml(r.name) + '</div>'
+      + '<div class="ip-prev-sub">' + escHtml(r.sub) + '</div></td>'
+      + '<td>' + pill('healthy', 'Healthy') + '</td>'
+      + '<td>' + chip(r.env, 'env') + '</td>'
+      + '<td>' + escHtml(r.policy) + '</td>'
+      + '<td><span class="ip-dot ip-dot-healthy"></span> ' + escHtml(r.version) + '</td></tr>').join('');
+    return ''
+      + '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Deployment targets</h2>'
+      +   '<p class="ip-sub">Assess health across the estate and drill in with fast, faceted filters.</p></div>'
+      +   '<a class="ip-btn" href="#targets/new">+ Add deployment target</a></header>'
+      + _zeroCard(ZERO_ICON.target, 'Add your first deployment target',
+          'Deployment targets are the servers, clusters, and services your projects deploy to. '
+          + 'Add one and Octopus starts tracking its health automatically.',
+          '#targets/new', 'Add deployment target',
+          'https://octopus.com/docs/infrastructure/deployment-targets', 'Learn about deployment targets')
+      + _previewBlock('Once added, your targets appear here with health, environment, and agent version:',
+          '<table class="ip-table ip-prev-table"><thead><tr><th>Deployment target</th><th>Health</th>'
+          + '<th>Environment</th><th>Machine policy</th><th>Agent version</th></tr></thead>'
+          + '<tbody><tr class="ip-prev-group"><td colspan="5">'
+          + '<span class="ip-dot ip-dot-healthy"></span> Healthy</td></tr>'
+          + rows + '</tbody></table>');
+  }
+  function renderWorkersZero(IP) {
+    const pools = [{ name:'Default Pool', n:6 }, { name:'Hosted Ubuntu', n:4 }, { name:'DMZ Pool', n:2 }]
+      .map(p => '<div class="ip-card ip-prev-pool"><div class="ip-prev-pool-name">'
+        + ZERO_ICON.worker.replace('width="28" height="28"', 'width="14" height="14"')
+        + ' ' + escHtml(p.name) + '</div>'
+        + '<div class="ip-prev-pool-n">' + p.n + ' <span>workers</span></div>'
+        + '<div class="ip-prev-pool-bar"></div></div>').join('');
+    return ''
+      + '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Workers</h2>'
+      +   '<p class="ip-sub">A separate class of infrastructure — organised into shared pools, not tenant-scoped.</p></div>'
+      +   '<a class="ip-btn" href="' + escHtml(_workerAddUrl()) + '" target="_blank" rel="noopener">+ Add worker</a></header>'
+      + _zeroCard(ZERO_ICON.worker, 'Add your first worker',
+          'Workers are shared infrastructure that run deployment steps outside your targets — '
+          + 'ideal for tasks like Terraform, database migrations, or cloud API calls.',
+          _workerAddUrl(), 'Add worker',
+          'https://octopus.com/docs/infrastructure/workers', 'Learn about workers & worker pools')
+      + _previewBlock('Once added, workers are grouped into pools with their own health and versions:',
+          '<div class="ip-grid ip-prev-pools">' + pools + '</div>');
   }
   function _row(k,v){ return '<div class="ip-kv"><span>' + escHtml(k) + '</span><b>' + escHtml(v) + '</b></div>'; }
   function _when(iso) {
@@ -530,6 +604,7 @@ const Views = (function () {
   function renderWorkers(IP) {
     IP.wFilters = IP.wFilters || {}; IP.wSearch = IP.wSearch || ''; IP.wPage = IP.wPage || 1;
     const all = IP.estate.workers || [];
+    if (!all.length) return renderWorkersZero(IP);
     const model = Data.workersModel(all);
     const facets = Data.workerFacets(all);
     const rows = Data.applyWorkerFilters(all, IP.wFilters, IP.wSearch);
@@ -764,7 +839,7 @@ const Views = (function () {
       Router.render();
     });
   }
-  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml,
+  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -492,6 +492,9 @@ const Views = (function () {
     const base = tone === 'bad' ? '214,61,61' : '0,171,98'; // red / green rgb
     return '<td' + attrs + ' style="background:rgba(' + base + ',' + (0.12 + a * 0.7).toFixed(2) + ')">' + value + '</td>';
   }
+  const ENV_ICON = '<svg class="ip-env-icon" width="15" height="15" viewBox="0 0 20 20" fill="none"'
+    + ' stroke="var(--color-blue-400)" stroke-width="1.5" stroke-linejoin="round">'
+    + '<path d="M10 2l8 4-8 4-8-4 8-4z"/><path d="M2 10l8 4 8-4"/><path d="M2 14l8 4 8-4"/></svg>';
   function _envRow(r, maxHealthy, maxUnhealthy, expandedKey) {
     const open = !!expandedKey;
     const shown = open ? filterEnvTargets(r.targets, expandedKey) : [];
@@ -507,32 +510,55 @@ const Views = (function () {
       : '';
     const envAttr = ' data-env="' + escHtml(r.name) + '"';
     return '<tr class="ip-row ip-env-row' + (open ? ' ip-env-row-open' : '') + '"' + envAttr + '>'
-      + '<td class="ip-env-cell"' + envAttr + ' data-health="all"><span class="ip-env-toggle">' + (open ? '▾' : '▸') + '</span>' + escHtml(r.name) + '</td>'
+      + '<td class="ip-env-cell"' + envAttr + ' data-health="all"><span class="ip-env-toggle">' + (open ? '▾' : '▸') + '</span>'
+      +   ENV_ICON + '<span class="ip-env-name">' + escHtml(r.name) + '</span></td>'
       + '<td class="ip-env-cell"' + envAttr + ' data-health="all">' + r.total + '</td>'
       + _envHeatCell(r.healthy, maxHealthy, 'good', r.name, 'healthy')
       + _envHeatCell(r.unhealthy, maxUnhealthy, 'bad', r.name, 'unhealthy')
       + '<td class="ip-env-cell"' + envAttr + ' data-health="disabled">' + r.disabled + '</td></tr>' + sub;
   }
+  const ENV_MODES = [{ key:'all', label:'All' }, { key:'attention', label:'Needs attention' },
+                     { key:'healthy', label:'All healthy' }];
   function renderEnvironments(IP) {
-    const rows = Data.environmentsModel(IP.estate.targets, IP.estate.environments);
+    const all = Data.environmentsModel(IP.estate.targets, IP.estate.environments);
+    IP.envMode = IP.envMode || 'all';
+    IP.envQuery = IP.envQuery || '';
+    const rows = Data.filterEnvRows(all, IP.envQuery, IP.envMode);
     const maxHealthy = rows.reduce((m, r) => Math.max(m, r.healthy), 0);
     const maxUnhealthy = rows.reduce((m, r) => Math.max(m, r.unhealthy), 0);
     IP.envExpanded = IP.envExpanded || {};
     const body = rows.map(r => _envRow(r, maxHealthy, maxUnhealthy, IP.envExpanded[r.name])).join('');
+    const modes = ENV_MODES.map(m => '<button class="ip-seg' + (IP.envMode === m.key ? ' active' : '')
+      + '" data-mode="' + escHtml(m.key) + '">' + escHtml(m.label) + '</button>').join('');
+    const count = all.length + (all.length === 1 ? ' environment' : ' environments');
+
+    if (!all.length) {
+      return ''
+        + '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Environments</h2>'
+        +   '<p class="ip-sub">Infrastructure through the lens of your deployment pipeline. '
+        +   'Expand an environment to see its targets.</p></div>'
+        +   '<a class="ip-btn ip-btn-secondary" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">+ Add environment</a></header>'
+        + '<div class="ip-empty"><h3>No environments in this space</h3>'
+        +   '<p>Environments are the stages a release moves through — Dev, Test, Production.</p>'
+        +   '<a class="ip-btn" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>';
+    }
     return ''
-      + '<header class="ip-head"><h2>Environments</h2>'
-      +   '<p class="ip-sub">Infrastructure through the lens of your deployment pipeline. Expand an environment to see its targets.</p></header>'
-      + '<section class="ip-card">'
-      +   '<div class="ip-card-head"><h4>Environments <span class="ip-count-inline">' + rows.length + '</span></h4>'
-      +     '<div class="ip-card-actions"><a class="ip-link" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>'
-      +   '</div>'
-      +   (rows.length
-            ? '<table class="ip-table ip-heatmap ip-env-heatmap">' + _envHeatHead()
-              + '<tbody>' + body + '</tbody></table>'
-            : '<div class="ip-empty"><h3>No environments in this space</h3>'
-              + '<p>Environments are the stages a release moves through — Dev, Test, Production.</p>'
-              + '<a class="ip-btn" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">Add environment</a></div>')
-      + '</section>';
+      + '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Environments</h2>'
+      +   '<p class="ip-sub">Infrastructure through the lens of your deployment pipeline. '
+      +   'Expand an environment to see its targets.</p></div>'
+      +   '<a class="ip-btn ip-btn-secondary" href="' + escHtml(_envAddUrl()) + '" target="_blank" rel="noopener">+ Add environment</a></header>'
+      + '<div class="ip-env-toolbar">'
+      +   '<input class="ip-search ip-env-search" type="search" placeholder="Search environments…" value="'
+      +     escHtml(IP.envQuery) + '">'
+      +   '<div class="ip-segs">' + modes + '</div>'
+      +   '<span class="ip-count">' + escHtml(count) + '</span>'
+      + '</div>'
+      + '<div class="ip-heatmap-head ip-env-caption"><span class="ip-caption">Cell intensity = share of estate</span></div>'
+      + (rows.length
+          ? '<table class="ip-table ip-heatmap ip-env-heatmap">' + _envHeatHead()
+            + '<tbody>' + body + '</tbody></table>'
+          : '<div class="ip-empty"><h3>No environments match</h3>'
+            + '<p>Try a different search or filter.</p></div>');
   }
   function bindEnvironments(IP) {
     const root = document.getElementById('main-content');
@@ -547,6 +573,19 @@ const Views = (function () {
       else IP.envExpanded[name] = key;
       root.innerHTML = renderEnvironments(IP);
       bindEnvironments(IP);
+    }));
+    const rerender = () => { root.innerHTML = renderEnvironments(IP); bindEnvironments(IP); };
+    const search = root.querySelector('.ip-env-search');
+    if (search) search.addEventListener('input', e => {
+      IP.envQuery = e.target.value;
+      rerender();
+      // Re-focus and restore the caret; the input is replaced wholesale on each keystroke.
+      const again = root.querySelector('.ip-env-search');
+      if (again) { again.focus(); again.setSelectionRange(again.value.length, again.value.length); }
+    });
+    root.querySelectorAll('.ip-seg').forEach(b => b.addEventListener('click', () => {
+      IP.envMode = b.getAttribute('data-mode');
+      rerender();
     }));
   }
   function _policyCreateUrl() {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -67,9 +67,11 @@ const Views = (function () {
     const typeRows = ov.byType.map(r =>
       '<div class="ip-type-row">'
       + '<div class="ip-type-name">' + escHtml(r.name) + '</div>'
-      + '<div class="ip-type-bar">' + healthBar(r.healthy, r.unhealthy, 0) + '</div>'
+      + '<div class="ip-type-bar">' + healthBar(r.healthy, r.unhealthy, r.disabled || 0) + '</div>'
       + '<div class="ip-type-counts"><span class="ip-num-healthy">' + r.healthy + '</span>'
-      +   '<span class="ip-num-unhealthy">' + r.unhealthy + '</span></div></div>').join('');
+      +   '<span class="ip-num-unhealthy">' + r.unhealthy + '</span>'
+      +   (r.disabled ? '<span class="ip-num-disabled">' + r.disabled + '</span>' : '')
+      + '</div></div>').join('');
     const envTop = ov.byEnv.slice(0,5);
     const maxHealthy = envTop.reduce((m,r)=>Math.max(m, r.healthy), 0);
     const maxUnhealthy = envTop.reduce((m,r)=>Math.max(m, r.unhealthy), 0);
@@ -221,6 +223,16 @@ const Views = (function () {
       +     '<a class="ip-btn" href="#targets/new">Add deployment target</a></div>'
       +   body + '</div></div>';
   }
+  // A resource the API refused or failed to return is not an empty resource. Views call
+  // this instead of their zero state so nobody is told a collection is empty when we
+  // simply couldn't read it — most often a permissions boundary on the space.
+  function _unreadable(label) {
+    return '<div class="ip-empty"><h3>Couldn\'t load ' + escHtml(label) + '</h3>'
+      + '<p>Octopus didn\'t return ' + escHtml(label) + ' for this space. That usually means '
+      + 'your account can\'t read them here, rather than that there are none. '
+      + 'Try another space, or open Octopus directly.</p></div>';
+  }
+
   // ── Designed zero states ──────────────────────────────────────────────────────
   // A view with nothing in it gets the prototype's treatment: one centred card that
   // explains what the thing is and how to add one, then a dimmed PREVIEW of what the
@@ -485,8 +497,14 @@ const Views = (function () {
   // Env heat cells carry data-env/data-health so a click can identify which environment and
   // which filter was clicked. This is a local twin of heatCell(), not a change to it — heatCell
   // is shared with Overview's read-only heatmap, which must stay non-interactive and unchanged.
+  function _envCellAttrs(name, key, extraClass) {
+    const what = key === 'all' ? 'all targets' : key + ' targets';
+    return ' class="' + extraClass + '" role="button" tabindex="0"'
+      + ' aria-label="Show ' + escHtml(what) + ' in ' + escHtml(name) + '"'
+      + ' data-env="' + escHtml(name) + '" data-health="' + escHtml(key) + '"';
+  }
   function _envHeatCell(value, max, tone, name, key) {
-    const attrs = ' class="ip-heat ip-env-cell" data-env="' + escHtml(name) + '" data-health="' + escHtml(key) + '"';
+    const attrs = _envCellAttrs(name, key, 'ip-heat ip-env-cell');
     if (value === 0) return '<td' + attrs + '>0</td>';
     const a = max > 0 ? (value / max) : 0;
     const base = tone === 'bad' ? '214,61,61' : '0,171,98'; // red / green rgb
@@ -510,12 +528,13 @@ const Views = (function () {
       : '';
     const envAttr = ' data-env="' + escHtml(r.name) + '"';
     return '<tr class="ip-row ip-env-row' + (open ? ' ip-env-row-open' : '') + '"' + envAttr + '>'
-      + '<td class="ip-env-cell"' + envAttr + ' data-health="all"><span class="ip-env-toggle">' + (open ? '▾' : '▸') + '</span>'
+      + '<td' + _envCellAttrs(r.name, 'all', 'ip-env-cell') + ' aria-expanded="' + (open ? 'true' : 'false') + '">'
+      +   '<span class="ip-env-toggle">' + (open ? '▾' : '▸') + '</span>'
       +   ENV_ICON + '<span class="ip-env-name">' + escHtml(r.name) + '</span></td>'
-      + '<td class="ip-env-cell"' + envAttr + ' data-health="all">' + r.total + '</td>'
+      + '<td' + _envCellAttrs(r.name, 'all', 'ip-env-cell') + '>' + r.total + '</td>'
       + _envHeatCell(r.healthy, maxHealthy, 'good', r.name, 'healthy')
       + _envHeatCell(r.unhealthy, maxUnhealthy, 'bad', r.name, 'unhealthy')
-      + '<td class="ip-env-cell"' + envAttr + ' data-health="disabled">' + r.disabled + '</td></tr>' + sub;
+      + '<td' + _envCellAttrs(r.name, 'disabled', 'ip-env-cell') + '>' + r.disabled + '</td></tr>' + sub;
   }
   const ENV_MODES = [{ key:'all', label:'All' }, { key:'attention', label:'Needs attention' },
                      { key:'healthy', label:'All healthy' }];
@@ -532,6 +551,12 @@ const Views = (function () {
       + '" data-mode="' + escHtml(m.key) + '">' + escHtml(m.label) + '</button>').join('');
     const count = all.length + (all.length === 1 ? ' environment' : ' environments');
 
+    if (!all.length && IP.estate.failed && IP.estate.failed.environments) {
+      return ''
+        + '<header class="ip-head"><h2>Environments</h2>'
+        + '<p class="ip-sub">Infrastructure through the lens of your deployment pipeline.</p></header>'
+        + _unreadable('environments');
+    }
     if (!all.length) {
       return ''
         + '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Environments</h2>'
@@ -565,15 +590,25 @@ const Views = (function () {
     // Each clickable cell (name, Total, Healthy, Unhealthy, Disabled) carries its own
     // data-env/data-health pair, so binding per-cell (not per-row) means a single click
     // fires exactly one handler — no row-level listener to double-fire alongside it.
-    root.querySelectorAll('.ip-env-row [data-health]').forEach(cell => cell.addEventListener('click', () => {
-      const name = cell.getAttribute('data-env');
-      const key = cell.getAttribute('data-health');
-      IP.envExpanded = IP.envExpanded || {};
-      if (IP.envExpanded[name] === key) delete IP.envExpanded[name];
-      else IP.envExpanded[name] = key;
-      root.innerHTML = renderEnvironments(IP);
-      bindEnvironments(IP);
-    }));
+    root.querySelectorAll('.ip-env-row [data-health]').forEach(cell => {
+      const toggle = () => {
+        const name = cell.getAttribute('data-env');
+        const key = cell.getAttribute('data-health');
+        IP.envExpanded = IP.envExpanded || {};
+        if (IP.envExpanded[name] === key) delete IP.envExpanded[name];
+        else IP.envExpanded[name] = key;
+        root.innerHTML = renderEnvironments(IP);
+        bindEnvironments(IP);
+        // Re-render replaces the node, so put focus back where the user left it.
+        const again = root.querySelector('.ip-env-row [data-env="' + (name || '').replace(/"/g, '\\"')
+          + '"][data-health="' + key + '"]');
+        if (again) again.focus();
+      };
+      cell.addEventListener('click', toggle);
+      cell.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') { e.preventDefault(); toggle(); }
+      });
+    });
     const rerender = () => { root.innerHTML = renderEnvironments(IP); bindEnvironments(IP); };
     const search = root.querySelector('.ip-env-search');
     if (search) search.addEventListener('input', e => {
@@ -643,6 +678,11 @@ const Views = (function () {
   function renderWorkers(IP) {
     IP.wFilters = IP.wFilters || {}; IP.wSearch = IP.wSearch || ''; IP.wPage = IP.wPage || 1;
     const all = IP.estate.workers || [];
+    const wFailed = IP.estate.failed && IP.estate.failed.workers;
+    if (!all.length && wFailed) return ''
+      + '<header class="ip-head"><h2>Workers</h2>'
+      + '<p class="ip-sub">A separate class of infrastructure — organised into shared pools, not tenant-scoped.</p></header>'
+      + _unreadable('workers');
     if (!all.length) return renderWorkersZero(IP);
     const model = Data.workersModel(all);
     const facets = Data.workerFacets(all);

--- a/promptsv4.json
+++ b/promptsv4.json
@@ -32,6 +32,10 @@
           {
             "dashboardName": "Target agent versions",
             "dashboardFile": "targetagentversions/index.html"
+          },
+          {
+            "dashboardName": "Infrastructure (PreAlpha)",
+            "dashboardFile": "infrastructureprealpha/index.html"
           }
         ]
       },
@@ -79,6 +83,10 @@
           {
             "dashboardName": "Target agent versions",
             "dashboardFile": "targetagentversions/index.html"
+          },
+          {
+            "dashboardName": "Infrastructure (PreAlpha)",
+            "dashboardFile": "infrastructureprealpha/index.html"
           }
         ]
       },


### PR DESCRIPTION
## What this is

A new community dashboard, **Infrastructure (PreAlpha)**, that reimagines the Octopus **Infrastructure** section as a single embedded page wired to the real Octopus REST API (read-only). Lives at `dashboards/infrastructureprealpha/` and is registered in `promptsv4.json`.

## Views

- **Overview** — health donut, health-by-target-type bars, environment heatmap, workers summary, and an "N agents behind" pill.
- **Deployment targets** — faceted list (type/OS/health/env/tag/tenant/policy/version), health pills and env/tag chips, health-grouped rows.
- **Target detail** — connectivity, Tentacle version, settings, plus **real deployment history, runbook runs and events for that target**, fetched when the route opens.
- **Add a deployment target** — a two-step walkthrough at `#targets/new`: pick how Octopus should reach the machine, see the ports and prerequisites that choice implies, then hand off to Octopus. Writes nothing.
- **Environments** — search, All / Needs attention / All healthy filters, heatmap aligned with the Overview, expandable rows; clicking a health cell filters the expanded targets to that status.
- **Machine policies** — one card per policy with usage counts and governance settings.
- **Workers & worker pools** — pool summary + faceted worker list.
- **Deployment agents** — Tentacle/Kubernetes tabs, KPI cards, version distribution by major-version band; "behind" = agent major version at least one below the latest for its type.
- **Argo CD** — an honest "not available via the Octopus API yet" state. The API exposes no Argo endpoints, so there is nothing to show and nothing invented.

Plus a **space switcher** that rescopes every view, a **cold-start experience**, and a persisted **dark/light theme toggle**.

Only the selected space is loaded. Boot lists spaces in one request and hydrates just the one it's about to show, caching the result; switching to a space already seen costs nothing. Previously every space was hydrated at boot to display one — on a 9-space instance, 54 requests for one space's data.

## What the API actually supports

Three per-target data risks were listed as open in the design doc and never checked. A read-only probe against a live instance settled them:

- `/api/{space}/machines/{id}/tasks` returns that target's real deployment and runbook history — task name, description, state, completion time, project. This backs the detail view.
- `/api/{space}/machines/{id}/connection` returns status, current Tentacle version and last-checked.
- **`/api/{space}/tasks?regarding={id}` silently ignores the filter** and returns the entire task list. It looks like it works. Don't use it.
- `/api/{space}/events?regarding={machineId}` **is** honoured, unlike its tasks counterpart. Established by discrimination, not by any single result: a space holding 159,294 events returns 22 for a machine-scoped query. Had the filter been ignored it would have returned all of them. This backs the Events card.
- Earlier probes showed zero events for a machine on another instance, which looked like a broken filter and turned out to be Octopus' event pruning — that target's last activity was April 2025. The card says as much when a result is empty, rather than implying nothing ever happened.

## One rule worth stating

The UI never asserts a fact it hasn't verified. In practice:

- A failed fetch and an empty result render differently. "Couldn't load this" is never shown as "there are none".
- `emptyKind()` separates "this space has no workers" from "no workers match your filters", so nobody is told to clear a filter they never set.
- The zero-state previews are sample content, so they're labelled Preview, muted, and `aria-hidden` — they can't be read as this estate's own inventory.
- A target-detail card previously claimed "no runbook runs yet" without fetching anything. Removed.

## Safety & conventions

- **Read-only**: every Octopus API call is `GET` with `credentials: 'include'`. No mutating requests. Add / upgrade / connect actions are `<a href>` link-outs to the Octopus app.
- **Self-contained**: only `../api.js` is referenced. No external resources, no `eval`, no Chrome extensions API, no cookie reads. All `innerHTML` takes escaped values or trusted static markup.
- **97 passing jest tests** on the pure layer — normalisation, rollups, facets, filters, agent versioning, per-target activity, empty-state selection, cold-start routing.

## Known items for live verification

- OS / OS-version and machine-policy governance field names are best-effort candidate scans (flagged in code), pending confirmation against more instances.
- The Deployment Agents "Upgrade" link goes to the machines list; agent rows carry no per-machine id.
- Accent chips use the design-system pastel scale tokens, which aren't overridden for dark mode, so they stay light on dark cards.
- Task history is bounded by Octopus' own task retention, so a long-idle target can legitimately show no deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
