### PR TITLE
Infrastructure (PreAlpha): nav restructure, red unhealthy ring, linked target names

### DIFF
--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -895,3 +895,306 @@ describe('lazy space hydration', () => {
   });
 
 });
+
+// Paul Stovell's feedback on the walkthrough (28 Jul 2026): Machine Policies is a rare
+// destination and belongs inside Deployment Targets; the sidebar should carry five items,
+// with Deployment Targets | Agents | Policies as horizontal tabs within one section.
+describe('Deployment Targets section tabs (Paul Stovell feedback)', () => {
+  const Views = require('./views');
+  global.Data = require('./data');
+  const target = { id:'t1', name:'real-target', type:'Tentacle', kind:'Tentacle (Polling)', os:'', osVersion:'',
+    health:'Healthy', healthKey:'healthy', env:'Production', envCat:'production', tag:'web',
+    moreTags:0, tenant:'No tenants', policy:'Default', version:'8.5.1' };
+  const base = { serverUrl:'https://x.octopus.app/', filters:{}, search:'', page:1,
+                 wFilters:{}, wSearch:'', wPage:1 };
+  const empty = { ...base, estate:{ targets:[], workers:[], environments:[], policies:[] } };
+  const full  = { ...base, estate:{ targets:[target], workers:[], environments:[], policies:[] } };
+  const activeLabels = html => (html.match(/ip-section-tab ip-tab-active"[^>]*>([^<]+)</g) || [])
+    .map(m => m.replace(/^.*>/, '').replace(/<$/, ''));
+
+  test('every section renders all three tabs, so none is a dead end', () => {
+    [Views.renderTargets(full), Views.renderTargets(empty),
+     Views.renderAgents(full), Views.renderMachinePolicies(full)].forEach(html => {
+      expect(html).toContain('href="#targets"');
+      expect(html).toContain('href="#agents"');
+      expect(html).toContain('href="#machinepolicies"');
+    });
+  });
+
+  test('exactly one tab is active, and it is the section being rendered', () => {
+    expect(activeLabels(Views.renderTargets(full))).toEqual(['Deployment Targets']);
+    expect(activeLabels(Views.renderTargets(empty))).toEqual(['Deployment Targets']);
+    expect(activeLabels(Views.renderAgents(full))).toEqual(['Agents']);
+    expect(activeLabels(Views.renderMachinePolicies(full))).toEqual(['Policies']);
+  });
+
+  test('the page title is stable across tabs, so the tabs read as tabs', () => {
+    [Views.renderTargets(full), Views.renderTargets(empty),
+     Views.renderAgents(full), Views.renderMachinePolicies(full)].forEach(html => {
+      expect(html).toContain('<h2>Deployment targets</h2>');
+    });
+    // the old top-level headings are gone; the tab label names the sub-view now
+    expect(Views.renderAgents(full)).not.toContain('<h2>Deployment agents</h2>');
+    expect(Views.renderMachinePolicies(full)).not.toContain('<h2>Machine policies</h2>');
+  });
+
+  test('each tab keeps its own framing in the subtitle', () => {
+    expect(Views.renderTargets(full)).toMatch(/faceted filters/);
+    expect(Views.renderAgents(full)).toMatch(/Latest available/);
+    expect(Views.renderMachinePolicies(full)).toMatch(/health-check schedules/);
+  });
+
+  test('the tab bar sits above the facet rail, not inside the targets column', () => {
+    const html = Views.renderTargets(full);
+    expect(html.indexOf('ip-section-tabs')).toBeLessThan(html.indexOf('ip-targets-wrap'));
+    expect(html.indexOf('ip-section-tabs')).toBeGreaterThan(html.indexOf('<h2>Deployment targets</h2>'));
+  });
+
+  test('Tentacle/Kubernetes is a segmented control, subordinate to the section tabs', () => {
+    const html = Views.renderAgents(full);
+    expect(html).toContain('ip-kind-btn');
+    expect(html).toMatch(/ip-kind-btn[^>]*data-tab="tentacle"/);
+    expect(html).toMatch(/ip-kind-btn[^>]*data-tab="kubernetes"/);
+    // bindAgents binds .ip-kind-btn; a leftover .ip-tab button here would swallow tab
+    // navigation clicks and re-render Agents in place instead of routing.
+    expect(html).not.toMatch(/<button[^>]*class="ip-tab/);
+  });
+
+  test('the agent-kind choice still switches which group is shown', () => {
+    const t = Views.renderAgents({ ...full, agentTab:'tentacle' });
+    const k = Views.renderAgents({ ...full, agentTab:'kubernetes' });
+    expect(t).toMatch(/ip-kind-btn ip-kind-active"[^>]*data-tab="tentacle"/);
+    expect(k).toMatch(/ip-kind-btn ip-kind-active"[^>]*data-tab="kubernetes"/);
+  });
+
+  // .ip-seg is the Environments mode button. The agent-kind control briefly reused it as a
+  // container class, which left the two CSS rules overwriting each other's background and
+  // border. Keep the two vocabularies disjoint.
+  test('the agent-kind control does not reuse the Environments .ip-seg class', () => {
+    expect(Views.renderAgents(full)).not.toMatch(/class="ip-seg[ "]/);
+  });
+
+  test('each segmented-control class is defined exactly once in the stylesheet', () => {
+    const fs = require('fs');
+    const css = fs.readFileSync(require('path').join(__dirname, 'styles.css'), 'utf8');
+    const defs = sel => (css.match(new RegExp('^\\' + sel + '\\{', 'gm')) || []).length;
+    expect(defs('.ip-seg')).toBe(1);
+    expect(defs('.ip-kind-seg')).toBe(1);
+  });
+});
+
+// The Environments view expands into a per-environment target sub-list. The target name was
+// plain text there, while the same name in the Targets table linked to its detail page.
+describe('environments sub-list links its targets', () => {
+  const Views = require('./views');
+  const d = require('./data');
+  global.Data = d;
+  const t = (id, name, healthKey) => ({ id, name, spaceId:'Spaces-1', type:'Tentacle',
+    kind:'Tentacle (Polling)', os:'Ubuntu', osVersion:'22.04', health:healthKey,
+    healthKey, env:'Production', envCat:'production', tag:'web', moreTags:0,
+    tenant:'No tenants', policy:'Default', version:'8.5.1' });
+  const targets = [t('Machines-1','web-prod-01','healthy'), t('Machines-2','db-prod-01','unhealthy')];
+  const IP = () => ({ serverUrl:'https://x.octopus.app/', envMode:'all', envQuery:'',
+    envExpanded:{ Production:'all' },
+    estate:{ targets, workers:[], environments:[{ id:'Environments-1', name:'Production' }], policies:[] } });
+
+  test('an expanded environment links each target to its detail page', () => {
+    const html = Views.renderEnvironments(IP());
+    expect(html).toContain('href="#targets/Machines-1"');
+    expect(html).toContain('href="#targets/Machines-2"');
+    expect(html).toContain('ip-target-link');
+  });
+
+  test('the link is inside the sub-list row, not the environment row', () => {
+    const html = Views.renderEnvironments(IP());
+    const sub = /<tr class="ip-env-sub">([\s\S]*?)<\/tr>\s*<\/tbody>|<tr class="ip-env-sub">([\s\S]*)/
+      .exec(html);
+    expect((sub[1] || sub[2])).toContain('href="#targets/Machines-1"');
+  });
+
+  test('a collapsed environment renders no target links', () => {
+    const collapsed = { ...IP(), envExpanded:{} };
+    expect(Views.renderEnvironments(collapsed)).not.toContain('href="#targets/');
+  });
+
+  test('an id needing escaping is encoded', () => {
+    const odd = { ...IP(), estate: { ...IP().estate, targets:[t('Machines-a b','odd','healthy')] } };
+    expect(Views.renderEnvironments(odd)).toContain('href="#targets/Machines-a%20b"');
+  });
+
+  // The sub-list table is nested inside a .ip-heatmap cell, so the heatmap's link-neutralising
+  // rule reached it as a descendant and rendered the linked names as plain label text.
+  test('the heatmap link reset cannot reach the nested sub-list', () => {
+    const fs = require('fs');
+    const css = fs.readFileSync(require('path').join(__dirname, 'styles.css'), 'utf8');
+    const resets = css.match(/^\.ip-heatmap[^{]*td:first-child[^{]*a[^{]*\{[^}]*\}/gm) || [];
+    expect(resets.length).toBeGreaterThan(0);
+    resets.forEach(rule => expect(rule).toMatch(/td:first-child\s*>\s*a/));
+  });
+
+  test('a target with no id stays plain text rather than linking nowhere', () => {
+    const noId = { ...IP(), estate: { ...IP().estate, targets:[t('','no-id','healthy')] } };
+    const html = Views.renderEnvironments(noId);
+    expect(html).toContain('no-id');
+    expect(html).not.toContain('href="#targets/"');
+  });
+});
+
+// The agent table identified a machine by name only, and the name wasn't clickable — the row
+// model dropped the machine id and OS fields that machineToTarget already carries.
+describe('agent table carries machine identity', () => {
+  const d = require('./data');
+  const Views = require('./views');
+  global.Data = d;
+  const t = (over) => Object.assign({
+    id:'Machines-1', name:'web-prod-01', spaceId:'Spaces-1', type:'Tentacle',
+    kind:'Tentacle (Listening)', os:'Microsoft Windows Server 2022', osVersion:'10.0.20348',
+    health:'Healthy', healthKey:'healthy', env:'Production', envCat:'production', tag:'web',
+    moreTags:0, tenant:'No tenants', policy:'Auto-upgrade', version:'8.5.1' }, over || {});
+
+  test('the row model keeps the machine id and OS fields', () => {
+    const row = d.agentsModel([t()]).tentacle.rows[0];
+    expect(row).toMatchObject({ id:'Machines-1', name:'web-prod-01',
+      os:'Microsoft Windows Server 2022', osVersion:'10.0.20348' });
+  });
+
+  test('the machine name links to its detail page, the way the targets table does', () => {
+    const html = Views.renderAgents({ serverUrl:'https://x.octopus.app/', agentTab:'tentacle',
+      estate:{ targets:[t()], workers:[], environments:[], policies:[] } });
+    expect(html).toContain('href="#targets/Machines-1"');
+    expect(html).toContain('ip-target-link');
+  });
+
+  test('an id needing escaping is encoded in the href', () => {
+    const html = Views.renderAgents({ serverUrl:'https://x.octopus.app/', agentTab:'tentacle',
+      estate:{ targets:[t({ id:'Machines-a b' })], workers:[], environments:[], policies:[] } });
+    expect(html).toContain('href="#targets/Machines-a%20b"');
+  });
+
+  test('the OS and OS version reach the rendered row', () => {
+    const html = Views.renderAgents({ serverUrl:'https://x.octopus.app/', agentTab:'tentacle',
+      estate:{ targets:[t()], workers:[], environments:[], policies:[] } });
+    expect(html).toContain('Microsoft Windows Server 2022');
+    expect(html).toContain('10.0.20348');
+  });
+
+  test('columns are headed to match the targets table vocabulary', () => {
+    const html = Views.renderAgents({ serverUrl:'https://x.octopus.app/', agentTab:'tentacle',
+      estate:{ targets:[t()], workers:[], environments:[], policies:[] } });
+    ['<th>Machine name</th>','<th>Environment</th>','<th>Operating system</th>',
+     '<th>OS version</th>','<th>Agent version</th>','<th>Status</th>','<th>Machine policy</th>']
+      .forEach(th => expect(html).toContain(th));
+    // "Version" alone is ambiguous once OS version is in the table
+    expect(html).not.toContain('<th>Version</th>');
+  });
+
+  test('a machine with no reported OS leaves the cells blank, not "Unknown"', () => {
+    const html = Views.renderAgents({ serverUrl:'https://x.octopus.app/', agentTab:'kubernetes',
+      estate:{ targets:[t({ type:'Kubernetes', kind:'Kubernetes Agent', os:'', osVersion:'',
+        version:'2.6.0' })], workers:[], environments:[], policies:[] } });
+    // scoped to the row: "Unknown" is also a KPI card heading (the unknown-version bucket)
+    const row = /<tr class="ip-row-static">([\s\S]*?)<\/tr>/.exec(html)[1];
+    expect(row).not.toMatch(/Unknown/);
+    expect(row).toContain('<td></td><td></td>');       // OS and OS version, both empty
+    expect(row).toContain('href="#targets/Machines-1"');
+  });
+});
+
+// The overview ring drew one green arc against a grey remainder, so unhealthy and disabled
+// targets shared an undifferentiated track — while the health-by-type bars beside it were
+// already green/red/slate. The ring now segments the same way.
+describe('overview ring segments unhealthy in red', () => {
+  const Views = require('./views');
+  const arcs = svg => [...svg.matchAll(/stroke="(var\(--color-[a-z]+-\d+\))"/g)].map(m => m[1]);
+
+  test('unhealthy targets get their own red arc', () => {
+    const svg = Views.donut({ healthy:10, unhealthy:3, disabled:1, healthyPct:71 });
+    expect(arcs(svg)).toEqual([
+      'var(--color-green-400)', 'var(--color-red-400)', 'var(--color-slate-300)']);
+  });
+
+  test('the ring uses the same colours as the health bar', () => {
+    const ring = arcs(Views.donut({ healthy:7, unhealthy:2, disabled:1 }));
+    const bar = [...Views.healthBar(7, 2, 1).matchAll(/background:(var\(--color-[a-z]+-\d+\))/g)].map(m => m[1]);
+    expect(ring).toEqual(bar);
+  });
+
+  test('arc lengths are proportional to the counts, and fill the ring exactly', () => {
+    const svg = Views.donut({ healthy:10, unhealthy:3, disabled:1 });
+    const lens = [...svg.matchAll(/stroke-dasharray="([\d.]+) ([\d.]+)"/g)]
+      .map(m => ({ len: parseFloat(m[1]), circ: parseFloat(m[2]) }));
+    const C = lens[0].circ;
+    expect(lens.map(l => Math.round(l.len / C * 100))).toEqual([71, 21, 7]);
+    expect(lens.reduce((s, l) => s + l.len, 0)).toBeCloseTo(C, 1);
+  });
+
+  test('segments are laid end to end, each offset by what precedes it', () => {
+    const svg = Views.donut({ healthy:10, unhealthy:3, disabled:1 });
+    const offs = [...svg.matchAll(/stroke-dashoffset="(-?[\d.]+)"/g)].map(m => parseFloat(m[1]));
+    const lens = [...svg.matchAll(/stroke-dasharray="([\d.]+) /g)].map(m => parseFloat(m[1]));
+    expect(offs[0]).toBe(0);
+    expect(offs[1]).toBeCloseTo(-lens[0], 1);
+    expect(offs[2]).toBeCloseTo(-(lens[0] + lens[1]), 1);
+  });
+
+  test('a bucket with nothing in it draws no arc', () => {
+    expect(arcs(Views.donut({ healthy:12, unhealthy:0, disabled:0 })))
+      .toEqual(['var(--color-green-400)']);
+    expect(arcs(Views.donut({ healthy:0, unhealthy:4, disabled:0 })))
+      .toEqual(['var(--color-red-400)']);
+  });
+
+  test('an empty estate draws the bare track and reads 0%', () => {
+    const svg = Views.donut({ healthy:0, unhealthy:0, disabled:0 });
+    expect(arcs(svg)).toEqual([]);
+    expect(svg).toContain('>0%<');
+    expect(svg).toContain('var(--muted)');            // the track is still there
+  });
+
+  test('healthyPct is honoured when given, derived when not', () => {
+    expect(Views.donut({ healthy:10, unhealthy:3, disabled:1, healthyPct:71 })).toContain('>71%<');
+    expect(Views.donut({ healthy:1, unhealthy:1, disabled:0 })).toContain('>50%<');
+  });
+
+  test('the overview passes the counts through, not just the percentage', () => {
+    global.Data = require('./data');
+    const d = require('./data');
+    const t = (name, healthKey) => ({ id:name, name, type:'Tentacle', kind:'Tentacle (Polling)', os:'', osVersion:'',
+      health:healthKey, healthKey, env:'Production', envCat:'production', tag:'web', moreTags:0,
+      tenant:'No tenants', policy:'Default', version:'8.5.1' });
+    const targets = [t('a','healthy'), t('b','unhealthy'), t('c','disabled')];
+    const ov = d.overviewModel(targets, []);
+    const html = Views.renderOverview(ov, { targets, workers:[], environments:[], policies:[] });
+    expect(html).toContain('var(--color-red-400)');   // the ring, not only the type bars
+    expect(html.match(/var\(--color-red-400\)/g).length).toBeGreaterThan(1);
+  });
+});
+
+describe('sidebar is down to Paul\'s five items', () => {
+  const fs = require('fs');
+  const html = fs.readFileSync(require('path').join(__dirname, 'index.html'), 'utf8');
+  const items = [...html.matchAll(/class="ip-nav-item" data-view="([^"]+)">([^<]+)</g)]
+    .map(m => ({ view:m[1], label:m[2] }));
+
+  test('five nav items, in the order Paul proposed', () => {
+    expect(items.map(i => i.view)).toEqual(
+      ['overview','targets','environments','workers','argocd']);
+  });
+
+  test('Machine Policies and Deployment Agents are no longer nav destinations', () => {
+    expect(items.map(i => i.view)).not.toContain('machinepolicies');
+    expect(items.map(i => i.view)).not.toContain('agents');
+    expect(html).not.toContain('>Machine Policies<');
+    expect(html).not.toContain('>Deployment Agents<');
+  });
+
+  test('every nav item still has a route to render it', () => {
+    const router = fs.readFileSync(require('path').join(__dirname, 'router.js'), 'utf8');
+    const views = /const VIEWS = \[([^\]]+)\]/.exec(router)[1];
+    items.forEach(i => expect(views).toContain("'" + i.view + "'"));
+    // the demoted views keep their routes — they're reached by tab now, and the overview's
+    // agent-versions pill still links straight to #agents
+    expect(views).toContain("'agents'");
+    expect(views).toContain("'machinepolicies'");
+  });
+});

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -339,8 +339,10 @@ function _agentGroup(rows) {
     const isUnknown = !t.version || t.version === '—';
     const isBehind = !isUnknown && majorVersion(t.version) < latestMajor;
     if (isUnknown) unknown++; else if (isBehind) behind++; else upToDate++;
-    return { name: t.name, env: t.env, version: t.version, band: versionBand(t.version),
-      behind: isBehind, policy: t.policy };
+    // Carries the machine id and OS through from machineToTarget: the agent table names the
+    // machine, links to its detail page, and reports the OS it's running on.
+    return { id: t.id, name: t.name, env: t.env, os: t.os, osVersion: t.osVersion,
+      version: t.version, band: versionBand(t.version), behind: isBehind, policy: t.policy };
   });
   const distMap = {};
   outRows.forEach(r => { const d = (distMap[r.version] = distMap[r.version] || { version: r.version, count: 0, band: r.band }); d.count++; });
@@ -430,7 +432,10 @@ function environmentsModel(targets, environments) {
     if (t.healthKey === 'healthy') e.healthy++;
     else if (t.healthKey === 'disabled') e.disabled++;
     else e.unhealthy++;
-    e.targets.push({ name: t.name, type: t.type, healthKey: t.healthKey, health: t.health, tag: t.tag, tenant: t.tenant });
+    // id comes through so the expanded sub-list can link each target to its detail page,
+    // the same way the targets table and the agent table do.
+    e.targets.push({ id: t.id, name: t.name, type: t.type, healthKey: t.healthKey,
+      health: t.health, tag: t.tag, tenant: t.tenant });
   });
   (environments || []).forEach(env => {
     if (!map[env.name]) map[env.name] = { name: env.name, total: 0, healthy: 0, unhealthy: 0, disabled: 0, targets: [] };

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -15,14 +15,15 @@
     <aside class="ip-sidebar">
       <div id="ip-space-switch" class="ip-space-switch"></div>
       <div class="ip-sidebar-title">Infrastructure</div>
+      <!-- Five items, per Paul Stovell's feedback on the 28 Jul walkthrough. Machine Policies
+           and Deployment Agents are rare destinations and are now tabs inside Deployment
+           Targets; both keep their routes (#machinepolicies, #agents). -->
       <nav class="ip-nav">
-        <a href="#overview"       class="ip-nav-item" data-view="overview">Overview</a>
-        <a href="#targets"        class="ip-nav-item" data-view="targets">Deployment Targets</a>
-        <a href="#environments"   class="ip-nav-item" data-view="environments">Environments</a>
-        <a href="#machinepolicies" class="ip-nav-item" data-view="machinepolicies">Machine Policies</a>
-        <a href="#workers"        class="ip-nav-item" data-view="workers">Workers &amp; Worker Pools</a>
-        <a href="#agents"         class="ip-nav-item" data-view="agents">Deployment Agents</a>
-        <a href="#argocd"         class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
+        <a href="#overview"     class="ip-nav-item" data-view="overview">Overview</a>
+        <a href="#targets"      class="ip-nav-item" data-view="targets">Deployment Targets</a>
+        <a href="#environments" class="ip-nav-item" data-view="environments">Environments</a>
+        <a href="#workers"      class="ip-nav-item" data-view="workers">Workers &amp; Worker Pools</a>
+        <a href="#argocd"       class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
       </nav>
       <div id="ip-theme-toggle" class="ip-theme-toggle"></div>
     </aside>

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -1,6 +1,8 @@
 'use strict';
 const Router = (function () {
   const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd'];
+  // Views that render inside the Deployment Targets section shell.
+  const IP_TARGET_SECTION_VIEWS = ['targets','agents','machinepolicies'];
   function setActive(view) {
     document.querySelectorAll('.ip-nav-item').forEach(a =>
       a.classList.toggle('active', a.getAttribute('data-view') === view));
@@ -47,7 +49,11 @@ const Router = (function () {
       return;
     }
     const view = VIEWS.includes(hash) ? hash : 'overview';
-    setActive(view);
+    // Agents and machine policies are tabs inside the Deployment Targets section rather than
+    // nav items of their own, so the sidebar highlights the section they live in. Their
+    // routes are unchanged: the tabs are anchors, and the overview's agent-versions pill
+    // still links straight to #agents.
+    setActive(IP_TARGET_SECTION_VIEWS.includes(view) ? 'targets' : view);
     if (view === 'overview')  { el.innerHTML = Views.renderOverview(IP.estate.overview, IP.estate); }
     else if (view === 'targets') { el.innerHTML = Views.renderTargets(IP); Views.bindTargets && Views.bindTargets(IP); }
     else if (view === 'environments') { el.innerHTML = Views.renderEnvironments(IP); Views.bindEnvironments && Views.bindEnvironments(IP); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -314,8 +314,11 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-heatmap th:nth-child(3),.ip-heatmap td:nth-child(3){width:16%}
 .ip-heatmap th:nth-child(4),.ip-heatmap td:nth-child(4){width:16%}
 .ip-heatmap th:nth-child(5),.ip-heatmap td:nth-child(5){width:16%}
-.ip-heatmap td:first-child a{color:inherit;text-decoration:none}
-.ip-heatmap td:first-child a:hover{text-decoration:underline}
+/* Neutralises the Overview heatmap's environment-name link so the cell reads as a label.
+   Direct-child chain on purpose: the Environments sub-list is a table nested inside a heatmap
+   cell, and a descendant selector here stripped the colour off its .ip-target-link names. */
+.ip-heatmap > tbody > tr > td:first-child > a{color:inherit;text-decoration:none}
+.ip-heatmap > tbody > tr > td:first-child > a:hover{text-decoration:underline}
 .ip-grid-below{margin-top:16px}
 
 /* Task B3 — targets list: name link, tag chip tone, health-grouped rows, column widths */
@@ -357,12 +360,29 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pool-card .ip-card-head{margin-bottom:8px}
 .ip-chipx-pool{background:var(--color-purple-100);border-color:var(--color-purple-200);color:var(--color-purple-700)}
 
-/* Task P3-2 — Deployment agents: Tentacle/Kubernetes tabs, KPI row, version distribution bars */
+/* Task P3-2 — Deployment agents: KPI row, version distribution bars */
 .ip-tabs{display:flex;gap:4px;margin-bottom:20px;border-bottom:1px solid var(--border)}
 .ip-tab{background:none;border:0;padding:8px 14px;font-size:13px;font-weight:500;
   color:var(--fg2);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
 .ip-tab:hover{color:var(--fg1)}
 .ip-tab-active{color:var(--fg1);border-bottom-color:var(--ring);font-weight:600}
+
+/* Task P5-1 — Deployment Targets section tabs. The class was written for <button>; these are
+   anchors so the tabs are real routes (deep-linkable, back button works). */
+.ip-section-tab{text-decoration:none;display:inline-block}
+.ip-section-tab:hover{text-decoration:none}
+
+/* Task P5-2 — agent type as a segmented control, sitting under the section tabs. Deliberately
+   quieter than .ip-tab: a second tab row in the same styling flattens the hierarchy.
+   Named ip-kind-*, not ip-seg-*: .ip-seg is already the Environments mode button (below), and
+   reusing it made the two rules overwrite each other's background and border. */
+.ip-kind-seg{display:inline-flex;margin-bottom:16px;border:1px solid var(--border);
+  border-radius:6px;overflow:hidden;background:var(--muted)}
+.ip-kind-btn{background:none;border:0;padding:5px 14px;font-size:12px;font-weight:500;
+  color:var(--fg2);cursor:pointer}
+.ip-kind-btn + .ip-kind-btn{border-left:1px solid var(--border)}
+.ip-kind-btn:hover{color:var(--fg1)}
+.ip-kind-active{background:var(--card);color:var(--fg1);font-weight:600}
 .ip-kpi-grid{grid-template-columns:repeat(4,1fr);margin-bottom:16px}
 .ip-dist-card{margin-bottom:16px}
 .ip-dist-rows{display:flex;flex-direction:column;gap:8px}

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -29,14 +29,42 @@ const Views = (function () {
   function chip(text, tone) {
     return '<span class="ip-chipx ip-chipx-' + escHtml(tone || 'neutral') + '">' + escHtml(text) + '</span>';
   }
-  function donut(pct) {
-    const p = Math.max(0, Math.min(100, Math.round(pct || 0)));
-    const R = 52, C = 2 * Math.PI * R, off = C * (1 - p / 100);
+  // The ring drew a single green arc against a grey remainder, which left unhealthy and
+  // disabled targets sharing one undifferentiated track — next to health-by-type bars that
+  // were already green/red/slate. It now segments on the same colours as bar(), so the ring,
+  // the legend under it and the type bars read as one thing. Takes the overview counts;
+  // still accepts a bare percentage for a healthy-only ring.
+  function donut(counts) {
+    const R = 52, C = 2 * Math.PI * R;
+    const clampPct = v => Math.max(0, Math.min(100, Math.round(v || 0)));
+    const num = v => Math.max(0, Math.round(Number(v) || 0));
+    let p, segs;
+    if (counts && typeof counts === 'object') {
+      const h = num(counts.healthy), u = num(counts.unhealthy), d = num(counts.disabled);
+      const total = h + u + d;
+      p = counts.healthyPct == null ? (total ? clampPct(h / total * 100) : 0) : clampPct(counts.healthyPct);
+      // Fractions come off the bucket total, not healthyPct, so the three arcs always close
+      // the circle even where healthyPct has been rounded.
+      segs = total ? [[h, 'var(--color-green-400)'], [u, 'var(--color-red-400)'], [d, 'var(--color-slate-300)']]
+        .filter(s => s[0] > 0).map(s => [s[0] / total, s[1]]) : [];
+    } else {
+      p = clampPct(counts);
+      segs = p > 0 ? [[p / 100, 'var(--color-green-400)']] : [];
+    }
+    // One dash run per segment, each shifted forward by the fraction already drawn (negative
+    // dashoffset advances along the path). Butt caps, not round: round caps on adjacent
+    // segments overlap, which overstates whichever segment is smaller.
+    let drawn = 0;
+    const arcs = segs.map(seg => {
+      const len = C * seg[0], off = -C * drawn;
+      drawn += seg[0];
+      return '<circle cx="64" cy="64" r="' + R + '" fill="none" stroke="' + seg[1] + '" stroke-width="14"'
+        + ' stroke-dasharray="' + len.toFixed(1) + ' ' + C.toFixed(1) + '"'
+        + ' stroke-dashoffset="' + off.toFixed(1) + '" transform="rotate(-90 64 64)"/>';
+    }).join('');
     return '<svg class="ip-donut" viewBox="0 0 128 128" width="128" height="128">'
       + '<circle cx="64" cy="64" r="' + R + '" fill="none" stroke="var(--muted)" stroke-width="14"/>'
-      + '<circle cx="64" cy="64" r="' + R + '" fill="none" stroke="var(--color-green-400)" stroke-width="14"'
-      + ' stroke-linecap="round" stroke-dasharray="' + C.toFixed(1) + '" stroke-dashoffset="' + off.toFixed(1) + '"'
-      + ' transform="rotate(-90 64 64)"/>'
+      + arcs
       + '<text x="64" y="60" text-anchor="middle" class="ip-donut-pct">' + p + '%</text>'
       + '<text x="64" y="80" text-anchor="middle" class="ip-donut-sub">healthy</text></svg>';
   }
@@ -98,7 +126,7 @@ const Views = (function () {
       +   '</div>'
       +   '<div class="ip-panel-cols">'
       +     '<div class="ip-panel-left">'
-      +       '<div class="ip-donut-wrap">' + donut(ov.healthyPct) + '</div>'
+      +       '<div class="ip-donut-wrap">' + donut(ov) + '</div>'
       +       '<div class="ip-legend-big">'
       +         '<div class="ip-legend-stat"><div class="ip-legend-label"><span class="ip-dot ip-dot-healthy"></span>Healthy</div>'
       +           '<div class="ip-legend-num ip-num-healthy">' + ov.healthy + '</div></div>'
@@ -130,15 +158,55 @@ const Views = (function () {
       + '</div>';
   }
   const IP_PAGE_SIZE = 100;
+  // ─── Deployment Targets section (Paul Stovell's feedback, 28 Jul) ────────────
+  // Machine policies and deployment agents used to be top-level nav items. Both are rare
+  // destinations next to the targets list itself, so they're tabs within one Deployment
+  // Targets section and the sidebar carries only the five places people actually navigate to.
+  //
+  // The routes stay flat — #agents and #machinepolicies, rendered inside this shell with
+  // "Deployment Targets" active in the sidebar. #targets/agents would collide with the
+  // #targets/<machine-id> detail route, which already has to reserve "new" for that reason,
+  // and flat routes keep the overview's agent-versions pill working.
+  const IP_TARGET_SECTIONS = [
+    { key:'targets',  hash:'#targets',         label:'Deployment Targets' },
+    { key:'agents',   hash:'#agents',          label:'Agents' },
+    { key:'policies', hash:'#machinepolicies', label:'Policies' }
+  ];
+  function _sectionTabs(active) {
+    return '<nav class="ip-tabs ip-section-tabs" aria-label="Deployment targets sections">'
+      + IP_TARGET_SECTIONS.map(s => '<a class="ip-tab ip-section-tab'
+        + (s.key === active ? ' ip-tab-active' : '') + '" href="' + s.hash + '"'
+        + (s.key === active ? ' aria-current="page"' : '') + '>' + escHtml(s.label) + '</a>').join('')
+      + '</nav>';
+  }
+  // The <h2> stays "Deployment targets" on all three tabs — a title that changed per tab
+  // would make the tabs read as navigation. Each section's own framing moves to the subtitle.
+  // `sub` is trusted markup: callers escape anything dynamic before passing it.
+  function _sectionHead(sub, actionHtml) {
+    const text = '<h2>Deployment targets</h2><p class="ip-sub">' + sub + '</p>';
+    return actionHtml
+      ? '<header class="ip-head ip-head-actions"><div class="ip-head-text">' + text + '</div>'
+        + actionHtml + '</header>'
+      : '<header class="ip-head">' + text + '</header>';
+  }
   function filterChip(key, value, label) {
     return '<button class="ip-chip" data-key="' + escHtml(key) + '" data-value="' + escHtml(value) + '">'
       + escHtml(label) + ' ✕</button>';
   }
   const IP_TARGETS_COLS = 10;
   const IP_HEALTH_GROUP_ORDER = ['unhealthy', 'healthy', 'disabled'];
+  // A target's name links to its detail page wherever it appears — the targets table, the
+  // agent table, and the environments sub-list. Falls back to plain text without an id, so a
+  // row from a model that doesn't carry one never renders a link to nowhere.
+  function targetNameLink(id, name) {
+    return id
+      ? '<a class="ip-target-link" href="#targets/' + escHtml(encodeURIComponent(id)) + '">'
+        + escHtml(name) + '</a>'
+      : escHtml(name);
+  }
   function _targetRow(t) {
     return '<tr class="ip-row" data-id="' + escHtml(t.id) + '">'
-      + '<td><a class="ip-target-link" href="#targets/' + escHtml(encodeURIComponent(t.id)) + '">' + escHtml(t.name) + '</a></td>'
+      + '<td>' + targetNameLink(t.id, t.name) + '</td>'
       + '<td>' + escHtml(t.type) + '</td>'
       + '<td>' + escHtml(t.os) + '</td>'
       + '<td>' + escHtml(t.osVersion) + '</td>'
@@ -211,13 +279,15 @@ const Views = (function () {
           + '<a class="ip-btn" href="#targets/new">Add deployment target</a></div>'
         : '<div class="ip-empty"><h3>No targets match these filters</h3><p>Try removing a filter or clearing your search.</p></div>';
 
-    return '<div class="ip-targets-wrap">'
+    // Header and tabs sit above the facet rail: the rail filters within this list, the tabs
+    // switch section. Side by side they'd read as another filter.
+    return _sectionHead('Assess health across the estate and drill in with fast, faceted filters.')
+      + _sectionTabs('targets')
+      + '<div class="ip-targets-wrap">'
       + '<div class="ip-facets"><div class="ip-facet-title">Filters</div>'
       +   (chips.length ? '<div class="ip-chips">' + chips.join('') + '<button class="ip-clear">Clear all</button></div>' : '')
       +   facetHtml + '</div>'
       + '<div class="ip-targets-main">'
-      +   '<header class="ip-head"><h2>Deployment targets</h2>'
-      +     '<p class="ip-sub">Assess health across the estate and drill in with fast, faceted filters.</p></header>'
       +   '<div class="ip-toolbar"><input class="ip-search" type="search" placeholder="Search targets…" value="'
       +     escHtml(IP.search||'') + '"><span class="ip-count">' + rows.length + ' of ' + all.length + '</span>'
       +     '<a class="ip-btn" href="#targets/new">Add deployment target</a></div>'
@@ -270,10 +340,13 @@ const Views = (function () {
       + '<td>' + chip(r.env, 'env') + '</td>'
       + '<td>' + escHtml(r.policy) + '</td>'
       + '<td><span class="ip-dot ip-dot-healthy"></span> ' + escHtml(r.version) + '</td></tr>').join('');
+    // The tabs belong here too. Phase 4 established that an explicit nav click always
+    // reaches its own view; an empty estate that couldn't reach Agents or Policies would
+    // reintroduce the same dead end one level down.
     return ''
-      + '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Deployment targets</h2>'
-      +   '<p class="ip-sub">Assess health across the estate and drill in with fast, faceted filters.</p></div>'
-      +   '<a class="ip-btn" href="#targets/new">+ Add deployment target</a></header>'
+      + _sectionHead('Assess health across the estate and drill in with fast, faceted filters.',
+          '<a class="ip-btn" href="#targets/new">+ Add deployment target</a>')
+      + _sectionTabs('targets')
       + _zeroCard(ZERO_ICON.target, 'Add your first deployment target',
           'Deployment targets are the servers, clusters, and services your projects deploy to. '
           + 'Add one and Octopus starts tracking its health automatically.',
@@ -503,7 +576,7 @@ const Views = (function () {
   }
   function _envTargetRow(t) {
     return '<tr class="ip-row-static">'
-      + '<td>' + escHtml(t.name) + '</td>'
+      + '<td>' + targetNameLink(t.id, t.name) + '</td>'
       + '<td>' + escHtml(t.type) + '</td>'
       + '<td>' + pill(t.healthKey, t.health) + '</td>'
       + '<td>' + chip(t.tag, 'tag') + '</td>'
@@ -669,9 +742,9 @@ const Views = (function () {
     const rows = Data.policiesModel(IP.estate.policies, IP.estate.targets);
     const cards = rows.map(_policyCard).join('');
     return ''
-      + '<header class="ip-head"><h2>Machine policies</h2>'
-      +   '<p class="ip-sub">Govern targets collectively — health-check schedules and the tentacle upgrade '
-      +   'behaviour that drives version state across the estate.</p></header>'
+      + _sectionHead('Govern targets collectively — health-check schedules and the tentacle upgrade '
+          + 'behaviour that drives version state across the estate.')
+      + _sectionTabs('policies')
       + '<div class="ip-card-head"><h4>Machine policies <span class="ip-count-inline">' + rows.length + '</span></h4>'
       +   '<div class="ip-card-actions"><a class="ip-link" href="' + escHtml(_policyCreateUrl())
       +     '" target="_blank" rel="noopener">Create machine policy</a></div></div>'
@@ -806,10 +879,16 @@ const Views = (function () {
     }));
   }
   // ─── Deployment agents (Task P3-2) ──────────────────────────────────────
-  function _agentTabBar(tab) {
-    return '<div class="ip-tabs">'
-      + '<button type="button" class="ip-tab' + (tab === 'tentacle' ? ' ip-tab-active' : '') + '" data-tab="tentacle">Tentacle</button>'
-      + '<button type="button" class="ip-tab' + (tab === 'kubernetes' ? ' ip-tab-active' : '') + '" data-tab="kubernetes">Kubernetes</button>'
+  // A segmented control rather than a second tab bar: this sits under the section tabs, and
+  // two rows in identical styling leaves the hierarchy ambiguous at a glance. The class name
+  // is load-bearing — bindAgents binds these buttons, and .ip-tab now belongs to the section
+  // tab anchors, which must route rather than re-render Agents in place.
+  function _agentKindBar(tab) {
+    return '<div class="ip-kind-seg" role="group" aria-label="Agent type">'
+      + '<button type="button" class="ip-kind-btn' + (tab === 'tentacle' ? ' ip-kind-active' : '')
+      +   '" data-tab="tentacle"' + (tab === 'tentacle' ? ' aria-pressed="true"' : '') + '>Tentacle</button>'
+      + '<button type="button" class="ip-kind-btn' + (tab === 'kubernetes' ? ' ip-kind-active' : '')
+      +   '" data-tab="kubernetes"' + (tab === 'kubernetes' ? ' aria-pressed="true"' : '') + '>Kubernetes</button>'
       + '</div>';
   }
   function _bandColor(band) {
@@ -825,16 +904,22 @@ const Views = (function () {
       + '<div class="ip-dist-bar"><span style="width:' + pct + '%;background:' + _bandColor(d.band) + '"></span></div>'
       + '<div class="ip-dist-count">' + d.count + '</div></div>';
   }
-  // Row model (from Data.agentsModel) has no machine id, only name/env/version/band/behind/policy,
-  // so "Upgrade" links out to the general Octopus machines list rather than a specific machine —
-  // consistent with the read-only, no-mutation contract for this dashboard.
+  // "Upgrade" still links to the general Octopus machines list rather than to this machine.
+  // The row model now carries the id, so a per-machine link is possible — it's left general
+  // pending a decision, not for want of the id.
+  //
+  // OS cells render blank where the machine reports nothing, matching the targets table:
+  // osLabel deliberately returns '' rather than 'Unknown' so a column of un-health-checked
+  // machines doesn't read as a wall of "Unknown". Kubernetes agents commonly report no OS.
   function _agentRow(r) {
     const status = r.band === 'unknown'
       ? pill('disabled', 'Unknown')
       : pill(r.behind ? 'unhealthy' : 'healthy', r.behind ? 'Behind' : 'Up to date');
     return '<tr class="ip-row-static">'
-      + '<td>' + escHtml(r.name) + '</td>'
+      + '<td>' + targetNameLink(r.id, r.name) + '</td>'
       + '<td>' + chip(r.env, 'env') + '</td>'
+      + '<td>' + escHtml(r.os) + '</td>'
+      + '<td>' + escHtml(r.osVersion) + '</td>'
       + '<td>' + escHtml(r.version) + '</td>'
       + '<td>' + status + '</td>'
       + '<td>' + escHtml(r.policy) + '</td>'
@@ -849,15 +934,16 @@ const Views = (function () {
     const rowsHtml = G.rows.map(_agentRow).join('');
     const body = G.rows.length
       ? '<div class="ip-targets-scroll"><table class="ip-table ip-targets"><thead><tr>'
-        + '<th>Agent name</th><th>Environment</th><th>Version</th><th>Status</th><th>Machine policy</th><th></th>'
+        + '<th>Machine name</th><th>Environment</th><th>Operating system</th><th>OS version</th>'
+        + '<th>Agent version</th><th>Status</th><th>Machine policy</th><th></th>'
         + '</tr></thead><tbody>' + rowsHtml + '</tbody></table></div>'
       : '<div class="ip-empty"><h3>No ' + escHtml(IP.agentTab) + ' agents</h3>'
         + '<p>No matching deployment targets in this estate.</p></div>';
     return ''
-      + '<header class="ip-head"><h2>Deployment agents</h2>'
-      +   '<p class="ip-sub">Review agent versions across the estate and upgrade what\'s fallen behind. '
-      +   'Latest available ' + escHtml(G.latest) + '.</p></header>'
-      + _agentTabBar(IP.agentTab)
+      + _sectionHead('Review agent versions across the estate and upgrade what\'s fallen behind. '
+          + 'Latest available ' + escHtml(G.latest) + '.')
+      + _sectionTabs('agents')
+      + _agentKindBar(IP.agentTab)
       + '<div class="ip-grid ip-kpi-grid">'
       +   '<section class="ip-card"><h4>Total</h4><div class="ip-big">' + G.total + '</div></section>'
       +   '<section class="ip-card"><h4>Up to date</h4><div class="ip-big ip-num-healthy">' + G.upToDate + '</div></section>'
@@ -873,7 +959,7 @@ const Views = (function () {
   }
   function bindAgents(IP) {
     const root = document.getElementById('main-content');
-    root.querySelectorAll('.ip-tab').forEach(btn => btn.addEventListener('click', () => {
+    root.querySelectorAll('.ip-kind-btn').forEach(btn => btn.addEventListener('click', () => {
       IP.agentTab = btn.getAttribute('data-tab') === 'kubernetes' ? 'kubernetes' : 'tentacle';
       root.innerHTML = renderAgents(IP);
       bindAgents(IP);


### PR DESCRIPTION
Follow-up to #29, acting on [Paul's feedback](https://octopusdeploy.slack.com/archives/C3Q17599U/p1785205326439529) on the 28 Jul walkthrough, plus two follow-ons.

## Nav restructure (Paul's ask)

> "Machine Policies is very rare, I'd put it as a link or something somewhere inside Deployment Targets."
>
> "Deployment Targets on one tab. Then inside it 3 horizontal tabs — Deployment Targets | Agents | Policies. Then the main menu is just Overview / Deployment Targets / Environments / Workers & Worker Pools / Argo CD Instances."

Sidebar drops from seven items to five. Machine Policies and Deployment Agents become horizontal tabs within one Deployment Targets section.

**Routes stay flat.** `#agents` and `#machinepolicies` render inside the section shell with Deployment Targets active in the sidebar. `#targets/agents` would collide with the `#targets/<machine-id>` detail route, which already reserves `new` for the same reason — and flat routes keep the overview's agent-versions pill working. The zero state carries the tab bar too, so an empty space can still reach Agents and Policies.

Agents' Tentacle/Kubernetes split becomes a segmented control rather than a second tab row in identical styling, which flattened the hierarchy.

## Overview ring segments unhealthy in red

`donut()` drew one green arc against a grey remainder, so unhealthy and disabled targets shared an undifferentiated track — next to health-by-type bars that were already green/red/slate. It now segments on the same colours.

Fractions come off the bucket total rather than `healthyPct`, so the arcs close the circle even where the percentage has been rounded. Butt caps replace round ones: round caps on adjacent segments overlap and overstate the smaller one.

## Target names link to their detail page everywhere

`_agentGroup` and `environmentsModel` both dropped the machine id that `machineToTarget` already carries, so neither the agent table nor the environments sub-list could link a name. Both now carry it, behind one `targetNameLink()` helper shared with the targets table.

The agent table also gains **Operating system** and **OS version**, and `Version` is renamed `Agent version` now that OS version sits beside it.

## Two bugs fixed along the way

1. `.ip-seg` was already the Environments mode button. The agent-kind control reused it as a *container* class, so the two CSS rules overwrote each other's background and border. Renamed to `.ip-kind-*`; a test now asserts each class is defined exactly once.
2. `.ip-heatmap td:first-child a` neutralises the Overview heatmap's environment link so the cell reads as a label. The Environments sub-list is a table nested *inside* a heatmap cell, so that descendant selector stripped the colour from the newly linked target names — the links worked but didn't look like links. Scoped to a direct-child chain; Overview heatmap labels verified unchanged.

## Verification

Tests 96 → 147. Rendered against a fixture instance (14 targets, 3 environments, 2 policies, mixed health and agent versions) in light and dark.

**Not yet verified against a live instance.** Fixtures can't exercise click-to-expand on Environments, the space switcher re-render, or back/forward through the tab anchors.

## Not in scope

Paul's tenants / domain-model thread (replies 6–7) — he framed it as thinking further out, and it's a separate piece of work.

"Upgrade →" still points at the general Octopus machines list. The row model now has the id, so per-machine is a one-line change; the stale comment claiming it was general for want of an id has been corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)