### PR TITLE
Infrastructure (PreAlpha): Projects and Tenants sections, and a per-project page

### DIFF
--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3082,3 +3082,43 @@ describe('A space where targets are forbidden is not a space that failed', () =>
     expect(html).not.toContain('No deployment targets');
   });
 });
+
+describe('Projects render as cards, not as a table', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const model = data.releasesModel({
+    Environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Prod' }],
+    ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }],
+    Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' },
+               { Id: 'P2', Name: 'Hub', ProjectGroupId: 'G1' }],
+    Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' },
+            { IsCurrent: true, ProjectId: 'P2', EnvironmentId: 'E2', ReleaseVersion: '4.1', State: 'Success' }]
+  });
+
+  test('every project gets its own card', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model } });
+    expect((html.match(/ip-rel-card"/g) || []).length).toBe(2);
+  });
+
+  test('the environment header still stands above them', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model } });
+    expect(html).toContain('ip-rel-head');
+    expect(html.indexOf('ip-rel-head')).toBeLessThan(html.indexOf('ip-rel-cards'));
+  });
+
+  test('an open project is marked, and its history sits inside its own card', () => {
+    const html = Views.renderProjects({ projectOpen: { P1: true },
+      projectHistory: { P1: { status: 'loading' } }, releases: { status: 'ready', model } });
+    expect(html).toContain('ip-rel-card is-open');
+    expect(/ip-rel-card is-open[\s\S]*?ip-rel-history/.test(html)).toBe(true);
+  });
+
+  test('the columns still line up between the header and the cards', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model } });
+    // Header and rows use the same track template, which is what keeps the
+    // nodes under their environment names once the shared box is gone.
+    const tracks = html.match(/grid-template-columns:repeat\(2,[^"]+/g) || [];
+    expect(tracks.length).toBeGreaterThan(1);
+    expect(new Set(tracks).size).toBe(1);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2628,27 +2628,27 @@ describe('Tenant detail — readiness', () => {
     Templates: [{ Id: 'tpl-1', Name: 'ApiKey', Label: 'API key' }, { Id: 'tpl-2', Name: 'Region', DefaultValue: 'eu' }],
     Variables: { E1: { 'tpl-1': 'abc' }, E2: {} } } } };
 
-  test('a template with no value and no default is missing', () => {
-    const r = data.tenantReadiness(vars, { P1: ['E1', 'E2'] }, envName);
+  test('a template with no value and no default is unset', () => {
+    const r = data.tenantReadiness(vars, { P1: ['E1', 'E2'] }, envName, {});
     expect(r.ready).toBe(false);
     expect(r.count).toBe(1);
-    expect(r.missing[0]).toMatchObject({ name: 'API key', environment: 'Production' });
+    expect(r.missing[0]).toMatchObject({ name: 'API key', environments: ['Production'] });
   });
 
   test('a default value satisfies a template', () => {
-    const r = data.tenantReadiness(vars, { P1: ['E1', 'E2'] }, envName);
+    const r = data.tenantReadiness(vars, { P1: ['E1', 'E2'] }, envName, {});
     expect(r.missing.some(x => x.name === 'Region')).toBe(false);
   });
 
   test('only connected environments can be missing anything', () => {
-    const r = data.tenantReadiness(vars, { P1: ['E1'] }, envName);
+    const r = data.tenantReadiness(vars, { P1: ['E1'] }, envName, {});
     expect(r.ready).toBe(true);
   });
 
   test('an empty value counts as missing, not as supplied', () => {
     const blank = { ProjectVariables: { P1: { ProjectId: 'P1', Templates: [{ Id: 't', Name: 'X' }],
       Variables: { E1: { t: '' } } } } };
-    expect(data.tenantReadiness(blank, { P1: ['E1'] }, envName).count).toBe(1);
+    expect(data.tenantReadiness(blank, { P1: ['E1'] }, envName, {}).count).toBe(1);
   });
 });
 
@@ -2759,5 +2759,62 @@ describe('A tenant page is still the tenants view', () => {
     const router = fs.readFileSync(path.join(__dirname, 'router.js'), 'utf8');
     // Cold start is gated on needsEstate, which a tenant route now fails.
     expect(router).toContain('needsEstate && typeof Data !== \'undefined\' && Data.coldStartApplies');
+  });
+});
+
+describe('Readiness is triangulated against what has deployed', () => {
+  const data = require('./data');
+  const envName = { E1: 'Dev', E2: 'Test', E3: 'Production' };
+  const conn = { P1: ['E1', 'E2', 'E3'] };
+  const vars = { ProjectVariables: { P1: { ProjectId: 'P1', ProjectName: 'Patient Records',
+    Templates: [{ Id: 't1', Name: 'ApiKey' }, { Id: 't2', Name: 'Region', DefaultValue: 'eu' }, { Id: 't3', Name: 'Secret' }],
+    Variables: { E1: {}, E2: {}, E3: {} } } } };
+
+  test('the count is distinct templates, not template times environment', () => {
+    const r = data.tenantReadiness(vars, conn, envName, {});
+    // Two templates unset across three environments is two, not six.
+    expect(r.count).toBe(2);
+    expect(r.pairCount).toBe(6);
+  });
+
+  test('each unset template names the environments it is unset in', () => {
+    const r = data.tenantReadiness(vars, conn, envName, {});
+    expect(r.missing[0].environments).toEqual(['Dev', 'Test', 'Production']);
+  });
+
+  test('a pair that has deployed successfully marks the template proven', () => {
+    const r = data.tenantReadiness(vars, conn, envName, { 'P1|E3': true });
+    expect(r.missing.every(m => m.proven)).toBe(true);
+    expect(r.unprovenCount).toBe(0);
+    expect(r.proven).toBe(true);
+  });
+
+  test('nothing deployed leaves them unproven', () => {
+    const r = data.tenantReadiness(vars, conn, envName, {});
+    expect(r.unprovenCount).toBe(2);
+    expect(r.proven).toBe(false);
+  });
+
+  test('a default value still satisfies a template outright', () => {
+    expect(data.tenantReadiness(vars, conn, envName, {}).missing.some(m => m.name === 'Region')).toBe(false);
+  });
+
+  test('the card stops asserting a deployment would fail', () => {
+    const Views = require('./views');
+    const NOW = Date.now();
+    const model = data.tenantDetailModel({
+      tenant: { Id: 'T1', Name: 'T', TenantTags: [], ProjectEnvironments: { P1: ['E3'] } },
+      dashboard: { Projects: [{ Id: 'P1', Name: 'Patient Records' }], Environments: [{ Id: 'E3', Name: 'Production' }],
+        Items: [{ IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E3', ReleaseVersion: '1.0',
+          State: 'Success', CompletedTime: new Date(NOW - 3 * 86400000).toISOString() }] },
+      variables: { ProjectVariables: { P1: { ProjectId: 'P1', ProjectName: 'Patient Records',
+        Templates: [{ Id: 't1', Name: 'ApiKey' }], Variables: { E3: {} } } } },
+      now: NOW
+    });
+    const html = Views.renderTenantDetail({ spaceId: 'S', tenantDetail: { status: 'ready', model } });
+    // It deployed three days ago with the value unset, so the page says so.
+    expect(html).not.toContain('would fail on configuration');
+    expect(html).toContain('Deployments have succeeded with these unset');
+    expect(html).toContain('deployed without it');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3538,9 +3538,21 @@ describe('Project map — lifecycles', () => {
     expect(model.lifecycles[1].channels).toEqual(['Hotfix']);
   });
 
-  test('phases render in order with their environments', () => {
+  test('environments are named once, as columns', () => {
+    expect(model.lifecycleEnvironments).toEqual(['Dev', 'Production']);
+    // Each environment heading appears once in the table head, not once per lifecycle.
+    const head = html.slice(html.indexOf('<thead>'), html.indexOf('</thead>'));
+    expect((head.match(/Production/g) || []).length).toBe(1);
+  });
+
+  test('each lifecycle is a row across those columns', () => {
+    expect(model.lifecycles[0].cells.map(c => c.reached)).toEqual([true, true]);
+    expect(model.lifecycles[1].cells.map(c => c.reached)).toEqual([false, true]);
     expect(html).toContain('Straight to prod');
-    expect((html.match(/ip-pm-phasebox/g) || []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('a lifecycle that never reaches an environment leaves the cell blank', () => {
+    expect(html).toContain('ip-pm-lccell is-absent');
   });
 
   test('an automatic environment is marked as such', () => {
@@ -3560,7 +3572,57 @@ describe('Project map — lifecycles', () => {
       lifecycles: [{ Id: 'L1', Name: 'Standard', Phases: [] }],
       process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
       environments: [], tenants: { TotalResults: 0 } });
-    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: orphan } }))
-      .toContain('no channel uses this');
+    const orphanHtml = Views.renderProjectMap({ projectMap: { status: 'ready', model: orphan } });
+    // No phases at all, so there are no columns and nothing to tabulate.
+    expect(orphanHtml).toContain('no lifecycle phases');
+  });
+});
+
+describe('Lifecycle columns are ordered and shared', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const model = data.projectMapModel({
+    project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+    channels: { Items: [{ Name: 'Full', LifecycleId: 'L1' }, { Name: 'Hotfix', LifecycleId: 'L2' }] },
+    lifecycle: { Id: 'L1', Name: 'Standard', Phases: [
+      { Name: 'Dev', OptionalDeploymentTargets: ['E1'] },
+      { Name: 'Test', OptionalDeploymentTargets: ['E2'] },
+      { Name: 'Prod', AutomaticDeploymentTargets: ['E3'] } ] },
+    lifecycles: [
+      { Id: 'L1', Name: 'Standard', Phases: [
+        { Name: 'Dev', OptionalDeploymentTargets: ['E1'] },
+        { Name: 'Test', OptionalDeploymentTargets: ['E2'] },
+        { Name: 'Prod', AutomaticDeploymentTargets: ['E3'] } ] },
+      { Id: 'L2', Name: 'Hotfix path', Phases: [{ Name: 'Straight to prod', OptionalDeploymentTargets: ['E3'] }] },
+      { Id: 'L3', Name: 'Lab only', Phases: [{ Name: 'Lab', OptionalDeploymentTargets: ['E9'] }] } ],
+    process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
+    environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Test' },
+                   { Id: 'E3', Name: 'Production' }, { Id: 'E9', Name: 'Lab' }],
+    tenants: { TotalResults: 0 }
+  });
+
+  test('columns follow the default lifecycle, then anything only others reach', () => {
+    expect(model.lifecycleEnvironments).toEqual(['Dev', 'Test', 'Production', 'Lab']);
+  });
+
+  test('two routes to production land in the same column', () => {
+    const prod = model.lifecycleEnvironments.indexOf('Production');
+    expect(model.lifecycles[0].cells[prod]).toMatchObject({ reached: true, phase: 'Prod', automatic: true });
+    expect(model.lifecycles[1].cells[prod]).toMatchObject({ reached: true, phase: 'Straight to prod' });
+  });
+
+  test('every row has a cell per column, reached or not', () => {
+    model.lifecycles.forEach(lc => expect(lc.cells).toHaveLength(model.lifecycleEnvironments.length));
+  });
+
+  test('an automatic phase is marked, an optional one is not', () => {
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+    expect(html).toContain('ip-pm-auto');
+    expect((html.match(/ip-pm-auto/g) || []).length).toBe(1);
+  });
+
+  test('a blank cell is explained rather than left ambiguous', () => {
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+    expect(html).toContain('never reaches that environment');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3443,7 +3443,7 @@ describe('Project map', () => {
       project: Object.assign({}, payload.project, { TenantedDeploymentMode: 'Tenanted' }),
       tenants: { TotalResults: 48 } }));
     expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: tenanted } }))
-      .toContain('48 tenants are');
+      .toContain('48 tenants connected');
   });
 
   test('the project card links to the map without swallowing the expand', () => {
@@ -3642,5 +3642,85 @@ describe('Lifecycle columns are ordered and shared', () => {
   test('a blank cell is explained rather than left ambiguous', () => {
     const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
     expect(html).toContain('never reaches that environment');
+  });
+});
+
+describe('Destinations: selection, targets and their shape', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const machines = { items: [
+    { Id: 'M1', Name: 'web-01', Roles: ['web'], EnvironmentIds: ['E1'], HealthStatus: 'Healthy', IsDisabled: false, TenantedDeploymentParticipation: 'Untenanted' },
+    { Id: 'M2', Name: 'web-02', Roles: ['web'], EnvironmentIds: ['E2'], HealthStatus: 'Unhealthy', IsDisabled: false, TenantedDeploymentParticipation: 'Tenanted', TenantIds: ['T1'] },
+    { Id: 'M3', Name: 'db-01', Roles: ['db'], EnvironmentIds: ['E1'], HealthStatus: 'Healthy', IsDisabled: true },
+    { Id: 'M4', Name: 'other', Roles: ['unrelated'], EnvironmentIds: ['E1'], HealthStatus: 'Healthy' },
+    { Id: 'M5', Name: 'wrong-env', Roles: ['web'], EnvironmentIds: ['E9'], HealthStatus: 'Healthy' }
+  ] };
+  const build = (roles, extra) => data.projectMapModel(Object.assign({
+    project: { Id: 'P1', Name: 'X', LifecycleId: 'L1', TenantedDeploymentMode: 'Tenanted' },
+    channels: { Items: [] },
+    lifecycle: { Id: 'L1', Name: 'Std', Phases: [{ Name: 'All', OptionalDeploymentTargets: ['E1', 'E2'] }] },
+    lifecycles: [{ Id: 'L1', Name: 'Std', Phases: [{ Name: 'All', OptionalDeploymentTargets: ['E1', 'E2'] }] }],
+    process: { Steps: [{ Name: 'Deploy', Properties: { 'Octopus.Action.TargetRoles': roles },
+      Actions: [{ ActionType: 'Octopus.Script' }] }] },
+    triggers: { Items: [] }, feeds: { Items: [] },
+    environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Prod' }, { Id: 'E9', Name: 'Lab' }],
+    tenants: { TotalResults: 12 }, machines: machines
+  }, extra || {}));
+
+  test('targets are matched by role and environment together', () => {
+    const t = build('web,db').targets;
+    expect(t.total).toBe(3);                       // M4 wrong role, M5 wrong environment
+    expect(t.matched.map(x => x.name).sort()).toEqual(['db-01', 'web-01', 'web-02']);
+  });
+
+  test('health aggregates, disabled counted separately from unhealthy', () => {
+    const t = build('web,db').targets;
+    expect({ healthy: t.healthy, unhealthy: t.unhealthy, disabled: t.disabled })
+      .toEqual({ healthy: 1, unhealthy: 1, disabled: 1 });
+  });
+
+  test('it breaks down by role and by environment', () => {
+    const t = build('web,db').targets;
+    expect(t.byRole).toEqual([{ role: 'web', count: 2 }, { role: 'db', count: 1 }]);
+    expect(t.byEnvironment).toEqual([{ environment: 'Dev', count: 2 }, { environment: 'Prod', count: 1 }]);
+  });
+
+  test('tenant participation is aggregated for a tenanted project', () => {
+    const t = build('web,db').targets;
+    expect(t.tenanted.dedicated).toBe(1);
+    expect(t.tenanted.participation).toEqual({ Untenanted: 2, Tenanted: 1 });
+  });
+
+  test('an untenanted project reports no tenant aggregate at all', () => {
+    const m = build('web', { project: { Id: 'P1', Name: 'X', LifecycleId: 'L1', TenantedDeploymentMode: 'Untenanted' } });
+    expect(m.targets.tenanted).toBeNull();
+  });
+
+  test('a project with no roles says so rather than reporting zero targets', () => {
+    const m = build('');
+    expect(m.targets.selectsByRole).toBe(false);
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: m } });
+    expect(html).toContain('run on the server or on workers');
+    expect(html).not.toContain('Deployments would have nowhere to run');
+  });
+
+  test('roles that match nothing is a warning, and a different one', () => {
+    const m = build('ghost');
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: m } });
+    expect(html).toContain('Deployments would have nowhere to run');
+  });
+
+  test('unreadable machines leave the selection visible', () => {
+    const m = build('web', { machines: null, machinesError: new Error('403') });
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: m } });
+    expect(html).toContain('Deployment targets cannot be read');
+    expect(html).toContain('Selected by');       // how it chooses is still known
+  });
+
+  test('the selection mechanism is stated whatever the targets say', () => {
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: build('web,db') } });
+    expect(html).toContain('Selected by');
+    expect(html).toContain('Within');
+    expect(html).toContain('12 tenants connected');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2041,3 +2041,44 @@ describe('Projects — grouping by time or type', () => {
     expect(render('Type')).toContain('Not shown:');
   });
 });
+
+describe('Flag rows are visually separated', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E3', name: 'Prod' }];
+  const model = {
+    environments: grid,
+    groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+      projects: [{ id: 'P1', name: 'Portal',
+        cells: grid.map(e => ({ envId: e.id, envName: e.name, entries: [], versionCount: 0, tenantTotal: 0 })),
+        links: [null, 'none'] }] }],
+    projects: [{ id: 'P1' }], truncated: {}
+  };
+  const flagPayload = { total: 1, truncated: false, items: [
+    { Id: 'F1', Name: 'new-checkout', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
+      { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 10 }] } ] };
+  const html = Views.renderProjects({
+    projectOpen: { P1: true },
+    projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: grid } } },
+    projectFlags: { P1: { status: 'ready', model: data.featureFlagModel(flagPayload, grid),
+      changes: [{ id: 'c1', flagName: 'x', scope: 'environment', envId: 'E3', envName: 'Prod',
+        occurred: Date.now(), before: { key: 'off', percent: null }, after: { key: 'on', percent: 100 } }] } },
+    grouping: 'Type', releases: { status: 'ready', model }
+  });
+
+  test('flag rows carry the class the wash is attached to', () => {
+    expect(html).toContain('ip-rel-hrow ip-rel-frow');
+  });
+
+  test('release rows do not', () => {
+    // A release row is an ip-rel-hrow that is not an ip-rel-frow.
+    expect(html).not.toContain('ip-rel-hrow ip-rel-hrow');
+  });
+
+  test('the wash is not the only signal a row is a flag', () => {
+    // Square node, purple line and the flag name each survive without colour.
+    expect(html).toContain('ip-rel-fnode');
+    expect(html).toContain('ip-rel-flagname');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3266,3 +3266,46 @@ describe('An open card looks like a card', () => {
     expect(html).toContain('ip-rel-card is-open');
   });
 });
+
+describe('One card treatment across the dashboard', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
+  const rule = name => (new RegExp('\\.' + name + ' \\{[\\s\\S]*?\\}').exec(css) || [''])[0];
+
+  // Every raised surface added for Projects and Tenants.
+  const surfaces = ['ip-tn-card', 'ip-tn-panel', 'ip-tn-facets', 'ip-rel-card'];
+
+  surfaces.forEach(name => {
+    test(name + ' uses the shared border, radius and shadow', () => {
+      const r = rule(name);
+      expect(r).toContain('var(--border)');
+      expect(r).toContain('var(--radius-lg)');
+      expect(r).toContain('var(--shadow-xs)');
+    });
+  });
+
+  test('every surface resolves its background to --card', () => {
+    // The project card reaches it through --ip-rel-cardbg, which is what lets
+    // the version labels mask the line in the card's own colour.
+    expect(rule('ip-tn-card')).toContain('var(--card)');
+    expect(rule('ip-tn-panel')).toContain('var(--card)');
+    expect(rule('ip-tn-facets')).toContain('var(--card)');
+    expect(rule('ip-rel-card')).toContain('var(--ip-rel-surface)');
+    expect(css).toContain('--ip-rel-cardbg: var(--card)');
+  });
+
+  test('no surface carries a hand-written dark border', () => {
+    // --card and --border already flip per theme; a second set would drift.
+    expect(/\.dark \.ip-tn-(card|panel|facets)[^{]*\{[^}]*border-color/.test(css)).toBe(false);
+    expect(/\.dark \.ip-rel-card \{[^}]*border-color/.test(css)).toBe(false);
+  });
+
+  test('none of them is a bare outline', () => {
+    surfaces.forEach(name => {
+      const r = rule(name);
+      expect(r).toMatch(/background:/);
+      expect(r).toMatch(/box-shadow:/);
+    });
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -4108,3 +4108,121 @@ describe('Switching space lands on Projects', () => {
     expect(Views.spaceSwitchNav('')).toEqual({ hash: '#projects', rerender: true });
   });
 });
+
+describe('Incomplete reads say so where the zero used to be', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const err = msg => { const e = new Error(msg); e.code = msg; return e; };
+  const mapWith = extra => data.projectMapModel(Object.assign({
+    project: { Id: 'P1', Name: 'X', LifecycleId: 'L1', TenantedDeploymentMode: 'Tenanted' },
+    process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+    lifecycle: { Name: 'Std', Phases: [{ Name: 'All', OptionalDeploymentTargets: ['E1'] }] },
+    lifecycles: [{ Id: 'L1', Name: 'Std', Phases: [{ Name: 'All', OptionalDeploymentTargets: ['E1'] }] }],
+    feeds: { Items: [] }, environments: [{ Id: 'E1', Name: 'Dev' }], tenants: { TotalResults: 4 }
+  }, extra));
+  const render = m => Views.renderProjectMap({ projectTab: 'Overview',
+    projectMap: { status: 'ready', model: m } });
+
+  test('a forbidden read is not "none configured"', () => {
+    const html = render(mapWith({ channelsError: err('403'), triggersError: err('403'),
+      tenantsError: err('403'), lifecycleError: err('403'), lifecycle: null, lifecycles: [] }));
+    expect(html).toContain('Channels could not be read');
+    expect(html).toContain('Triggers could not be read');
+    expect(html).toContain('Lifecycles could not be read');
+    expect(html).toContain('Connected tenants could not be counted');
+    // None of the confident zeros survive.
+    expect(html).not.toContain('one implicit channel');
+    expect(html).not.toContain('No triggers are configured');
+    expect(html).not.toContain('no lifecycle phases');
+    expect(html).not.toContain('4 tenants connected');
+  });
+
+  test('a lifecycle with no phases does not silently mean every environment', () => {
+    const machines = { items: [
+      { Id: 'M1', Name: 'in-scope', Roles: ['web'], EnvironmentIds: ['E1'], HealthStatus: 'Healthy' },
+      { Id: 'M2', Name: 'far-away', Roles: ['web'], EnvironmentIds: ['E9'], HealthStatus: 'Healthy' }
+    ], total: 2 };
+    const m = data.projectMapModel({
+      project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+      process: { Steps: [{ Name: 'D', Properties: { 'Octopus.Action.TargetRoles': 'web' },
+        Actions: [{ ActionType: 'Octopus.Script' }] }] },
+      channels: { Items: [] }, triggers: { Items: [] },
+      lifecycle: { Id: 'L1', Name: 'Default Lifecycle', Phases: [] },
+      lifecycles: [{ Id: 'L1', Name: 'Default Lifecycle', Phases: [] }],
+      feeds: { Items: [] }, environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E9', Name: 'Lab' }],
+      tenants: { TotalResults: 0 }, machines: machines });
+    expect(m.targets.scopeUnknown).toBe(true);
+    expect(m.targets.total).toBe(0);
+    const html = render(m);
+    expect(html).toContain('is not known');
+    expect(html).not.toContain('far-away');
+  });
+
+  test('a capped estate is not an empty one, on either page', () => {
+    const capped = { items: [{ Id: 'M1', Name: 'a', Roles: ['other'], EnvironmentIds: ['E1'] }],
+      total: 5000, truncated: true };
+    const html = render(mapWith({ machines: capped,
+      process: { Steps: [{ Name: 'D', Properties: { 'Octopus.Action.TargetRoles': 'web' },
+        Actions: [{ ActionType: 'Octopus.Script' }] }] } }));
+    expect(html).toContain('The rest were not read');
+    expect(html).not.toContain('nowhere to run');
+
+    const tenant = data.tenantDetailModel({
+      tenant: { Id: 'T1', Name: 'Acme', ProjectEnvironments: {} },
+      dashboard: { Projects: [], Environments: [], Items: [] },
+      machines: capped });
+    expect(tenant.infrastructure.orphaned).toBe(false);
+    expect(tenant.infrastructure.truncated).toBe(true);
+    const tHtml = Views.renderTenantDetail({ tenantDetail: { status: 'ready', model: tenant } });
+    expect(tHtml).toContain('The rest were not read');
+    expect(tHtml).not.toContain('resolve to nothing');
+  });
+
+  test('a fully read estate still says plainly when nothing matches', () => {
+    const whole = { items: [], total: 0, truncated: false };
+    const tenant = data.tenantDetailModel({
+      tenant: { Id: 'T1', Name: 'Acme', ProjectEnvironments: {} },
+      dashboard: { Projects: [], Environments: [], Items: [] }, machines: whole });
+    expect(tenant.infrastructure.orphaned).toBe(true);
+    expect(Views.renderTenantDetail({ tenantDetail: { status: 'ready', model: tenant } }))
+      .toContain('resolve to nothing');
+  });
+
+  test('the dashboard cap is disclosed on both tenant views', () => {
+    const dash = { Projects: [{ Id: 'P1', Name: 'One' }], ProjectGroups: [], Environments: [],
+      Tenants: [], Items: [], ProjectLimit: 1 };
+    const list = data.tenantsModel({ tenants: { items: [{ Id: 'T1', Name: 'Acme', ProjectEnvironments: { 'P9': ['E1'] } }], total: 1 },
+      dashboard: dash, tagSets: [] });
+    expect(list.dashboardCap.capped).toBe(true);
+    expect(Views.renderTenants({ tenants: { status: 'ready', model: list } }))
+      .toContain('reads as never deployed');
+
+    const detail = data.tenantDetailModel({ tenant: { Id: 'T1', Name: 'Acme', ProjectEnvironments: { 'P9': ['E1'] } },
+      dashboard: dash });
+    expect(detail.dashboardCap.capped).toBe(true);
+    expect(Views.renderTenantDetail({ tenantDetail: { status: 'ready', model: detail } }))
+      .toContain('reads here as never deployed');
+  });
+
+  test('an uncapped dashboard says nothing at all', () => {
+    const dash = { Projects: [{ Id: 'P1', Name: 'One' }], ProjectGroups: [], Environments: [],
+      Tenants: [], Items: [], ProjectLimit: 200 };
+    const list = data.tenantsModel({ tenants: { items: [{ Id: 'T1', Name: 'Acme', ProjectEnvironments: {} }], total: 1 },
+      dashboard: dash, tagSets: [] });
+    expect(list.dashboardCap.capped).toBe(false);
+    expect(Views.renderTenants({ tenants: { status: 'ready', model: list } }))
+      .not.toContain('reads as never deployed');
+  });
+
+  test('library variable sets are read by template, not by environment', () => {
+    const variables = { LibraryVariables: { 'LVS-1': {
+      LibraryVariableSetName: 'Standard',
+      Templates: [{ Id: 'tpl-region', Label: 'Region' }, { Id: 'tpl-tier', Label: 'Tier' }],
+      Variables: { 'tpl-region': 'eu-west' } } } };
+    const r = data.tenantReadiness(variables, { 'P1': ['E1', 'E2', 'E3'] },
+      { E1: 'Dev', E2: 'Test', E3: 'Prod' }, {});
+    // Region is supplied. Tier is not — once, not once per environment.
+    expect(r.missing.map(x => x.name)).toEqual(['Tier']);
+    expect(r.count).toBe(1);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3458,7 +3458,7 @@ describe('Project map', () => {
   });
 });
 
-describe('Inputs, triggers and channels share a column', () => {
+describe('The project map columns hold what belongs together', () => {
   const data = require('./data');
   const Views = require('./views');
   const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: data.projectMapModel({
@@ -3468,10 +3468,11 @@ describe('Inputs, triggers and channels share a column', () => {
     lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [], tenants: { TotalResults: 0 }
   }) } });
 
-  // Walk div depth to find where the column actually ends, rather than trusting
+  // Walk div depth to find where a column actually ends, rather than trusting
   // a lazy regex to guess it.
-  const column = (() => {
-    const start = html.indexOf('<div class="ip-pm-col">');
+  const column = n => {
+    let start = -1;
+    for (let i = 0; i <= n; i++) start = html.indexOf('<div class="ip-pm-col">', start + 1);
     if (start === -1) return null;
     const rest = html.slice(start);
     const tok = /<div\b|<\/div>/g;
@@ -3481,23 +3482,26 @@ describe('Inputs, triggers and channels share a column', () => {
       if (depth === 0) return rest.slice(0, m.index + m[0].length);
     }
     return null;
-  })();
+  };
+  const headings = col => (col.match(/<h3>([^<]*)/g) || []).map(h => h.replace('<h3>', ''));
 
-  test('the column exists and closes cleanly', () => {
-    expect(column).not.toBeNull();
+  test('both columns exist and close cleanly', () => {
+    expect(column(0)).not.toBeNull();
+    expect(column(1)).not.toBeNull();
   });
 
-  test('it holds exactly the three panels, in order', () => {
-    expect((column.match(/<section/g) || []).length).toBe(3);
-    const headings = (column.match(/<h3>([^<]*)/g) || []).map(h => h.replace('<h3>', ''));
-    expect(headings).toEqual(['Inputs', 'Triggers', 'Channels']);
+  test('channels lead the left column, above what feeds the project', () => {
+    expect(headings(column(0))).toEqual(['Channels', 'Inputs', 'Triggers']);
   });
 
-  test('process and destinations stay outside it', () => {
-    ['>Process', '>Destinations'].forEach(h => {
-      expect(column.indexOf(h)).toBe(-1);
-      expect(html.indexOf(h)).toBeGreaterThan(-1);
-    });
+  test('flags sit under destinations in the right column', () => {
+    expect(headings(column(1))).toEqual(['Destinations', 'Feature flags']);
+  });
+
+  test('process stays outside both columns', () => {
+    expect(column(0).indexOf('>Process')).toBe(-1);
+    expect(column(1).indexOf('>Process')).toBe(-1);
+    expect(html.indexOf('>Process')).toBeGreaterThan(-1);
   });
 
   test('lifecycles sit above the grid, full width', () => {
@@ -3722,5 +3726,133 @@ describe('Destinations: selection, targets and their shape', () => {
     expect(html).toContain('Selected by');
     expect(html).toContain('Within');
     expect(html).toContain('12 tenants connected');
+  });
+});
+
+describe('Project feature flags across the lifecycle environments', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const envs = ['E1', 'E2'];
+  const names = { E1: 'Dev', E2: 'Prod' };
+  const model = items => data.projectFlagModel({ items: items, total: items.length }, envs, names);
+
+  test('a flag with no environment settings resolves against its default', () => {
+    const on = model([{ Id: 'F1', Name: 'a', DefaultIsEnabled: true }]);
+    expect(on.fullyOn).toBe(1);
+    expect(on.flags[0].cells.every(c => c.viaDefault)).toBe(true);
+    expect(model([{ Id: 'F2', Name: 'b', DefaultIsEnabled: false }]).fullyOff).toBe(1);
+  });
+
+  test('an environment setting beats the default for that environment only', () => {
+    const m = model([{ Id: 'F1', Name: 'a', DefaultIsEnabled: false,
+      Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true }] }]);
+    expect(m.flags[0].cells.map(c => c.key)).toEqual(['on', 'off']);
+    expect(m.betweenCount).toBe(1);
+  });
+
+  test('a percentage rollout is in between wherever it lands', () => {
+    const m = model([{ Id: 'F1', Name: 'a', DefaultIsEnabled: true,
+      Environments: [{ DeploymentEnvironmentId: 'E2', IsEnabled: true, RolloutPercentage: 25 }] }]);
+    expect(m.flags[0].settled).toBe('between');
+    expect(m.flags[0].cells[1]).toMatchObject({ key: 'partial', percent: 25 });
+  });
+
+  test('the ones in between are named, not just counted', () => {
+    const m = model([
+      { Id: 'F1', Name: 'settled', DefaultIsEnabled: true },
+      { Id: 'F2', Name: 'drifting', DefaultIsEnabled: false,
+        Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true }] }
+    ]);
+    expect(m.between.map(f => f.name)).toEqual(['drifting']);
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: Object.assign(
+      data.projectMapModel({ project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+        process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+        lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
+        tenants: { TotalResults: 0 } }), { flags: m }) } });
+    expect(html).toContain('drifting');
+    expect(html).not.toContain('>settled<');
+  });
+
+  test('environment targeting counts toward what the flag says it does', () => {
+    const m = model([{ Id: 'F1', Name: 'a', DefaultIsEnabled: false,
+      Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true, TenantIds: ['T1', 'T2'], TenantTags: ['x/y'] }] }]);
+    expect(m.flags[0].cells[0].tenantCount).toBe(3);
+  });
+
+  test('no flags, and flags with nowhere to land, read differently', () => {
+    const base = data.projectMapModel({ project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+      process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+      lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
+      tenants: { TotalResults: 0 } });
+    const render = flags => Views.renderProjectMap({ projectMap: { status: 'ready',
+      model: Object.assign({}, base, { flags: flags }) } });
+    expect(render(data.projectFlagModel({ items: [], total: 0 }, envs, names)))
+      .toContain('no feature flags');
+    expect(render(data.projectFlagModel({ items: [{ Id: 'F1', Name: 'a' }], total: 1 }, [], names)))
+      .toContain('no lifecycle environments to place them in');
+  });
+
+  test('an instance without the preview says so rather than showing zero', () => {
+    const err = new Error('404 Not Found'); err.code = '404 Not Found';
+    const m = data.projectMapModel({ project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+      process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+      lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
+      tenants: { TotalResults: 0 }, flagsError: err });
+    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: m } }))
+      .toContain('Feature flags are not available on this instance');
+    // Anything else is a read failure, not an absent capability.
+    const other = new Error('500 Server Error'); other.code = '500 Server Error';
+    const m2 = data.projectMapModel({ project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+      process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+      lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
+      tenants: { TotalResults: 0 }, flagsError: other });
+    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: m2 } }))
+      .toContain('could not be read for this project');
+  });
+});
+
+describe('The lifecycle panel opens on the default only', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const lc = (id, name, envIds) => ({ Id: id, Name: name,
+    Phases: envIds.map((e, i) => ({ Name: 'P' + i, OptionalDeploymentTargets: [e] })) });
+  const build = extra => data.projectMapModel(Object.assign({
+    project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+    process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
+    environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Prod' }],
+    tenants: { TotalResults: 0 }
+  }, extra));
+
+  test('one lifecycle needs no disclosure at all', () => {
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: build({
+      channels: { Items: [] }, lifecycle: lc('L1', 'Std', ['E1', 'E2']), lifecycles: [lc('L1', 'Std', ['E1', 'E2'])]
+    }) } });
+    expect(html).toContain('Std');
+    expect(html).not.toContain('ip-pm-lcmore');
+  });
+
+  test('the others fold away behind a count', () => {
+    const model = build({
+      channels: { Items: [{ Id: 'C1', Name: 'Hotfix', LifecycleId: 'L2' }] },
+      lifecycle: lc('L1', 'Std', ['E1', 'E2']),
+      lifecycles: [lc('L1', 'Std', ['E1', 'E2']), lc('L2', 'Hotfix', ['E2'])]
+    });
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: model } });
+    const details = html.slice(html.indexOf('<details class="ip-pm-lcmore">'));
+    expect(html).toContain('<details class="ip-pm-lcmore">');
+    expect(html).toContain('1 other lifecycle</summary>');
+    // The default is on the page before the disclosure; the other is inside it.
+    expect(html.indexOf('Std')).toBeLessThan(html.indexOf('<details'));
+    expect(details).toContain('Hotfix');
+    // Not open by default — that is the whole point.
+    expect(html).not.toContain('<details class="ip-pm-lcmore" open>');
+  });
+
+  test('the plural is right for more than one', () => {
+    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: build({
+      channels: { Items: [] }, lifecycle: lc('L1', 'Std', ['E1']),
+      lifecycles: [lc('L1', 'Std', ['E1']), lc('L2', 'A', ['E1']), lc('L3', 'B', ['E2'])]
+    }) } });
+    expect(html).toContain('2 other lifecycles</summary>');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1694,17 +1694,24 @@ describe('Projects — tenant split lives in the environment cell', () => {
     expect(cell.entries.map(e => e.tenantCount).sort((a, b) => a - b)).toEqual([3, 6, 11]);
   });
 
-  test('the contracted row carries each release share as its own fill', () => {
+  test('the contracted row carries a share bar per release', () => {
     const html = render(false);
     expect(html).toContain('ip-rel-entry-share');
-    expect(html).toContain('--ip-rel-share:55.0%');   // 11 of 20
+    expect(html).toContain('ip-rel-tsbar');
+    expect(html).toContain('width:55.0%');   // 11 of 20
   });
 
-  test('a share row is one line: version, then the tenant count', () => {
-    const html = render(false);
-    // No separate bar element, so the share costs no extra height.
-    expect(html).not.toContain('ip-rel-tsbar');
-    expect(html).not.toContain('ip-rel-entry-head');
+  test('a share row is one line: version, bar, count — and no status', () => {
+    const failing = Object.assign({}, payload, {
+      Items: payload.Items.map((it, i) => i === 0 ? Object.assign({}, it, { State: 'Failed' }) : it)
+    });
+    const html = Views.renderProjects({ projectOpen: {},
+      releases: { status: 'ready', model: data.releasesModel(failing) } });
+    // The node above carries the environment's state; the rollout rows answer
+    // "how much of the estate", so they stay free of status chips.
+    const cell = /<div class="ip-rel-cell has-split">[\s\S]*?<\/div><\/div>/.exec(html)[0];
+    expect(cell).not.toContain('ip-rel-state');
+    expect(cell).not.toContain('ip-rel-entry-head');
   });
 
   test('there is no separate tenant panel above the history', () => {
@@ -1734,5 +1741,66 @@ describe('Projects — tenant split lives in the environment cell', () => {
     });
     const html = Views.renderProjects({ projectOpen: {}, releases: { status: 'ready', model: data.releasesModel(single) } });
     expect(html).not.toContain('ip-rel-entry-share');
+  });
+});
+
+describe('Projects — muting an environment', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Branch Instances' }, { id: 'E2', name: 'Production' }];
+  const model = {
+    environments: grid,
+    groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+      projects: [{ id: 'P1', name: 'Portal',
+        cells: [{ envId: 'E1', envName: 'Branch Instances', entries: [], versionCount: 0, tenantTotal: 0 },
+                { envId: 'E2', envName: 'Production', entries: [], versionCount: 0, tenantTotal: 0 }],
+        links: [null, 'none'] }] }],
+    projects: [{ id: 'P1' }], truncated: {}
+  };
+  // One release that only ever reached the noisy environment, one that reached Production.
+  const history = { status: 'ready', model: {
+    environments: grid, channels: ['Main'], totalReleases: 2, hiddenByWindow: 0, neverDeployedCount: 0,
+    releases: [
+      { version: 'noise.1', channelName: 'Main', assembled: null, lag: 0, everDeployed: true, frontier: 0,
+        cells: [{ envId: 'E1', envName: 'Branch Instances', deployed: true, stateKey: 'success', stateLabel: 'Succeeded', when: null, tenantCount: 0, count: 1 },
+                { envId: 'E2', envName: 'Production', deployed: false, stateKey: null, stateLabel: '', when: null, tenantCount: 0, count: 0 }] },
+      { version: 'real.1', channelName: 'Main', assembled: null, lag: 0, everDeployed: true, frontier: 1,
+        cells: [{ envId: 'E1', envName: 'Branch Instances', deployed: true, stateKey: 'success', stateLabel: 'Succeeded', when: null, tenantCount: 0, count: 1 },
+                { envId: 'E2', envName: 'Production', deployed: true, stateKey: 'success', stateLabel: 'Succeeded', when: null, tenantCount: 0, count: 1 }] }
+    ] } };
+  const render = envOff => Views.renderProjects({
+    projectOpen: { P1: true }, projectHistory: { P1: history },
+    envOff: envOff, releases: { status: 'ready', model }
+  });
+
+  test('every environment has a switch, on by default', () => {
+    const html = render(undefined);
+    expect((html.match(/data-envtoggle=/g) || []).length).toBe(2);
+    expect(html).not.toContain('aria-checked="false"');
+  });
+
+  test('muting drops releases that only reached the muted environment', () => {
+    const html = render({ G1: { E1: true } });
+    expect(html).toContain('real.1');
+    expect(html).not.toContain('noise.1');
+    expect(html).toContain('1 release only reached muted environments');
+  });
+
+  test('the muted column stays in place so nothing shifts', () => {
+    const html = render({ G1: { E1: true } });
+    expect(html).toContain('repeat(2,calc((100% - var(--ip-rel-endgutter)) / var(--ip-rel-cols)))');
+    expect(html).toContain('ip-rel-hcell is-off');
+  });
+
+  test('the collapsed row still reports the muted environment', () => {
+    const html = render({ G1: { E1: true } });
+    // The grid answers "what is running where"; muting is a history filter.
+    expect(html).toContain('Branch Instances');
+    expect(html).toContain('aria-checked="false"');
+  });
+
+  test('muting everything says so rather than showing a blank panel', () => {
+    const html = render({ G1: { E1: true, E2: true } });
+    expect(html).toContain('only reached environments you have muted');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1422,8 +1422,8 @@ describe('Releases — many releases live in one environment', () => {
   });
   test('the view names a few and summarises the rest', () => {
     const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(many) } });
-    expect(html).toContain('more releases across 41 tenants');
-    expect(html).not.toContain('ip-rel-tenants" style');
+    // The tail reports the tenants it covers, which is the actionable half.
+    expect(html).toContain('+38 more releases on 38 tenants');
     // Three named, not forty-one.
     expect((html.match(/ip-rel-ver/g) || []).length).toBe(3);
   });
@@ -1664,61 +1664,68 @@ describe('Project history — the age on the line', () => {
   });
 });
 
-describe('Projects — tenant spread in the expanded row', () => {
+describe('Projects — tenant split lives in the environment cell', () => {
   const data = require('./data');
   const Views = require('./views');
-  // One environment holding several releases across many tenants: the case the
-  // collapsed cell can only summarise.
+  const tenants = Array.from({ length: 20 }, (_, i) => ({ Id: 'T' + i, Name: 'Tenant ' + i }));
   const payload = {
     Environments: [{ Id: 'E1', Name: 'Production' }],
     ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }],
     Projects: [{ Id: 'P1', Name: 'Octopus Server', ProjectGroupId: 'G1' }],
-    Tenants: Array.from({ length: 10 }, (_, i) => ({ Id: 'T' + i, Name: 'Tenant ' + i })),
-    Items: Array.from({ length: 10 }, (_, i) => ({
+    Tenants: tenants,
+    // 11 tenants on 9.3, 6 on 9.2, 3 on 9.0 — a rollout part-way through.
+    Items: tenants.map((t, i) => ({
       IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1',
-      // Six tenants on 2.0, four on 1.0.
-      ReleaseVersion: i < 6 ? '2.0' : '1.0', State: 'Success',
-      TenantId: 'T' + i, CompletedTime: '2026-08-14T0' + (i % 5) + ':00:00Z'
+      ReleaseVersion: i < 11 ? '9.3' : (i < 17 ? '9.2' : '9.0'),
+      State: 'Success', TenantId: t.Id, CompletedTime: '2026-08-14T0' + (i % 5) + ':00:00Z'
     }))
   };
   const model = data.releasesModel(payload);
-  const render = () => Views.renderProjects({
-    projectOpen: { P1: true },
+  const render = open => Views.renderProjects({
+    projectOpen: open ? { P1: true } : {},
     projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: [] } } },
     releases: { status: 'ready', model }
   });
 
   test('the model keeps every version and its tenant count', () => {
     const cell = model.groups[0].projects[0].cells[0];
-    expect(cell.versionCount).toBe(2);
-    expect(cell.tenantTotal).toBe(10);
-    expect(cell.entries.map(e => e.tenantCount).sort()).toEqual([4, 6]);
+    expect(cell.versionCount).toBe(3);
+    expect(cell.tenantTotal).toBe(20);
+    expect(cell.entries.map(e => e.tenantCount).sort((a, b) => a - b)).toEqual([3, 6, 11]);
   });
 
-  test('expanding names each release and how many tenants are on it', () => {
-    const html = render();
-    expect(html).toContain('2 releases · 10 tenants');
-    expect(html).toContain('>6<');
-    expect(html).toContain('>4<');
+  test('the contracted row carries a share bar per release', () => {
+    const html = render(false);
+    expect(html).toContain('ip-rel-tsbar');
+    expect(html).toContain('width:55.0%');   // 11 of 20
   });
 
-  test('the split is laid out in the environment columns, not stacked', () => {
-    const html = render();
-    const block = /<div class="ip-rel-tsblock">([\s\S]*?)<\/div><\/div>/.exec(html);
-    expect(block).not.toBeNull();
-    // It uses the same column template as the row above it.
-    expect(block[0]).toContain('var(--ip-rel-cols)');
+  test('there is no separate tenant panel above the history', () => {
+    expect(render(true)).not.toContain('ip-rel-tsblock');
   });
 
-  test('a project with no split shows no tenant block', () => {
-    const single = Object.assign({}, payload, {
-      Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '2.0', State: 'Success', TenantId: 'T0' }]
+  test('expanding shows every release in the cell, contracted caps at three', () => {
+    const many = Object.assign({}, payload, {
+      Items: tenants.map((t, i) => ({
+        IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1',
+        ReleaseVersion: 'v' + i, State: 'Success', TenantId: t.Id
+      }))
     });
-    const html = Views.renderProjects({
-      projectOpen: { P1: true },
+    const m2 = data.releasesModel(many);
+    const shut = Views.renderProjects({ projectOpen: {}, releases: { status: 'ready', model: m2 } });
+    const open = Views.renderProjects({ projectOpen: { P1: true },
       projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: [] } } },
-      releases: { status: 'ready', model: data.releasesModel(single) }
+      releases: { status: 'ready', model: m2 } });
+    expect((shut.match(/ip-rel-entry"/g) || []).length).toBe(3);
+    expect((open.match(/ip-rel-entry"/g) || []).length).toBe(20);
+    expect(shut).toContain('+17 more releases on 17 tenants');
+  });
+
+  test('an environment on a single release draws no bar', () => {
+    const single = Object.assign({}, payload, {
+      Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success', TenantId: 'T0' }]
     });
-    expect(html).not.toContain('ip-rel-tsblock');
+    const html = Views.renderProjects({ projectOpen: {}, releases: { status: 'ready', model: data.releasesModel(single) } });
+    expect(html).not.toContain('ip-rel-tsbar');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3984,6 +3984,15 @@ describe('A project page opens on Status and keeps Overview a click away', () =>
     expect(html).toContain('--ip-rel-cols:2');
   });
 
+  test('the controls sit on the tab row, not above the content', () => {
+    const html = Views.renderProjectMap(IP());
+    const bar = html.slice(html.indexOf('<div class="ip-pm-tabbar">'), html.indexOf('</nav>') + 200);
+    expect(bar).toContain('ip-rel-controls');
+    // They belong to Status, and there is nothing to filter until the dashboard lands.
+    expect(Views.renderProjectMap(IP({ projectTab: 'Overview' }))).not.toContain('ip-rel-controls');
+    expect(Views.renderProjectMap(IP({ releases: { status: 'loading' } }))).not.toContain('ip-rel-controls');
+  });
+
   test('the row opens expanded, because the page is about this project', () => {
     expect(Views.renderProjectMap(IP())).toContain('ip-rel-card is-open');
     expect(Views.renderProjectMap(IP({ projectOpen: {} }))).not.toContain('ip-rel-card is-open');

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1231,9 +1231,9 @@ describe('sidebar composition', () => {
   const items = [...html.matchAll(/class="ip-nav-item" data-view="([^"]+)">([^<]+)</g)]
     .map(m => ({ view:m[1], label:m[2] }));
 
-  test('Projects leads, then Paul\'s five in his order', () => {
+  test('Projects leads, then Paul\'s five in his order, then Tenants', () => {
     expect(items.map(i => i.view)).toEqual(
-      ['projects','overview','targets','environments','workers','argocd']);
+      ['projects','overview','targets','environments','workers','argocd','tenants']);
   });
   test('Projects sits above the Infrastructure heading', () => {
     expect(html.indexOf('data-view="projects"')).toBeLessThan(html.indexOf('ip-sidebar-title'));
@@ -2373,5 +2373,131 @@ describe('A release is named where it stops, not everywhere it went', () => {
     ]);
     const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
     expect((html.match(/9\.3</g) || []).length).toBe(1);
+  });
+});
+
+describe('Tenants — the four independent facts', () => {
+  const data = require('./data');
+  const NOW = Date.parse('2026-08-17T12:00:00Z');
+  const ago = d => new Date(NOW - d * 86400000).toISOString();
+  const payload = {
+    now: NOW,
+    tenants: { total: 4, truncated: false, items: [
+      { Id: 'T1', Name: 'Mercy Polyclinic', TenantTags: ['Hosted/Reef', 'Ring/Stable'], ProjectEnvironments: { P1: ['E1'] } },
+      { Id: 'T2', Name: 'Riverside General', TenantTags: ['Hosted/Cluster'], ProjectEnvironments: { P1: ['E1'], P2: ['E1'] } },
+      { Id: 'T3', Name: 'Never Ran', TenantTags: [], ProjectEnvironments: { P1: ['E1'] } },
+      { Id: 'T4', Name: 'Unwired', TenantTags: [], ProjectEnvironments: {} }
+    ] },
+    dashboard: {
+      Projects: [{ Id: 'P1', Name: 'Patient Records' }, { Id: 'P2', Name: 'Billing' }],
+      Environments: [{ Id: 'E1', Name: 'Production' }],
+      Items: [
+        { IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E1', State: 'Failed', CompletedTime: ago(2) },
+        { IsCurrent: true, TenantId: 'T2', ProjectId: 'P1', EnvironmentId: 'E1', State: 'Success', CompletedTime: ago(1) }
+      ]
+    },
+    tagSets: [{ Name: 'Hosted', Tags: [{ Name: 'Reef' }, { Name: 'Cluster' }] }]
+  };
+  const m = data.tenantsModel(payload);
+  const by = name => m.tenants.find(t => t.name === name);
+
+  test('connection, last outcome, never-deployed and not-connected stay separate', () => {
+    expect(by('Mercy Polyclinic').needsAttention).toBe(true);
+    expect(by('Never Ran').neverDeployed).toBe(true);
+    expect(by('Never Ran').needsAttention).toBe(false);
+    expect(by('Unwired').notConnected).toBe(true);
+    expect(by('Unwired').neverDeployed).toBe(false);
+  });
+
+  test('a task running past a week is stuck, not in progress', () => {
+    expect(data.tenantOutcomeKey('Executing', NOW - 8 * 86400000, NOW)).toBe('stuck');
+    expect(data.tenantOutcomeKey('Executing', NOW - 3600000, NOW)).toBe('running');
+  });
+
+  test('tags are split into their set and value', () => {
+    expect(data.parseTenantTag('Hosted/Reef')).toEqual({ set: 'Hosted', name: 'Reef', raw: 'Hosted/Reef' });
+    expect(data.parseTenantTag('Loose').set).toBe('');
+  });
+
+  test('the default sort is actionability, not alphabet', () => {
+    expect(data.sortTenants(m.tenants, 'Actionability').map(t => t.name))
+      .toEqual(['Mercy Polyclinic', 'Never Ran', 'Unwired', 'Riverside General']);
+    expect(data.sortTenants(m.tenants, 'Name').map(t => t.name)[0]).toBe('Mercy Polyclinic');
+  });
+
+  test('filters combine, and a tag filter needs every selected tag', () => {
+    expect(data.filterTenants(m.tenants, '', { tags: { 'Hosted/Reef': true } }).map(t => t.name)).toEqual(['Mercy Polyclinic']);
+    expect(data.filterTenants(m.tenants, '', { tags: { 'Hosted/Reef': true, 'Ring/Stable': true } })).toHaveLength(1);
+    expect(data.filterTenants(m.tenants, '', { tags: { 'Hosted/Reef': true, 'Hosted/Cluster': true } })).toHaveLength(0);
+  });
+
+  test('search matches name or id', () => {
+    expect(data.filterTenants(m.tenants, 'riverside', {})).toHaveLength(1);
+    expect(data.filterTenants(m.tenants, 'T4', {})).toHaveLength(1);
+  });
+
+  test('state filters use the independent facts', () => {
+    expect(data.filterTenants(m.tenants, '', { state: { 'needs-attention': true } }).map(t => t.name)).toEqual(['Mercy Polyclinic']);
+    expect(data.filterTenants(m.tenants, '', { state: { 'not-connected': true } }).map(t => t.name)).toEqual(['Unwired']);
+  });
+
+  test('facet counts are computed against the other active filters', () => {
+    const facets = data.tenantFacets(m.tenants, '', { state: { 'needs-attention': true } });
+    // Only Mercy needs attention, and it is the only Reef tenant.
+    expect(facets.count('tags', 'Hosted/Reef')).toBe(1);
+    expect(facets.count('tags', 'Hosted/Cluster')).toBe(0);
+  });
+
+  test('counts report the three list-scale facts', () => {
+    expect(m.counts).toEqual({ needsAttention: 1, neverDeployed: 1, notConnected: 1 });
+  });
+
+  test('an empty payload yields nothing and does not throw', () => {
+    expect(data.tenantsModel({}).tenants).toEqual([]);
+    expect(data.tenantsModel(undefined).tenants).toEqual([]);
+  });
+});
+
+describe('Tenants — view', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const NOW = Date.parse('2026-08-17T12:00:00Z');
+  const model = data.tenantsModel({
+    now: NOW,
+    tenants: { total: 2, truncated: false, items: [
+      { Id: 'T1', Name: 'Mercy Polyclinic', TenantTags: ['Hosted/Reef'], ProjectEnvironments: { P1: ['E1'] } },
+      { Id: 'T2', Name: 'Unwired', TenantTags: [], ProjectEnvironments: {} }
+    ] },
+    dashboard: { Projects: [{ Id: 'P1', Name: 'Patient Records' }], Environments: [{ Id: 'E1', Name: 'Production' }],
+      Items: [{ IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E1', State: 'Failed',
+        CompletedTime: new Date(NOW - 2 * 86400000).toISOString() }] },
+    tagSets: [{ Name: 'Hosted', Tags: [{ Name: 'Reef' }] }]
+  });
+  const html = Views.renderTenants({ tenants: { status: 'ready', model } });
+
+  test('a tenant links to its own page', () => {
+    expect(html).toContain('href="#tenants/T1"');
+  });
+
+  test('the unscoped currency prompt is shown rather than a faked figure', () => {
+    expect(html).toContain('Pick a release scope to see currency');
+  });
+
+  test('readiness says where it lives rather than pretending to be absent', () => {
+    expect(html).toContain('Readiness needs a request per tenant');
+  });
+
+  test('a not-connected tenant says so instead of showing a zero', () => {
+    expect(html).toContain('Not connected');
+  });
+
+  test('facet groups come from the instance tag sets', () => {
+    expect(html).toContain('Hosted');
+    expect(html).toContain('Reef');
+  });
+
+  test('an empty space explains what a tenant is', () => {
+    const empty = Views.renderTenants({ tenants: { status: 'ready', model: data.tenantsModel({}) } });
+    expect(empty).toContain('No tenants in this space');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3856,3 +3856,78 @@ describe('The lifecycle panel opens on the default only', () => {
     expect(html).toContain('2 other lifecycles</summary>');
   });
 });
+
+describe('Flags name their environments once, not once per flag', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const render = items => {
+    const fm = data.projectFlagModel({ items: items, total: items.length },
+      ['E1', 'E2', 'E3'], { E1: 'Dev', E2: 'Staging', E3: 'Production' });
+    const base = data.projectMapModel({ project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+      process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+      lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
+      tenants: { TotalResults: 0 } });
+    return Views.renderProjectMap({ projectMap: { status: 'ready',
+      model: Object.assign({}, base, { flags: fm }) } });
+  };
+  const twoFlags = [
+    { Id: 'F1', Name: 'alpha', DefaultIsEnabled: false,
+      Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true }] },
+    { Id: 'F2', Name: 'beta', DefaultIsEnabled: false,
+      Environments: [{ DeploymentEnvironmentId: 'E2', IsEnabled: true, RolloutPercentage: 40 }] }
+  ];
+
+  test('each environment head appears once however many flags there are', () => {
+    const html = render(twoFlags);
+    const grid = html.slice(html.indexOf('ip-pm-fg'));
+    expect((grid.match(/ip-pm-colhead/g) || []).length).toBe(3);
+    expect((grid.match(/>Production</g) || []).length).toBe(1);
+  });
+
+  test('every flag gets a cell per environment, aligned to those heads', () => {
+    const grid = render(twoFlags);
+    const rows = grid.split('<div class="ip-pm-lcrow">').slice(1);
+    expect(rows.length).toBe(2);
+    rows.forEach(r => expect((r.match(/ip-pm-cell/g) || []).length).toBe(3));
+  });
+
+  test('a rollout shows its number; on and off differ by more than colour', () => {
+    const grid = render(twoFlags);
+    expect(grid).toContain('<span class="ip-pm-fpct">40</span>');
+    expect(grid).toContain('ip-pm-fdot is-on');
+    expect(grid).toContain('ip-pm-fdot is-off');
+  });
+
+  test('the environment a state belongs to survives in the cell title', () => {
+    expect(render(twoFlags)).toContain('title="Staging: 40% rollout"');
+  });
+
+  test('a state inherited from the default is marked as such', () => {
+    const html = render([{ Id: 'F1', Name: 'a', DefaultIsEnabled: true,
+      Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: false }] }]);
+    expect(html).toContain('is-on is-default');
+    expect(html).toContain('(by default)');
+  });
+});
+
+// String-replace edits have twice copied a render block into a second function
+// that happened to share an anchor. Neither copy is reachable from the wrong
+// view, so nothing failed — it just sat there. This catches the next one.
+describe('Render blocks are defined once, in the view that uses them', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const src = fs.readFileSync(path.join(__dirname, 'views.js'), 'utf8');
+  const body = name => {
+    const i = src.indexOf('function ' + name + '(IP)');
+    if (i === -1) return '';
+    const j = src.indexOf('\n  function ', i + 1);
+    return src.slice(i, j === -1 ? undefined : j);
+  };
+
+  test('the project map owns the flag panel and the lifecycle track', () => {
+    expect((src.match(/const flagPanel = \(function/g) || []).length).toBe(1);
+    expect(body('renderProjectMap')).toContain('const flagPanel = (function');
+    expect(body('renderTenantDetail')).not.toContain('const flagPanel = (function');
+    expect((src.match(/const lcRow = lc =>/g) || []).length).toBe(1);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1809,7 +1809,7 @@ describe('Feature flags — model', () => {
   const data = require('./data');
   const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E2', name: 'Test' }, { id: 'E3', name: 'Prod' }];
   const payload = { total: 5, truncated: false, items: [
-    { Id: 'F1', Name: 'on-everywhere', Environments: [
+    { Id: 'F1', Name: 'on-everywhere', DefaultIsEnabled: true, Environments: [
       { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
       { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 100 }] },
     { Id: 'F2', Name: 'partial', Environments: [
@@ -1826,6 +1826,36 @@ describe('Feature flags — model', () => {
   test('only flags mid-journey get a row', () => {
     const m = data.featureFlagModel(payload, grid);
     expect(m.flags.map(f => f.name)).toEqual(['mixed', 'partial']);
+  });
+
+  test('an unconfigured environment falls to the default, and can put a flag in flight', () => {
+    // On in Dev, and off in Test and Prod because the flag's default says so.
+    // Counting only configured environments called this "on everywhere".
+    const drifting = { total: 1, items: [{ Id: 'X1', Name: 'drifting', DefaultIsEnabled: false,
+      Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 }] }] };
+    const m = data.featureFlagModel(drifting, grid);
+    expect(m.flags.map(f => f.name)).toEqual(['drifting']);
+    expect(m.settled).toEqual({ onEverywhere: 0, offEverywhere: 0, noOverrides: 0 });
+  });
+
+  test('the two flag models on the project page agree', () => {
+    const one = { total: 1, items: [{ Id: 'X1', Name: 'a', DefaultIsEnabled: false,
+      Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 }] }] };
+    const status = data.featureFlagModel(one, grid);
+    const overview = data.projectFlagModel(one, grid.map(e => e.id), { E1: 'Dev', E2: 'Test', E3: 'Prod' });
+    // Status drew a row for it; Overview must not call it settled.
+    expect(status.flags.length).toBe(1);
+    expect(overview.betweenCount).toBe(1);
+    expect(overview.fullyOn).toBe(0);
+  });
+
+  test('enabled at 0% reaches nobody, in both resolvers', () => {
+    expect(data.flagEnvState({ IsEnabled: true, RolloutPercentage: 0 }).key).toBe('off');
+    expect(data.flagStateForTenant({ IsEnabled: true, RolloutPercentage: 0 }, { Id: 'T1' }, false).key).toBe('off');
+    const zero = { total: 1, items: [{ Id: 'X1', Name: 'a', DefaultIsEnabled: false,
+      Environments: grid.map(e => ({ DeploymentEnvironmentId: e.id, IsEnabled: true, RolloutPercentage: 0 })) }] };
+    expect(data.featureFlagModel(zero, grid).settled.onEverywhere).toBe(0);
+    expect(data.projectFlagModel(zero, grid.map(e => e.id), {}).fullyOn).toBe(0);
   });
 
   test('the settled majority is counted, not drawn', () => {
@@ -1873,7 +1903,7 @@ describe('Feature flags — view', () => {
     { Id: 'F2', Name: 'new-checkout', Environments: [
       { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
       { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 10 }] },
-    { Id: 'F1', Name: 'settled', Environments: [
+    { Id: 'F1', Name: 'settled', DefaultIsEnabled: true, Environments: [
       { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 }] },
     { Id: 'F3', Name: 'also-settled', Environments: [] }
   ] };
@@ -1964,9 +1994,14 @@ describe('Flag changes — reconstructed from the audit trail', () => {
     expect(data.flagChangeLabel(def)).toBe('Off → On');
   });
 
-  test('a change in an environment the grid does not show is dropped', () => {
+  test('a change in an environment the grid does not show is kept and marked', () => {
+    // It has no column to sit in, but dropping it silently lost a real audit
+    // entry. The view counts these in its note instead of drawing them.
     const c = data.flagChangeModel(events, grid, null, Date.now());
-    expect(c.some(x => x.flagName === 'elsewhere')).toBe(false);
+    const outside = c.find(x => x.flagName === 'elsewhere');
+    expect(outside).toBeDefined();
+    expect(outside.scopedElsewhere).toBe(true);
+    expect(outside.envName).toBe('');
   });
 
   test('changes come back newest first', () => {
@@ -1977,8 +2012,12 @@ describe('Flag changes — reconstructed from the audit trail', () => {
 
   test('the window filters changes', () => {
     const now = Date.parse('2026-08-14T04:00:00Z');
-    expect(data.flagChangeModel(events, grid, 2, now)).toHaveLength(1);   // only Ev1
-    expect(data.flagChangeModel(events, grid, null, now).length).toBe(3); // Ev4 excluded by grid
+    // Ev1 is the only one inside the window with a column; Ev4 is inside it too
+    // but scoped elsewhere.
+    expect(data.flagChangeModel(events, grid, 2, now).filter(c => !c.scopedElsewhere)).toHaveLength(1);
+    const all = data.flagChangeModel(events, grid, null, now);
+    expect(all.filter(c => !c.scopedElsewhere).length).toBe(3);  // Ev4 has no column
+    expect(all.length).toBe(4);                                  // but is not lost
   });
 
   test('an empty payload yields nothing and does not throw', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3136,9 +3136,17 @@ describe('Project cards: background, sticky header, inline toggle', () => {
     expect(card).toContain('background: var(--ip-rel-surface)');
   });
 
-  test('the card background is defined for both themes', () => {
-    expect(css).toContain('--ip-rel-cardbg: var(--color-grey-100)');
-    expect(css).toContain('--ip-rel-cardbg: var(--color-navy-800)');
+  test('the card uses the same treatment as the overview cards', () => {
+    // One card style across the dashboard, and --card already flips per theme.
+    expect(css).toContain('--ip-rel-cardbg: var(--card)');
+    const card = rule(/\.ip-rel-card \{[\s\S]*?\}/);
+    expect(card).toContain('border: 1px solid var(--border)');
+    expect(card).toContain('border-radius: var(--radius-lg)');
+    expect(card).toContain('box-shadow: var(--shadow-xs)');
+  });
+
+  test('the header draws no rule under itself', () => {
+    expect(css).not.toContain('.ip-rel-head::after');
   });
 
   test('the environment header sticks, with a background to sit on', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1544,3 +1544,80 @@ describe('Project history — progression model', () => {
     expect(data.progressionModel({}, grid).releases).toEqual([]);
   });
 });
+
+describe('Project history — window', () => {
+  const data = require('./data');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E2', name: 'Prod' }];
+  const NOW = Date.parse('2026-08-14T12:00:00Z');
+  const hoursAgo = h => new Date(NOW - h * 3600000).toISOString();
+  const prog = {
+    Releases: [
+      { Release: { Id: 'R3', Version: '3.0', ChannelId: 'C1', Assembled: hoursAgo(2) },
+        Channel: { Id: 'C1', Name: 'Main' }, Deployments: {} },
+      { Release: { Id: 'R2', Version: '2.0', ChannelId: 'C1', Assembled: hoursAgo(72) },
+        Channel: { Id: 'C1', Name: 'Main' }, Deployments: {} },
+      // Cut long ago, promoted an hour ago — recent news despite an old birthday.
+      { Release: { Id: 'R1', Version: '1.0', ChannelId: 'C1', Assembled: hoursAgo(800) },
+        Channel: { Id: 'C1', Name: 'Main' },
+        Deployments: { E2: [{ State: 'Success', CompletedTime: hoursAgo(1) }] } }
+    ]
+  };
+
+  test('24 hours keeps what was created or moved inside it', () => {
+    const m = data.progressionModel(prog, grid, 24, NOW);
+    expect(m.releases.map(r => r.version).sort()).toEqual(['1.0', '3.0']);
+    expect(m.hiddenByWindow).toBe(1);
+  });
+
+  test('7 days widens to everything created inside it', () => {
+    const m = data.progressionModel(prog, grid, 24 * 7, NOW);
+    expect(m.releases).toHaveLength(3);
+    expect(m.hiddenByWindow).toBe(0);
+  });
+
+  test('no window keeps the lot', () => {
+    const m = data.progressionModel(prog, grid, null, NOW);
+    expect(m.releases).toHaveLength(3);
+  });
+
+  test('totalReleases reports the unfiltered count so an empty window can explain itself', () => {
+    // Half an hour excludes even the deployment made an hour ago.
+    const m = data.progressionModel(prog, grid, 0.5, NOW);
+    expect(m.releases).toHaveLength(0);
+    expect(m.totalReleases).toBe(3);
+  });
+
+  test('lag is counted before the window filter, so it stays true', () => {
+    const m = data.progressionModel(prog, grid, 24, NOW);
+    expect(m.releases.find(r => r.version === '1.0').lag).toBe(2);
+  });
+
+  test('the window options are 24 hours, 7 days and All', () => {
+    expect(data.HISTORY_WINDOWS.map(w => w.label)).toEqual(['24 hours', '7 days', 'All']);
+  });
+});
+
+describe('Projects — column geometry', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const payload = {
+    Environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Prod' }],
+    ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }, { Id: 'G2', Name: 'Tools' }],
+    Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' }, { Id: 'P2', Name: 'Script', ProjectGroupId: 'G2' }],
+    Items: [
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' },
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E2', ReleaseVersion: '9.3', State: 'Success' },
+      { IsCurrent: true, ProjectId: 'P2', EnvironmentId: 'E1', ReleaseVersion: '1.0', State: 'Success' }
+    ]
+  };
+  test('every track uses the fixed column width, never a stretching fraction', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
+    expect(html).toContain('var(--ip-rel-col)');
+    expect(html).not.toContain('minmax(0,1fr)');
+  });
+  test('a group with fewer environments still starts at the same left edge', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
+    expect(html).toContain('repeat(2,var(--ip-rel-col))'); // Cloud
+    expect(html).toContain('repeat(1,var(--ip-rel-col))'); // Tools
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1697,9 +1697,17 @@ describe('Projects — tenant spread in the expanded row', () => {
 
   test('expanding names each release and how many tenants are on it', () => {
     const html = render();
-    expect(html).toContain('Production — 2 releases across 10 tenants');
-    expect(html).toContain('6 tenants');
-    expect(html).toContain('4 tenants');
+    expect(html).toContain('2 releases · 10 tenants');
+    expect(html).toContain('>6<');
+    expect(html).toContain('>4<');
+  });
+
+  test('the split is laid out in the environment columns, not stacked', () => {
+    const html = render();
+    const block = /<div class="ip-rel-tsblock">([\s\S]*?)<\/div><\/div>/.exec(html);
+    expect(block).not.toBeNull();
+    // It uses the same column template as the row above it.
+    expect(block[0]).toContain('var(--ip-rel-cols)');
   });
 
   test('a project with no split shows no tenant block', () => {
@@ -1711,6 +1719,6 @@ describe('Projects — tenant spread in the expanded row', () => {
       projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: [] } } },
       releases: { status: 'ready', model: data.releasesModel(single) }
     });
-    expect(html).not.toContain('ip-rel-tenants-block');
+    expect(html).not.toContain('ip-rel-tsblock');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1804,3 +1804,123 @@ describe('Projects — muting an environment', () => {
     expect(html).toContain('only reached environments you have muted');
   });
 });
+
+describe('Feature flags — model', () => {
+  const data = require('./data');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E2', name: 'Test' }, { id: 'E3', name: 'Prod' }];
+  const payload = { total: 5, truncated: false, items: [
+    { Id: 'F1', Name: 'on-everywhere', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
+      { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 100 }] },
+    { Id: 'F2', Name: 'partial', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
+      { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 10 }] },
+    { Id: 'F3', Name: 'mixed', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
+      { DeploymentEnvironmentId: 'E3', IsEnabled: false }] },
+    { Id: 'F4', Name: 'no-overrides', Environments: [] },
+    { Id: 'F5', Name: 'off-everywhere', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: false }] }
+  ] };
+
+  test('only flags mid-journey get a row', () => {
+    const m = data.featureFlagModel(payload, grid);
+    expect(m.flags.map(f => f.name)).toEqual(['mixed', 'partial']);
+  });
+
+  test('the settled majority is counted, not drawn', () => {
+    const m = data.featureFlagModel(payload, grid);
+    expect(m.settled).toEqual({ onEverywhere: 1, offEverywhere: 1, noOverrides: 1 });
+    expect(m.total).toBe(5);
+  });
+
+  test('a percentage between 0 and 100 is a partial rollout, 100 is not', () => {
+    expect(data.flagEnvState({ IsEnabled: true, RolloutPercentage: 10 }).key).toBe('partial');
+    expect(data.flagEnvState({ IsEnabled: true, RolloutPercentage: 100 }).key).toBe('on');
+    expect(data.flagEnvState({ IsEnabled: false }).key).toBe('off');
+    expect(data.flagEnvState(undefined).key).toBe('inherit');
+  });
+
+  test('an environment with no override inherits rather than reading as off', () => {
+    const m = data.featureFlagModel(payload, grid);
+    const partial = m.flags.find(f => f.name === 'partial');
+    expect(partial.cells.map(c => c.state)).toEqual(['on', 'inherit', 'partial']);
+  });
+
+  test('cells follow the grid columns so a flag row lines up with the releases', () => {
+    const m = data.featureFlagModel(payload, grid);
+    expect(m.flags[0].cells.map(c => c.envName)).toEqual(['Dev', 'Test', 'Prod']);
+  });
+
+  test('an empty payload yields nothing and does not throw', () => {
+    expect(data.featureFlagModel(undefined, grid).flags).toEqual([]);
+  });
+});
+
+describe('Feature flags — view', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E3', name: 'Prod' }];
+  const model = {
+    environments: grid,
+    groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+      projects: [{ id: 'P1', name: 'Portal',
+        cells: grid.map(e => ({ envId: e.id, envName: e.name, entries: [], versionCount: 0, tenantTotal: 0 })),
+        links: [null, 'none'] }] }],
+    projects: [{ id: 'P1' }], truncated: {}
+  };
+  const flagPayload = { total: 3, truncated: false, items: [
+    { Id: 'F2', Name: 'new-checkout', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 },
+      { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 10 }] },
+    { Id: 'F1', Name: 'settled', Environments: [
+      { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 }] },
+    { Id: 'F3', Name: 'also-settled', Environments: [] }
+  ] };
+  const render = (flags, envOff) => Views.renderProjects({
+    projectOpen: { P1: true },
+    projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: grid } } },
+    projectFlags: { P1: flags },
+    envOff: envOff,
+    releases: { status: 'ready', model }
+  });
+
+  test('an in-flight flag draws a row with its percentage', () => {
+    const html = render({ status: 'ready', model: data.featureFlagModel(flagPayload, grid) });
+    expect(html).toContain('Feature flags in flight');
+    expect(html).toContain('new-checkout');
+    expect(html).toContain('10%');
+    expect(html).toContain('1 of 3');
+  });
+
+  test('the settled majority is reported as a count', () => {
+    const html = render({ status: 'ready', model: data.featureFlagModel(flagPayload, grid) });
+    expect(html).toContain('Not shown:');
+    expect(html).toContain('1 on everywhere');
+    expect(html).toContain('1 on their default');
+  });
+
+  test('flags do not borrow the deployment palette', () => {
+    const html = render({ status: 'ready', model: data.featureFlagModel(flagPayload, grid) });
+    const band = /<div class="ip-rel-band">[\s\S]*$/.exec(html)[0];
+    expect(band).toContain('ip-rel-fnode');
+    expect(band).not.toContain('ip-rel-node-healthy');
+  });
+
+  test('a project with no flags at all renders no band', () => {
+    const html = render({ status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false } });
+    expect(html).not.toContain('ip-rel-band');
+  });
+
+  test('muting an environment hides that column for flags too', () => {
+    const html = render({ status: 'ready', model: data.featureFlagModel(flagPayload, grid) }, { G1: { E3: true } });
+    const band = /<div class="ip-rel-band">[\s\S]*$/.exec(html)[0];
+    expect(band).toContain('ip-rel-hcell is-off');
+  });
+
+  test('a flag read failure does not take the release history with it', () => {
+    const html = render({ status: 'error', error: 'Feature flags could not be read for this project.' });
+    expect(html).toContain('Feature flags could not be read');
+    expect(html).toContain('ip-rel-history');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1924,3 +1924,120 @@ describe('Feature flags — view', () => {
     expect(html).toContain('ip-rel-history');
   });
 });
+
+describe('Flag changes — reconstructed from the audit trail', () => {
+  const data = require('./data');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E3', name: 'Prod' }];
+  const events = { Items: [
+    { Id: 'Ev1', Occurred: '2026-08-14T03:00:00Z', ChangeDetails: {
+      DocumentContext: { Name: 'new-checkout', Environments: [{ DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 0 }] },
+      Differences: [{ op: 'replace', path: '/Environments/0', value: { DeploymentEnvironmentId: 'E3', IsEnabled: true, RolloutPercentage: 10 } }] } },
+    { Id: 'Ev2', Occurred: '2026-08-14T01:00:00Z', ChangeDetails: {
+      DocumentContext: { Name: 'new-checkout', Environments: [] },
+      Differences: [{ op: 'add', path: '/Environments/0', value: { DeploymentEnvironmentId: 'E1', IsEnabled: true, RolloutPercentage: 100 } }] } },
+    { Id: 'Ev3', Occurred: '2026-08-13T01:00:00Z', ChangeDetails: {
+      DocumentContext: { Name: 'legacy', DefaultIsEnabled: false },
+      Differences: [{ op: 'replace', path: '/DefaultIsEnabled', value: true }] } },
+    // An override for an environment this project's grid does not show.
+    { Id: 'Ev4', Occurred: '2026-08-14T02:00:00Z', ChangeDetails: {
+      DocumentContext: { Name: 'elsewhere', Environments: [] },
+      Differences: [{ op: 'add', path: '/Environments/0', value: { DeploymentEnvironmentId: 'E9', IsEnabled: true } }] } }
+  ] };
+
+  test('both ends of the arrow come out of context plus patch', () => {
+    const c = data.flagChangeModel(events, grid, null, Date.now());
+    const first = c.find(x => x.id.indexOf('Ev1') === 0);
+    expect(data.flagChangeLabel(first)).toBe('0% → 10%');
+  });
+
+  test('an added override reads as "no override", not as off', () => {
+    const c = data.flagChangeModel(events, grid, null, Date.now());
+    const added = c.find(x => x.id.indexOf('Ev2') === 0);
+    expect(added.before).toBeNull();
+    expect(data.flagChangeLabel(added)).toBe('no override → On');
+  });
+
+  test('a default-level change is kept and marked as such', () => {
+    const c = data.flagChangeModel(events, grid, null, Date.now());
+    const def = c.find(x => x.scope === 'default');
+    expect(def.flagName).toBe('legacy');
+    expect(data.flagChangeLabel(def)).toBe('Off → On');
+  });
+
+  test('a change in an environment the grid does not show is dropped', () => {
+    const c = data.flagChangeModel(events, grid, null, Date.now());
+    expect(c.some(x => x.flagName === 'elsewhere')).toBe(false);
+  });
+
+  test('changes come back newest first', () => {
+    const c = data.flagChangeModel(events, grid, null, Date.now());
+    const times = c.map(x => x.occurred);
+    expect(times).toEqual([...times].sort((a, b) => b - a));
+  });
+
+  test('the window filters changes', () => {
+    const now = Date.parse('2026-08-14T04:00:00Z');
+    expect(data.flagChangeModel(events, grid, 2, now)).toHaveLength(1);   // only Ev1
+    expect(data.flagChangeModel(events, grid, null, now).length).toBe(3); // Ev4 excluded by grid
+  });
+
+  test('an empty payload yields nothing and does not throw', () => {
+    expect(data.flagChangeModel(undefined, grid, null, Date.now())).toEqual([]);
+    expect(data.flagChangeModel({ Items: [] }, grid, null, Date.now())).toEqual([]);
+  });
+});
+
+describe('Projects — grouping by time or type', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E3', name: 'Prod' }];
+  const model = {
+    environments: grid,
+    groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+      projects: [{ id: 'P1', name: 'Portal',
+        cells: grid.map(e => ({ envId: e.id, envName: e.name, entries: [], versionCount: 0, tenantTotal: 0 })),
+        links: [null, 'none'] }] }],
+    projects: [{ id: 'P1' }], truncated: {}
+  };
+  const history = { status: 'ready', model: {
+    environments: grid, channels: ['Main'], totalReleases: 1, hiddenByWindow: 0, neverDeployedCount: 0,
+    releases: [{ version: '9.3', channelName: 'Main', assembled: '2026-08-14T02:00:00Z', lag: 0,
+      everDeployed: true, frontier: 1,
+      cells: [{ envId: 'E1', envName: 'Dev', deployed: true, stateKey: 'success', stateLabel: 'Succeeded', when: '2026-08-14T02:00:00Z', tenantCount: 0, count: 1 },
+              { envId: 'E3', envName: 'Prod', deployed: true, stateKey: 'success', stateLabel: 'Succeeded', when: '2026-08-14T02:30:00Z', tenantCount: 0, count: 1 }] }] } };
+  const flags = { status: 'ready',
+    model: { flags: [], total: 2, settled: { onEverywhere: 2 }, truncated: false },
+    changes: [{ id: 'c1', flagName: 'new-checkout', scope: 'environment', envId: 'E3', envName: 'Prod',
+      occurred: Date.parse('2026-08-14T02:45:00Z'), before: { key: 'partial', percent: 0 }, after: { key: 'partial', percent: 10 } }] };
+  const render = grouping => Views.renderProjects({
+    projectOpen: { P1: true }, projectHistory: { P1: history }, projectFlags: { P1: flags },
+    grouping: grouping, releases: { status: 'ready', model }
+  });
+
+  test('the control offers Time and Type, defaulting to Time', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model } });
+    expect(html).toContain('data-grouping="Time"');
+    expect(html).toContain('data-grouping="Type"');
+    expect(html).toContain('class="ip-seg active" data-grouping="Time"');
+  });
+
+  test('grouped by time, a flag change sits among the releases', () => {
+    const html = render('Time');
+    const body = /ip-rel-history-body[\s\S]*$/.exec(html)[0];
+    // The change is more recent than the release, so it comes first.
+    expect(body.indexOf('new-checkout')).toBeLessThan(body.indexOf('9.3'));
+    expect(html).not.toContain('Flag changes');
+  });
+
+  test('grouped by type, changes get their own band instead', () => {
+    const html = render('Type');
+    expect(html).toContain('Flag changes');
+    const body = /ip-rel-history-body[\s\S]*$/.exec(html)[0];
+    expect(body.indexOf('9.3')).toBeLessThan(body.indexOf('new-checkout'));
+  });
+
+  test('current flag state survives both groupings', () => {
+    expect(render('Time')).toContain('Not shown:');
+    expect(render('Type')).toContain('Not shown:');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2729,3 +2729,35 @@ describe('Tenant detail — view', () => {
     expect(render()).toContain('href="#tenants"');
   });
 });
+
+describe('A tenant page is still the tenants view', () => {
+  const data = require('./data');
+  const fs = require('fs');
+  const path = require('path');
+
+  test('a detail route is matched by its base, not the whole hash', () => {
+    expect(data.viewNeedsEstate('tenants/Tenants-1')).toBe(false);
+    expect(data.viewNeedsEstate('tenants')).toBe(false);
+    expect(data.viewNeedsEstate('projects')).toBe(false);
+  });
+
+  test('an infrastructure detail route still needs the estate', () => {
+    // Target detail reads IP.estate.targets, so it must stay gated.
+    expect(data.viewNeedsEstate('targets/Machines-1')).toBe(true);
+    expect(data.viewNeedsEstate('overview')).toBe(true);
+  });
+
+  test('the tenant route is checked before the view falls back to overview', () => {
+    const router = fs.readFileSync(path.join(__dirname, 'router.js'), 'utf8');
+    const detail = router.indexOf("hash.indexOf('tenants/') === 0");
+    const fallback = router.indexOf("const view = VIEWS.includes(hash)");
+    expect(detail).toBeGreaterThan(-1);
+    expect(detail).toBeLessThan(fallback);
+  });
+
+  test('cold start cannot intercept a tenant page', () => {
+    const router = fs.readFileSync(path.join(__dirname, 'router.js'), 'utf8');
+    // Cold start is gated on needsEstate, which a tenant route now fails.
+    expect(router).toContain('needsEstate && typeof Data !== \'undefined\' && Data.coldStartApplies');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3000,11 +3000,14 @@ describe('Feature flag posture on the tenant overview', () => {
         Environments: [{ Id: 'E1', Name: 'Staging' }, { Id: 'E2', Name: 'Production' }], Items: [] } });
     const html = Views.renderTenantDetail({ spaceId: 'S',
       flags: { status: 'ready', model: model }, tenantDetail: { status: 'ready', model: detail } });
-    expect(html).toContain('fully on');
-    expect(html).toContain('fully off');
-    expect(html).toContain('in between');
+    expect(html).toContain('ip-tn-statlabel">on<');
+    expect(html).toContain('ip-tn-statlabel">off<');
+    expect(html).toContain('ip-tn-statlabel">rolling out<');
     expect(html).toContain('half-rolled');
     expect(html).toContain('25%');
+    // It sits beside the matrix rather than under it.
+    expect(html).toContain('ip-tn-matrixrow');
+    expect(html).toContain('ip-tn-flagpanel');
   });
 
   test('a tenant whose flags are all settled says so rather than showing an empty list', () => {
@@ -3023,6 +3026,6 @@ describe('Feature flag posture on the tenant overview', () => {
       dashboard: { Projects: [], Environments: [], Items: [] } });
     const html = Views.renderTenantDetail({ spaceId: 'S', flags: { status: 'loading' },
       tenantDetail: { status: 'ready', model: detail } });
-    expect(html).not.toContain('fully on');
+    expect(html).not.toContain('ip-tn-statlabel');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2566,3 +2566,166 @@ describe('Tenants — sortable column headers', () => {
     data.TENANT_SORTS.forEach(s => expect(html).toContain(s));
   });
 });
+
+describe('Tenant detail — model', () => {
+  const data = require('./data');
+  const NOW = Date.parse('2026-08-17T12:00:00Z');
+  const ago = d => new Date(NOW - d * 86400000).toISOString();
+  const tenant = { Id: 'T1', Name: 'Mercy Polyclinic', TenantTags: ['Hosted/Reef', 'Ring/Stable'],
+    Description: 'A hospital group', ProjectEnvironments: { P1: ['E1', 'E2'], P2: ['E2'] } };
+  const dashboard = {
+    Projects: [{ Id: 'P1', Name: 'Patient Records' }, { Id: 'P2', Name: 'Billing' }],
+    Environments: [{ Id: 'E1', Name: 'Staging' }, { Id: 'E2', Name: 'Production' }, { Id: 'E3', Name: 'Unused' }],
+    Items: [
+      { IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E2', ReleaseVersion: '5.9.0',
+        State: 'Failed', CompletedTime: ago(2), TaskId: 'ServerTasks-1' },
+      { IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '5.10.0',
+        State: 'Success', CompletedTime: ago(8), TaskId: 'ServerTasks-2' },
+      { IsCurrent: true, TenantId: 'OTHER', ProjectId: 'P1', EnvironmentId: 'E2', ReleaseVersion: '9.9', State: 'Success' }
+    ]
+  };
+  const build = extra => data.tenantDetailModel(Object.assign({ tenant, dashboard, now: NOW }, extra || {}));
+
+  test('the four facts are reported separately', () => {
+    const m = build();
+    expect(m.connection).toEqual({ connected: true, pairCount: 3, projectCount: 2 });
+    expect(m.lastOutcome.key).toBe('failed');
+    expect(m.readiness).toBeNull();          // not fetched in this call
+    expect(m.infrastructure).toBeNull();
+  });
+
+  test('columns are only the environments this tenant is connected to', () => {
+    expect(build().environments.map(e => e.name)).toEqual(['Staging', 'Production']);
+  });
+
+  test('another tenant\'s deployments are not counted', () => {
+    const m = build();
+    const prod = m.matrix.find(r => r.projectName === 'Patient Records').cells.find(c => c.envName === 'Production');
+    expect(prod.version).toBe('5.9.0');
+  });
+
+  test('not connected and never deployed are different cells', () => {
+    const m = build();
+    const billing = m.matrix.find(r => r.projectName === 'Billing');
+    const staging = billing.cells.find(c => c.envName === 'Staging');
+    const prod = billing.cells.find(c => c.envName === 'Production');
+    expect(staging.connected).toBe(false);   // structural: the pair does not exist
+    expect(prod.connected).toBe(true);
+    expect(prod.deployed).toBe(false);       // it does exist, nothing has gone to it
+  });
+
+  test('activity is newest first and only this tenant', () => {
+    const a = build().activity;
+    expect(a).toHaveLength(2);
+    expect(a[0].version).toBe('5.9.0');
+  });
+});
+
+describe('Tenant detail — readiness', () => {
+  const data = require('./data');
+  const envName = { E1: 'Staging', E2: 'Production' };
+  const vars = { ProjectVariables: { P1: { ProjectId: 'P1', ProjectName: 'Patient Records',
+    Templates: [{ Id: 'tpl-1', Name: 'ApiKey', Label: 'API key' }, { Id: 'tpl-2', Name: 'Region', DefaultValue: 'eu' }],
+    Variables: { E1: { 'tpl-1': 'abc' }, E2: {} } } } };
+
+  test('a template with no value and no default is missing', () => {
+    const r = data.tenantReadiness(vars, { P1: ['E1', 'E2'] }, envName);
+    expect(r.ready).toBe(false);
+    expect(r.count).toBe(1);
+    expect(r.missing[0]).toMatchObject({ name: 'API key', environment: 'Production' });
+  });
+
+  test('a default value satisfies a template', () => {
+    const r = data.tenantReadiness(vars, { P1: ['E1', 'E2'] }, envName);
+    expect(r.missing.some(x => x.name === 'Region')).toBe(false);
+  });
+
+  test('only connected environments can be missing anything', () => {
+    const r = data.tenantReadiness(vars, { P1: ['E1'] }, envName);
+    expect(r.ready).toBe(true);
+  });
+
+  test('an empty value counts as missing, not as supplied', () => {
+    const blank = { ProjectVariables: { P1: { ProjectId: 'P1', Templates: [{ Id: 't', Name: 'X' }],
+      Variables: { E1: { t: '' } } } } };
+    expect(data.tenantReadiness(blank, { P1: ['E1'] }, envName).count).toBe(1);
+  });
+});
+
+describe('Tenant detail — target matching', () => {
+  const data = require('./data');
+  const tenant = { Id: 'T1', TenantTags: ['Hosted/Reef'] };
+  const machines = { items: [
+    { Id: 'M1', Name: 'dedicated-01', TenantIds: ['T1'], TenantTags: [], HealthStatus: 'Healthy' },
+    { Id: 'M2', Name: 'shared-01', TenantIds: [], TenantTags: ['Hosted/Reef'], HealthStatus: 'Unhealthy' },
+    { Id: 'M3', Name: 'unrelated', TenantIds: ['T9'], TenantTags: ['Hosted/Other'], HealthStatus: 'Healthy' }
+  ] };
+
+  test('dedicated names the tenant, shared matches a tag', () => {
+    const r = data.matchTenantTargets(machines, tenant);
+    expect(r.dedicated.map(t => t.name)).toEqual(['dedicated-01']);
+    expect(r.shared.map(t => t.name)).toEqual(['shared-01']);
+    expect(r.shared[0].via).toBe('Hosted/Reef');
+  });
+
+  test('health rolls up as a count without hiding the unhealthy one', () => {
+    const r = data.matchTenantTargets(machines, tenant);
+    expect(r.total).toBe(2);
+    expect(r.healthy).toBe(1);
+  });
+
+  test('a tenant nothing matches is flagged, because its deployments resolve to nothing', () => {
+    expect(data.matchTenantTargets(machines, { Id: 'T404', TenantTags: [] }).orphaned).toBe(true);
+  });
+});
+
+describe('Tenant detail — view', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const NOW = Date.parse('2026-08-17T12:00:00Z');
+  const base = {
+    tenant: { Id: 'T1', Name: 'Mercy Polyclinic', TenantTags: ['Hosted/Reef'], ProjectEnvironments: { P1: ['E1'] } },
+    dashboard: { Projects: [{ Id: 'P1', Name: 'Patient Records' }], Environments: [{ Id: 'E1', Name: 'Production' }],
+      Items: [{ IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '5.9.0',
+        State: 'Success', CompletedTime: new Date(NOW - 86400000).toISOString() }] },
+    now: NOW
+  };
+  const render = extra => Views.renderTenantDetail({ spaceId: 'Spaces-1', serverUrl: 'https://x.octopus.app/',
+    tenantDetail: { status: 'ready', model: data.tenantDetailModel(Object.assign({}, base, extra || {})) } });
+
+  test('the four facts are three separate cards, never one badge', () => {
+    const html = render();
+    expect(html).toContain('Connection');
+    expect(html).toContain('Readiness');
+    expect(html).toContain('Last outcome');
+  });
+
+  test('unreadable machines degrade to a sentence, not a broken page', () => {
+    const html = render({ machinesError: 'Deployment targets cannot be read in this space.' });
+    expect(html).toContain('Deployment targets cannot be read');
+    expect(html).toContain('Deployment matrix');
+  });
+
+  test('unreadable variables leave readiness unknown rather than claiming ready', () => {
+    const html = render({ variablesError: 'Tenant variables could not be read.' });
+    expect(html).toContain('Unknown');
+    expect(html).not.toContain('>Ready<');
+  });
+
+  test('a tenant with no matching target says its deployments resolve to nothing', () => {
+    const html = render({ machines: { items: [] } });
+    expect(html).toContain('resolve to nothing');
+  });
+
+  test('the matrix legend explains the two kinds of absence', () => {
+    expect(render()).toContain('is structural');
+  });
+
+  test('what is not built yet is named rather than silently missing', () => {
+    expect(render()).toContain('need a request per connected project');
+  });
+
+  test('it links back to the list', () => {
+    expect(render()).toContain('href="#tenants"');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3203,3 +3203,34 @@ describe('The project divider is the height of its text', () => {
     expect(css).toContain('.ip-rel-history-gutter::after { display: none; }');
   });
 });
+
+describe('The divider follows the card open and shut', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
+  const rule = re => (re.exec(css) || [''])[0];
+
+  test('shut, it is a short segment beside the project name', () => {
+    const base = rule(/\.ip-rel-proj::after \{[\s\S]*?\}/);
+    expect(base).toContain('height: 16px');
+    expect(css).toContain('.ip-rel-history-gutter::after { display: none; }');
+  });
+
+  test('open, it runs to the bottom of the row', () => {
+    const open = rule(/\.ip-rel-card\.is-open \.ip-rel-proj::after \{[\s\S]*?\}/);
+    expect(open).toContain('bottom: 0');
+    expect(open).toContain('height: auto');
+  });
+
+  test('open, it continues through the history gutter as one line', () => {
+    const gut = rule(/\.ip-rel-card\.is-open \.ip-rel-history-gutter::after \{[\s\S]*?\}/);
+    expect(gut).toContain('display: block');
+    expect(gut).toContain('top: 0');
+    expect(gut).toContain('bottom: 0');
+  });
+
+  test('the open rules come after the shut ones so they win', () => {
+    expect(css.indexOf('.ip-rel-card.is-open .ip-rel-proj::after'))
+      .toBeGreaterThan(css.indexOf('.ip-rel-history-gutter::after { display: none; }'));
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2082,3 +2082,192 @@ describe('Flag rows are visually separated', () => {
     expect(html).toContain('ip-rel-flagname');
   });
 });
+
+describe('Variable changes — model', () => {
+  const data = require('./data');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E3', name: 'Prod' }];
+  const PLACEHOLDER = 'x'.repeat(45);
+  const events = { Items: [
+    { Id: 'V1', Occurred: '2026-08-14T03:00:00Z', ChangeDetails: {
+      DocumentContext: { Variables: [{ Name: 'ApiTimeout', Value: '30s', Scope: { Environment: ['E3'] } }] },
+      Differences: [{ op: 'replace', path: '/Variables/0/Value', value: '60s' }] } },
+    { Id: 'V2', Occurred: '2026-08-14T02:00:00Z', ChangeDetails: {
+      DocumentContext: { Variables: [{ Name: 'DbPassword', Type: 'Sensitive', Value: PLACEHOLDER, Scope: { Environment: ['E1', 'E3'] } }] },
+      Differences: [{ op: 'replace', path: '/Variables/0/Value', value: 'y'.repeat(45) }] } },
+    { Id: 'V3', Occurred: '2026-08-14T01:00:00Z', ChangeDetails: {
+      DocumentContext: { Variables: [{ Name: 'Global', Value: 'a' }] },
+      Differences: [{ op: 'replace', path: '/Variables/0/Value', value: 'b' }] } },
+    { Id: 'V4', Occurred: '2026-08-14T00:30:00Z', ChangeDetails: {
+      DocumentContext: { Variables: [{ Name: 'Elsewhere', Value: 'a', Scope: { Environment: ['E9'] } }] },
+      Differences: [{ op: 'replace', path: '/Variables/0/Value', value: 'b' }] } },
+    // Renames and description edits are not value changes and are ignored.
+    { Id: 'V5', Occurred: '2026-08-14T00:15:00Z', ChangeDetails: {
+      DocumentContext: { Variables: [{ Name: 'Renamed', Value: 'a' }] },
+      Differences: [{ op: 'replace', path: '/Variables/0/Name', value: 'NewName' }] } }
+  ] };
+  const model = () => data.variableChangeModel(events, grid, null, Date.now());
+
+  test('both ends of the arrow come from context plus patch', () => {
+    const c = model().find(x => x.name === 'ApiTimeout');
+    expect(data.variableChangeLabel(c)).toBe('30s → 60s');
+  });
+
+  test('a sensitive value never reaches the model, placeholder or not', () => {
+    const c = model().find(x => x.name === 'DbPassword');
+    expect(c.sensitive).toBe(true);
+    expect(c.before).toBeNull();
+    expect(c.after).toBeNull();
+    expect(data.variableChangeLabel(c)).toBe('secret changed');
+    expect(JSON.stringify(c)).not.toContain(PLACEHOLDER);
+  });
+
+  test('one edit scoped to two environments is one change marking both', () => {
+    const c = model().find(x => x.name === 'DbPassword');
+    expect(c.envIds).toEqual(['E1', 'E3']);
+  });
+
+  test('a variable with no environment scope applies everywhere', () => {
+    const c = model().find(x => x.name === 'Global');
+    expect(c.envIds).toEqual([]);
+    expect(c.scopedElsewhere).toBe(false);
+  });
+
+  test('scoped to an environment this grid does not show is flagged, not silently dropped', () => {
+    const c = model().find(x => x.name === 'Elsewhere');
+    expect(c.envIds).toEqual([]);
+    expect(c.scopedElsewhere).toBe(true);
+  });
+
+  test('a rename is not a value change', () => {
+    expect(model().some(x => x.name === 'Renamed')).toBe(false);
+  });
+
+  test('long values are truncated for display', () => {
+    const long = { Items: [{ Id: 'L', Occurred: '2026-08-14T03:00:00Z', ChangeDetails: {
+      DocumentContext: { Variables: [{ Name: 'Long', Value: 'a'.repeat(200) }] },
+      Differences: [{ op: 'replace', path: '/Variables/0/Value', value: 'b'.repeat(200) }] } }] };
+    const c = data.variableChangeModel(long, grid, null, Date.now())[0];
+    expect(c.before.length).toBeLessThanOrEqual(40);
+    expect(c.after.length).toBeLessThanOrEqual(40);
+  });
+
+  test('the window filters changes', () => {
+    const now = Date.parse('2026-08-14T04:00:00Z');
+    // 90 minutes excludes the 02:00 edit; a 2-hour window would include it,
+    // since a change exactly on the boundary is inside the window.
+    expect(data.variableChangeModel(events, grid, 1.5, now)).toHaveLength(1);
+    expect(data.variableChangeModel(events, grid, 2, now)).toHaveLength(2);
+  });
+
+  test('an empty payload yields nothing and does not throw', () => {
+    expect(data.variableChangeModel(undefined, grid, null, Date.now())).toEqual([]);
+  });
+});
+
+describe('Variable changes — view', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E3', name: 'Prod' }];
+  const model = {
+    environments: grid,
+    groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+      projects: [{ id: 'P1', name: 'Portal',
+        cells: grid.map(e => ({ envId: e.id, envName: e.name, entries: [], versionCount: 0, tenantTotal: 0 })),
+        links: [null, 'none'] }] }],
+    projects: [{ id: 'P1' }], truncated: {}
+  };
+  const vars = [
+    { id: 'v1', name: 'ApiTimeout', kind: 'value', sensitive: false, before: '30s', after: '60s',
+      envIds: ['E3'], scopedElsewhere: false, occurred: Date.now() - 3600000 },
+    { id: 'v2', name: 'DbPassword', kind: 'value', sensitive: true, before: null, after: null,
+      envIds: ['E1', 'E3'], scopedElsewhere: false, occurred: Date.now() - 7200000 },
+    { id: 'v3', name: 'Global', kind: 'value', sensitive: false, before: 'a', after: 'b',
+      envIds: [], scopedElsewhere: false, occurred: Date.now() - 10800000 },
+    { id: 'v4', name: 'Elsewhere', kind: 'value', sensitive: false, before: 'a', after: 'b',
+      envIds: [], scopedElsewhere: true, occurred: Date.now() - 14400000 }
+  ];
+  const render = grouping => Views.renderProjects({
+    projectOpen: { P1: true },
+    projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 1, channels: [], environments: grid,
+      hiddenByWindow: 0, neverDeployedCount: 0 } } },
+    projectFlags: { P1: { status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false },
+      changes: [], variables: vars } },
+    grouping: grouping, releases: { status: 'ready', model }
+  });
+
+  test('grouped by type, variables get their own band', () => {
+    const html = render('Type');
+    expect(html).toContain('Variable changes');
+    expect(html).toContain('ApiTimeout');
+    expect(html).toContain('30s → 60s');
+  });
+
+  test('a secret says it changed and never shows a value', () => {
+    const html = render('Type');
+    expect(html).toContain('secret changed');
+    expect(html).toContain('DbPassword');
+  });
+
+  test('an unscoped variable is labelled as applying everywhere', () => {
+    expect(render('Type')).toContain('all environments');
+  });
+
+  test('the snapshot caveat is stated, since a change alters nothing deployed', () => {
+    expect(render('Type')).toContain('snapshotted into a release');
+  });
+
+  test('a change scoped outside the grid is counted, not drawn', () => {
+    const html = render('Type');
+    expect(html).toContain('1 change is scoped to environments this project does not deploy to');
+    expect(html).not.toContain('Elsewhere');
+  });
+
+  test('grouped by time, variables interleave with everything else', () => {
+    const html = render('Time');
+    expect(html).toContain('ip-rel-vrow');
+    expect(html).not.toContain('Variable changes');
+  });
+
+  test('variable rows are amber, distinct from flags and releases', () => {
+    const html = render('Type');
+    expect(html).toContain('ip-rel-vnode');
+    expect(html).not.toContain('ip-rel-fnode');
+  });
+});
+
+describe('An empty release window still shows what changed', () => {
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Dev' }];
+  const model = {
+    environments: grid,
+    groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+      projects: [{ id: 'P1', name: 'Portal',
+        cells: [{ envId: 'E1', envName: 'Dev', entries: [], versionCount: 0, tenantTotal: 0 }], links: [null] }] }],
+    projects: [{ id: 'P1' }], truncated: {}
+  };
+  // Nothing released in the window, but a flag flipped and a variable changed.
+  const html = Views.renderProjects({
+    projectOpen: { P1: true },
+    projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 4, channels: [],
+      environments: grid, hiddenByWindow: 4, neverDeployedCount: 0 } } },
+    projectFlags: { P1: { status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false },
+      changes: [{ id: 'c1', flagName: 'new-checkout', scope: 'environment', envId: 'E1', envName: 'Dev',
+        occurred: Date.now(), before: { key: 'off', percent: null }, after: { key: 'on', percent: 100 } }],
+      variables: [{ id: 'v1', name: 'ApiTimeout', kind: 'value', sensitive: false, before: '30s', after: '60s',
+        envIds: ['E1'], scopedElsewhere: false, occurred: Date.now() }] } },
+    grouping: 'Type', releases: { status: 'ready', model }
+  });
+
+  test('the empty release state is stated', () => {
+    expect(html).toContain('Nothing moved in the last');
+  });
+
+  test('but the flag change still shows', () => {
+    expect(html).toContain('new-checkout');
+  });
+
+  test('and so does the variable change', () => {
+    expect(html).toContain('ApiTimeout');
+    expect(html).toContain('30s → 60s');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1612,15 +1612,15 @@ describe('Projects — column geometry', () => {
   };
   test('columns are a share of the page, never a stretching fraction per group', () => {
     const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
-    expect(html).toContain('calc(100% / var(--ip-rel-cols))');
+    expect(html).toContain('var(--ip-rel-cols)');
     expect(html).not.toContain('minmax(0,1fr)');
   });
   test('the widest group sets the column count for the whole page', () => {
     const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
     // Cloud has two environments, Tools one — both size against 2.
     expect(html).toContain('--ip-rel-cols:2');
-    expect(html).toContain('repeat(2,calc(100% / var(--ip-rel-cols)))');
-    expect(html).toContain('repeat(1,calc(100% / var(--ip-rel-cols)))');
+    expect(html).toContain('repeat(2,calc((100% - var(--ip-rel-endgutter)) / var(--ip-rel-cols)))');
+    expect(html).toContain('repeat(1,calc((100% - var(--ip-rel-endgutter)) / var(--ip-rel-cols)))');
   });
 });
 
@@ -1661,5 +1661,56 @@ describe('Project history — the age on the line', () => {
       Channel: { Id: 'C1', Name: 'Main' }, Deployments: {} }] };
     const m = data.progressionModel(prog, grid, 24, NOW);
     expect(m.releases[0].everDeployed).toBe(false);
+  });
+});
+
+describe('Projects — tenant spread in the expanded row', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  // One environment holding several releases across many tenants: the case the
+  // collapsed cell can only summarise.
+  const payload = {
+    Environments: [{ Id: 'E1', Name: 'Production' }],
+    ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }],
+    Projects: [{ Id: 'P1', Name: 'Octopus Server', ProjectGroupId: 'G1' }],
+    Tenants: Array.from({ length: 10 }, (_, i) => ({ Id: 'T' + i, Name: 'Tenant ' + i })),
+    Items: Array.from({ length: 10 }, (_, i) => ({
+      IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1',
+      // Six tenants on 2.0, four on 1.0.
+      ReleaseVersion: i < 6 ? '2.0' : '1.0', State: 'Success',
+      TenantId: 'T' + i, CompletedTime: '2026-08-14T0' + (i % 5) + ':00:00Z'
+    }))
+  };
+  const model = data.releasesModel(payload);
+  const render = () => Views.renderProjects({
+    projectOpen: { P1: true },
+    projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: [] } } },
+    releases: { status: 'ready', model }
+  });
+
+  test('the model keeps every version and its tenant count', () => {
+    const cell = model.groups[0].projects[0].cells[0];
+    expect(cell.versionCount).toBe(2);
+    expect(cell.tenantTotal).toBe(10);
+    expect(cell.entries.map(e => e.tenantCount).sort()).toEqual([4, 6]);
+  });
+
+  test('expanding names each release and how many tenants are on it', () => {
+    const html = render();
+    expect(html).toContain('Production — 2 releases across 10 tenants');
+    expect(html).toContain('6 tenants');
+    expect(html).toContain('4 tenants');
+  });
+
+  test('a project with no split shows no tenant block', () => {
+    const single = Object.assign({}, payload, {
+      Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '2.0', State: 'Success', TenantId: 'T0' }]
+    });
+    const html = Views.renderProjects({
+      projectOpen: { P1: true },
+      projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: [] } } },
+      releases: { status: 'ready', model: data.releasesModel(single) }
+    });
+    expect(html).not.toContain('ip-rel-tenants-block');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3369,3 +3369,91 @@ describe('Tenant description: one line, and never trusted', () => {
     expect(desc('plain text')).not.toContain('ip-sub');
   });
 });
+
+describe('Project map', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const payload = {
+    project: { Id: 'P1', Name: 'Azure Front Door', ProjectGroupId: 'G1', LifecycleId: 'L1',
+      IsVersionControlled: true, TenantedDeploymentMode: 'Untenanted', AutoCreateRelease: false,
+      PersistenceSettings: { Url: 'https://github.com/acme/repo.git', DefaultBranch: 'main', BasePath: '.octopus' } },
+    branch: 'main',
+    process: { Steps: [
+      { Name: 'Apply Terraform', Properties: { 'Octopus.Action.TargetRoles': 'web,api' },
+        Actions: [{ ActionType: 'Octopus.TerraformApply', Packages: [{ PackageId: 'infra', FeedId: 'Feeds-201' }] }] },
+      { Name: 'Notify', Actions: [{ ActionType: 'Octopus.Script', IsDisabled: true }] } ] },
+    channels: { Items: [{ Name: 'Full', IsDefault: true, LifecycleId: 'L1', Rules: [{}] }] },
+    triggers: { Items: [{ Name: 'Nightly', Filter: { FilterType: 'OnceDailySchedule' } }] },
+    lifecycle: { Name: 'Std', Phases: [
+      { Name: 'Dev', OptionalDeploymentTargets: ['E1'], AutomaticDeploymentTargets: [] },
+      { Name: 'Prod', OptionalDeploymentTargets: [], AutomaticDeploymentTargets: ['E2'] } ] },
+    feeds: { Items: [{ Id: 'Feeds-201', Name: 'Docker Hub', FeedType: 'Docker' }] },
+    environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Production' }],
+    tenants: { TotalResults: 0 }
+  };
+  const model = data.projectMapModel(payload);
+  const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+
+  test('inputs name the feed behind each package, not the feed id', () => {
+    expect(model.inputs).toEqual([{ feed: 'Docker Hub', feedType: 'Docker', packages: ['infra'] }]);
+  });
+
+  test('a version-controlled project shows its repository and branch', () => {
+    expect(model.git).toMatchObject({ url: 'https://github.com/acme/repo.git', branch: 'main' });
+    expect(html).toContain('github.com/acme/repo.git');
+  });
+
+  test('action types read as steps rather than as machinery', () => {
+    expect(data.actionTypeLabel('Octopus.TerraformApply')).toBe('Terraform Apply');
+    expect(data.actionTypeLabel('')).toBe('Step');
+  });
+
+  test('a disabled step is kept and marked, not dropped', () => {
+    expect(model.process[1]).toMatchObject({ name: 'Notify', disabled: true });
+    expect(html).toContain('disabled');
+  });
+
+  test('target roles are surfaced, since they decide where a step lands', () => {
+    expect(model.roles).toEqual(['web', 'api']);
+  });
+
+  test('lifecycle phases come out in order with their environments', () => {
+    expect(model.phases.map(p => p.name)).toEqual(['Dev', 'Prod']);
+    expect(model.phases[1].automatic).toEqual(['Production']);
+  });
+
+  test('triggers are named by kind', () => {
+    expect(model.triggers[0]).toMatchObject({ name: 'Nightly', kind: 'Schedule' });
+  });
+
+  test('it says that CI-driven deployments are invisible here', () => {
+    expect(html).toContain('do not appear here');
+  });
+
+  test('an unreadable process does not cost the rest of the map', () => {
+    const broken = data.projectMapModel(Object.assign({}, payload, { process: null, processError: new Error('x') }));
+    const out = Views.renderProjectMap({ projectMap: { status: 'ready', model: broken } });
+    expect(out).toContain('deployment process could not be read');
+    expect(out).toContain('Destinations');
+    expect(out).toContain('Channels');
+  });
+
+  test('a tenanted project reports how many tenants are connected', () => {
+    const tenanted = data.projectMapModel(Object.assign({}, payload, {
+      project: Object.assign({}, payload.project, { TenantedDeploymentMode: 'Tenanted' }),
+      tenants: { TotalResults: 48 } }));
+    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: tenanted } }))
+      .toContain('48 tenants are');
+  });
+
+  test('the project card links to the map without swallowing the expand', () => {
+    const rel = data.releasesModel({
+      Environments: [{ Id: 'E1', Name: 'Dev' }], ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }],
+      Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' }],
+      Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '1', State: 'Success' }] });
+    const list = Views.renderProjects({ releases: { status: 'ready', model: rel } });
+    expect(list).toContain('href="#projects/P1"');
+    expect(list).toContain('data-projectlink');
+    expect(list).toContain('data-project="P1"');   // the row is still the toggle
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1344,12 +1344,13 @@ describe('Releases — model', () => {
     expect(m.projects[0].links).toEqual([null, 'pale', 'strong']);
   });
 
-  test('an environment nothing has reached is dropped from the grid, and named', () => {
+  test('an environment nothing has reached is dropped from the group, and named', () => {
     const m = data.releasesModel(withItems([
       { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' }
     ]));
-    expect(m.environments.map(e => e.name)).toEqual(['Dev']);
-    expect(m.hiddenEnvironments.map(e => e.name)).toEqual(['Test', 'Prod']);
+    const g = m.groups[0];
+    expect(g.environments.map(e => e.name)).toEqual(['Dev']);
+    expect(g.hiddenEnvironments.map(e => e.name)).toEqual(['Test', 'Prod']);
   });
 
   test('a gap for one project still shows while another project uses that environment', () => {
@@ -1373,7 +1374,7 @@ describe('Releases — model', () => {
       { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' }
     ]));
     const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
-    expect(html).toContain('nothing has been deployed to them');
+    expect(html).toContain('this group has never deployed to them');
     expect(html).toContain('Test, Prod');
   });
 
@@ -1430,5 +1431,116 @@ describe('Releases — many releases live in one environment', () => {
     const one = Object.assign({}, many, { Items: many.Items.slice(0, 1) });
     const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(one) } });
     expect(html).not.toContain('ip-rel-more');
+  });
+});
+
+describe('Releases — project groups', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const payload = {
+    Environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Preprod' }, { Id: 'E3', Name: 'Prod' }],
+    ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }, { Id: 'G2', Name: 'Tools' }],
+    Projects: [
+      { Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' },
+      { Id: 'P2', Name: 'Hub', ProjectGroupId: 'G1' },
+      { Id: 'P3', Name: 'Script', ProjectGroupId: 'G2' }
+    ],
+    Items: [
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' },
+      { IsCurrent: true, ProjectId: 'P2', EnvironmentId: 'E3', ReleaseVersion: '4.1', State: 'Success' },
+      { IsCurrent: true, ProjectId: 'P3', EnvironmentId: 'E1', ReleaseVersion: '1.0', State: 'Success' }
+    ]
+  };
+
+  test('projects are grouped, groups and members ordered by name', () => {
+    const m = data.releasesModel(payload);
+    expect(m.groups.map(g => g.name)).toEqual(['Cloud', 'Tools']);
+    expect(m.groups[0].projects.map(p => p.name)).toEqual(['Hub', 'Portal']);
+  });
+
+  test('each group hides the environments it has never deployed to', () => {
+    const m = data.releasesModel(payload);
+    expect(m.groups[0].environments.map(e => e.name)).toEqual(['Dev', 'Prod']);
+    expect(m.groups[0].hiddenEnvironments.map(e => e.name)).toEqual(['Preprod']);
+    // Tools only ever touched Dev, so it carries one column, not Cloud's two.
+    expect(m.groups[1].environments.map(e => e.name)).toEqual(['Dev']);
+  });
+
+  test('a project keeps a gap for an environment its group uses but it does not', () => {
+    const m = data.releasesModel(payload);
+    const hub = m.groups[0].projects.find(p => p.name === 'Hub');
+    expect(hub.cells.map(c => c.envName)).toEqual(['Dev', 'Prod']);
+    expect(hub.cells[0].entries).toEqual([]);
+  });
+
+  test('a project with no group falls under Ungrouped rather than vanishing', () => {
+    const orphan = Object.assign({}, payload, {
+      Projects: [{ Id: 'P9', Name: 'Loose' }],
+      Items: [{ IsCurrent: true, ProjectId: 'P9', EnvironmentId: 'E1', ReleaseVersion: '1.0', State: 'Success' }]
+    });
+    const m = data.releasesModel(orphan);
+    expect(m.groups.map(g => g.name)).toEqual(['Ungrouped']);
+    expect(m.projects.map(p => p.name)).toEqual(['Loose']);
+  });
+
+  test('the view renders a grid per group and names each hidden environment', () => {
+    const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
+    expect((html.match(/ip-rel-grid/g) || []).length).toBe(2);
+    expect(html).toContain('Cloud');
+    expect(html).toContain('this group has never deployed to them: Preprod');
+  });
+});
+
+describe('Project history — progression model', () => {
+  const data = require('./data');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E2', name: 'Prod' }];
+  const prog = {
+    Releases: [
+      { Release: { Id: 'R4', Version: '2.4', ChannelId: 'C1', Assembled: '2026-08-14T00:00:00Z' },
+        Channel: { Id: 'C1', Name: 'Main' }, Deployments: {} },
+      { Release: { Id: 'R3', Version: '9.9-pre', ChannelId: 'C2', Assembled: '2026-08-13T00:00:00Z' },
+        Channel: { Id: 'C2', Name: 'Pre-Release' }, Deployments: {
+          E1: [{ State: 'Success', CompletedTime: '2026-08-13T01:00:00Z' }] } },
+      { Release: { Id: 'R2', Version: '2.3', ChannelId: 'C1', Assembled: '2026-08-12T00:00:00Z' },
+        Channel: { Id: 'C1', Name: 'Main' }, Deployments: {
+          E1: [{ State: 'Success', CompletedTime: '2026-08-12T01:00:00Z' }],
+          E2: [{ State: 'Failed', CompletedTime: '2026-08-12T02:00:00Z' }] } }
+    ]
+  };
+
+  test('lag counts within a channel, not across the whole list', () => {
+    const m = data.progressionModel(prog, grid);
+    const byVer = Object.fromEntries(m.releases.map(r => [r.version, r]));
+    expect(byVer['2.4'].lag).toBe(0);          // newest in Main
+    expect(byVer['9.9-pre'].lag).toBe(0);      // newest in Pre-Release, not "1 behind"
+    expect(byVer['2.3'].lag).toBe(1);          // one Main release ahead of it
+  });
+
+  test('cells follow the grid columns so an expanded row lines up', () => {
+    const m = data.progressionModel(prog, grid);
+    expect(m.releases[0].cells.map(c => c.envName)).toEqual(['Dev', 'Prod']);
+  });
+
+  test('a release created and never deployed is kept and marked', () => {
+    const m = data.progressionModel(prog, grid);
+    const never = m.releases.find(r => r.version === '2.4');
+    expect(never.everDeployed).toBe(false);
+    expect(never.frontier).toBe(-1);
+    expect(m.neverDeployedCount).toBe(1);
+  });
+
+  test('the furthest environment reached becomes the frontier', () => {
+    const m = data.progressionModel(prog, grid);
+    const full = m.releases.find(r => r.version === '2.3');
+    expect(full.frontier).toBe(1);
+    expect(full.cells[1].stateKey).toBe('failed');
+  });
+
+  test('channels present are listed', () => {
+    expect(data.progressionModel(prog, grid).channels.sort()).toEqual(['Main', 'Pre-Release']);
+  });
+
+  test('an empty payload yields no releases and does not throw', () => {
+    expect(data.progressionModel({}, grid).releases).toEqual([]);
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1694,10 +1694,17 @@ describe('Projects — tenant split lives in the environment cell', () => {
     expect(cell.entries.map(e => e.tenantCount).sort((a, b) => a - b)).toEqual([3, 6, 11]);
   });
 
-  test('the contracted row carries a share bar per release', () => {
+  test('the contracted row carries each release share as its own fill', () => {
     const html = render(false);
-    expect(html).toContain('ip-rel-tsbar');
-    expect(html).toContain('width:55.0%');   // 11 of 20
+    expect(html).toContain('ip-rel-entry-share');
+    expect(html).toContain('--ip-rel-share:55.0%');   // 11 of 20
+  });
+
+  test('a share row is one line: version, then the tenant count', () => {
+    const html = render(false);
+    // No separate bar element, so the share costs no extra height.
+    expect(html).not.toContain('ip-rel-tsbar');
+    expect(html).not.toContain('ip-rel-entry-head');
   });
 
   test('there is no separate tenant panel above the history', () => {
@@ -1716,8 +1723,8 @@ describe('Projects — tenant split lives in the environment cell', () => {
     const open = Views.renderProjects({ projectOpen: { P1: true },
       projectHistory: { P1: { status: 'ready', model: { releases: [], totalReleases: 0, channels: [], environments: [] } } },
       releases: { status: 'ready', model: m2 } });
-    expect((shut.match(/ip-rel-entry"/g) || []).length).toBe(3);
-    expect((open.match(/ip-rel-entry"/g) || []).length).toBe(20);
+    expect((shut.match(/ip-rel-entry-share/g) || []).length).toBe(3);
+    expect((open.match(/ip-rel-entry-share/g) || []).length).toBe(20);
     expect(shut).toContain('+17 more releases on 17 tenants');
   });
 
@@ -1726,6 +1733,6 @@ describe('Projects — tenant split lives in the environment cell', () => {
       Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success', TenantId: 'T0' }]
     });
     const html = Views.renderProjects({ projectOpen: {}, releases: { status: 'ready', model: data.releasesModel(single) } });
-    expect(html).not.toContain('ip-rel-tsbar');
+    expect(html).not.toContain('ip-rel-entry-share');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3029,3 +3029,56 @@ describe('Feature flag posture on the tenant overview', () => {
     expect(html).not.toContain('ip-tn-statlabel');
   });
 });
+
+describe('A space where targets are forbidden is not a space that failed', () => {
+  const d = require('./data');
+  const page = items => ({ status: 200, ok: true, json: async () => items });
+  const deny = { status: 403, ok: false, statusText: 'Forbidden' };
+
+  test('403 on machines keeps the space, and records what could not be read', async () => {
+    global.fetch = async (url) => String(url).includes('/machines/all') ? deny : page([{ Id: 'X' }]);
+    const hydrated = await d.hydrateSpace({ Id: 'Spaces-842', Name: 'Build Platform' });
+    expect(hydrated).not.toBeNull();
+    expect(hydrated.failed).toContain('machines');
+    // The resources that did come back are still there.
+    expect(hydrated.envs).toHaveLength(1);
+    expect(hydrated.workerpools).toHaveLength(1);
+  });
+
+  test('500 on machines still yields null — a broken read is a broken space', async () => {
+    global.fetch = async (url) => String(url).includes('/machines/all')
+      ? { status: 500, ok: false, statusText: 'Server Error' } : page([]);
+    expect(await d.hydrateSpace({ Id: 'Spaces-1', Name: 'One' })).toBe(null);
+  });
+
+  test('everything forbidden is still a space you cannot read', async () => {
+    global.fetch = async () => deny;
+    expect(await d.hydrateSpace({ Id: 'Spaces-1', Name: 'One' })).toBe(null);
+  });
+
+  test('the estate records the gap so views can avoid claiming zero', async () => {
+    global.fetch = async (url) => String(url).includes('/machines/all') ? deny : page([]);
+    const hydrated = await d.hydrateSpace({ Id: 'Spaces-842', Name: 'Build Platform' });
+    const estate = d.buildEstate([hydrated]);
+    expect(estate.failed.machines).toBe(true);
+    expect(estate.targets).toEqual([]);
+  });
+
+  test('cold start does not offer to add infrastructure you simply cannot see', async () => {
+    global.fetch = async (url) => String(url).includes('/machines/all') ? deny : page([]);
+    const blind = d.buildEstate([await d.hydrateSpace({ Id: 'Spaces-842', Name: 'Build Platform' })]);
+    expect(d.coldStartApplies('overview', blind)).toBe(false);
+    // A genuinely empty estate still gets the walkthrough.
+    global.fetch = async () => page([]);
+    const empty = d.buildEstate([await d.hydrateSpace({ Id: 'Spaces-622', Name: 'Octopus Server' })]);
+    expect(d.coldStartApplies('overview', empty)).toBe(true);
+  });
+
+  test('the targets view says unreadable rather than showing none', () => {
+    const Views = require('./views');
+    const html = Views.renderTargets({ estate: { failed: { machines: true }, targets: [], workers: [],
+      environments: [], policies: [] } });
+    expect(html).toContain('your account can\'t read them here');
+    expect(html).not.toContain('No deployment targets');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3392,7 +3392,7 @@ describe('Project map', () => {
     tenants: { TotalResults: 0 }
   };
   const model = data.projectMapModel(payload);
-  const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+  const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model } });
 
   test('inputs name the feed behind each package, not the feed id', () => {
     expect(model.inputs).toEqual([{ feed: 'Docker Hub', feedType: 'Docker', packages: ['infra'] }]);
@@ -3432,7 +3432,7 @@ describe('Project map', () => {
 
   test('an unreadable process does not cost the rest of the map', () => {
     const broken = data.projectMapModel(Object.assign({}, payload, { process: null, processError: new Error('x') }));
-    const out = Views.renderProjectMap({ projectMap: { status: 'ready', model: broken } });
+    const out = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: broken } });
     expect(out).toContain('deployment process could not be read');
     expect(out).toContain('Destinations');
     expect(out).toContain('Channels');
@@ -3442,7 +3442,7 @@ describe('Project map', () => {
     const tenanted = data.projectMapModel(Object.assign({}, payload, {
       project: Object.assign({}, payload.project, { TenantedDeploymentMode: 'Tenanted' }),
       tenants: { TotalResults: 48 } }));
-    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: tenanted } }))
+    expect(Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: tenanted } }))
       .toContain('48 tenants connected');
   });
 
@@ -3461,7 +3461,7 @@ describe('Project map', () => {
 describe('The project map columns hold what belongs together', () => {
   const data = require('./data');
   const Views = require('./views');
-  const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: data.projectMapModel({
+  const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: data.projectMapModel({
     project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
     process: { Steps: [{ Name: 'Deploy', Actions: [{ ActionType: 'Octopus.Script' }] }] },
     channels: { Items: [] }, triggers: { Items: [{ Name: 'Nightly', Filter: { FilterType: 'OnceDailySchedule' } }] },
@@ -3530,7 +3530,7 @@ describe('Project map — lifecycles', () => {
     process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
     environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Production' }], tenants: { TotalResults: 0 }
   });
-  const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+  const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model } });
 
   test('every lifecycle the project ships through is modelled, not just the default', () => {
     expect(model.lifecycles.map(l => l.name)).toEqual(['Standard', 'Hotfix path']);
@@ -3584,7 +3584,7 @@ describe('Project map — lifecycles', () => {
       lifecycles: [{ Id: 'L1', Name: 'Standard', Phases: [] }],
       process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
       environments: [], tenants: { TotalResults: 0 } });
-    const orphanHtml = Views.renderProjectMap({ projectMap: { status: 'ready', model: orphan } });
+    const orphanHtml = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: orphan } });
     // No phases at all, so there are no columns and nothing to tabulate.
     expect(orphanHtml).toContain('no lifecycle phases');
   });
@@ -3628,7 +3628,7 @@ describe('Lifecycle columns are ordered and shared', () => {
   });
 
   test('an automatic phase is marked, an optional one is not', () => {
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model } });
     // Only Standard's Prod phase is automatic, across all three lifecycles.
     expect((html.match(/ip-pm-node is-auto/g) || []).length).toBe(1);
   });
@@ -3644,7 +3644,7 @@ describe('Lifecycle columns are ordered and shared', () => {
   });
 
   test('a blank cell is explained rather than left ambiguous', () => {
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model } });
     expect(html).toContain('never reaches that environment');
   });
 });
@@ -3703,26 +3703,26 @@ describe('Destinations: selection, targets and their shape', () => {
   test('a project with no roles says so rather than reporting zero targets', () => {
     const m = build('');
     expect(m.targets.selectsByRole).toBe(false);
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: m } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: m } });
     expect(html).toContain('run on the server or on workers');
     expect(html).not.toContain('Deployments would have nowhere to run');
   });
 
   test('roles that match nothing is a warning, and a different one', () => {
     const m = build('ghost');
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: m } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: m } });
     expect(html).toContain('Deployments would have nowhere to run');
   });
 
   test('unreadable machines leave the selection visible', () => {
     const m = build('web', { machines: null, machinesError: new Error('403') });
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: m } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: m } });
     expect(html).toContain('Deployment targets cannot be read');
     expect(html).toContain('Selected by');       // how it chooses is still known
   });
 
   test('the selection mechanism is stated whatever the targets say', () => {
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: build('web,db') } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: build('web,db') } });
     expect(html).toContain('Selected by');
     expect(html).toContain('Within');
     expect(html).toContain('12 tenants connected');
@@ -3764,7 +3764,7 @@ describe('Project feature flags across the lifecycle environments', () => {
         Environments: [{ DeploymentEnvironmentId: 'E1', IsEnabled: true }] }
     ]);
     expect(m.between.map(f => f.name)).toEqual(['drifting']);
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: Object.assign(
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: Object.assign(
       data.projectMapModel({ project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
         process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
         lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
@@ -3784,7 +3784,7 @@ describe('Project feature flags across the lifecycle environments', () => {
       process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
       lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
       tenants: { TotalResults: 0 } });
-    const render = flags => Views.renderProjectMap({ projectMap: { status: 'ready',
+    const render = flags => Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready',
       model: Object.assign({}, base, { flags: flags }) } });
     expect(render(data.projectFlagModel({ items: [], total: 0 }, envs, names)))
       .toContain('no feature flags');
@@ -3798,7 +3798,7 @@ describe('Project feature flags across the lifecycle environments', () => {
       process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
       lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
       tenants: { TotalResults: 0 }, flagsError: err });
-    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: m } }))
+    expect(Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: m } }))
       .toContain('Feature flags are not available on this instance');
     // Anything else is a read failure, not an absent capability.
     const other = new Error('500 Server Error'); other.code = '500 Server Error';
@@ -3806,7 +3806,7 @@ describe('Project feature flags across the lifecycle environments', () => {
       process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
       lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
       tenants: { TotalResults: 0 }, flagsError: other });
-    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: m2 } }))
+    expect(Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: m2 } }))
       .toContain('could not be read for this project');
   });
 });
@@ -3824,7 +3824,7 @@ describe('The lifecycle panel opens on the default only', () => {
   }, extra));
 
   test('one lifecycle needs no disclosure at all', () => {
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: build({
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: build({
       channels: { Items: [] }, lifecycle: lc('L1', 'Std', ['E1', 'E2']), lifecycles: [lc('L1', 'Std', ['E1', 'E2'])]
     }) } });
     expect(html).toContain('Std');
@@ -3837,7 +3837,7 @@ describe('The lifecycle panel opens on the default only', () => {
       lifecycle: lc('L1', 'Std', ['E1', 'E2']),
       lifecycles: [lc('L1', 'Std', ['E1', 'E2']), lc('L2', 'Hotfix', ['E2'])]
     });
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: model } });
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: model } });
     const details = html.slice(html.indexOf('<details class="ip-pm-lcmore">'));
     expect(html).toContain('<details class="ip-pm-lcmore">');
     expect(html).toContain('1 other lifecycle</summary>');
@@ -3849,7 +3849,7 @@ describe('The lifecycle panel opens on the default only', () => {
   });
 
   test('the plural is right for more than one', () => {
-    const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: build({
+    const html = Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready', model: build({
       channels: { Items: [] }, lifecycle: lc('L1', 'Std', ['E1']),
       lifecycles: [lc('L1', 'Std', ['E1']), lc('L2', 'A', ['E1']), lc('L3', 'B', ['E2'])]
     }) } });
@@ -3867,7 +3867,7 @@ describe('Flags name their environments once, not once per flag', () => {
       process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
       lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [],
       tenants: { TotalResults: 0 } });
-    return Views.renderProjectMap({ projectMap: { status: 'ready',
+    return Views.renderProjectMap({ projectTab: 'Overview', projectMap: { status: 'ready',
       model: Object.assign({}, base, { flags: fm }) } });
   };
   const twoFlags = [
@@ -3929,5 +3929,115 @@ describe('Render blocks are defined once, in the view that uses them', () => {
     expect(body('renderProjectMap')).toContain('const flagPanel = (function');
     expect(body('renderTenantDetail')).not.toContain('const flagPanel = (function');
     expect((src.match(/const lcRow = lc =>/g) || []).length).toBe(1);
+  });
+});
+
+describe('A project page opens on Status and keeps Overview a click away', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const dash = {
+    Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'PG1' },
+               { Id: 'P2', Name: 'Other', ProjectGroupId: 'PG1' }],
+    ProjectGroups: [{ Id: 'PG1', Name: 'Web' }],
+    Environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Prod' }],
+    Tenants: [],
+    Items: [
+      { ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '2.0', State: 'Success', IsCurrent: true, CompletedTime: '2026-08-13T09:00:00Z' },
+      { ProjectId: 'P1', EnvironmentId: 'E2', ReleaseVersion: '1.9', State: 'Success', IsCurrent: true, CompletedTime: '2026-08-12T09:00:00Z' },
+      { ProjectId: 'P2', EnvironmentId: 'E1', ReleaseVersion: '5.0', State: 'Success', IsCurrent: true, CompletedTime: '2026-08-13T09:00:00Z' }
+    ]
+  };
+  const mapModel = data.projectMapModel({
+    project: { Id: 'P1', Name: 'Portal', LifecycleId: 'L1' },
+    process: { Steps: [] }, channels: { Items: [] }, triggers: { Items: [] },
+    lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] },
+    environments: [], tenants: { TotalResults: 0 }
+  });
+  const IP = extra => Object.assign({
+    projectMap: { status: 'ready', projectId: 'P1', model: mapModel },
+    releases: { status: 'ready', spaceId: 'S1', model: data.releasesModel(dash) },
+    projectOpen: { P1: true }
+  }, extra || {});
+
+  test('both tabs are offered, and Status is where it lands', () => {
+    const html = Views.renderProjectMap(IP());
+    expect(html).toContain('data-projecttab="Status"');
+    expect(html).toContain('data-projecttab="Overview"');
+    expect(html).toContain('ip-tab-active" data-projecttab="Status"');
+  });
+
+  test('Status draws this project only, not the whole dashboard', () => {
+    const html = Views.renderProjectMap(IP());
+    expect(html).toContain('data-project="P1"');
+    expect(html).toContain('Portal');
+    expect(html).not.toContain('data-project="P2"');
+    expect(html).not.toContain('>Other<');
+  });
+
+  test('Status carries the same environment columns and controls as the list', () => {
+    const html = Views.renderProjectMap(IP());
+    expect(html).toContain('data-envtoggle="PG1|E1"');
+    expect(html).toContain('data-envtoggle="PG1|E2"');
+    expect(html).toContain('data-window=');
+    expect(html).toContain('data-grouping=');
+    // Same column count the group would give it, so the row lines up.
+    expect(html).toContain('--ip-rel-cols:2');
+  });
+
+  test('the row opens expanded, because the page is about this project', () => {
+    expect(Views.renderProjectMap(IP())).toContain('ip-rel-card is-open');
+    expect(Views.renderProjectMap(IP({ projectOpen: {} }))).not.toContain('ip-rel-card is-open');
+  });
+
+  test('Overview is the map, and carries none of the Status furniture', () => {
+    const html = Views.renderProjectMap(IP({ projectTab: 'Overview' }));
+    expect(html).toContain('>Destinations');
+    expect(html).toContain('>Lifecycles');
+    expect(html).not.toContain('data-envtoggle=');
+    expect(html).toContain('ip-tab-active" data-projecttab="Overview"');
+  });
+
+  test('a project the dashboard never returned says which of the two reasons', () => {
+    const empty = data.releasesModel({ Projects: [], ProjectGroups: [], Environments: [], Tenants: [], Items: [] });
+    expect(Views.renderProjectMap(IP({ releases: { status: 'ready', model: empty } })))
+      .toContain('no releases on the dashboard yet');
+    const capped = data.releasesModel(Object.assign({}, dash,
+      { Projects: [], Items: [], IsFiltered: false, ProjectLimit: 20 }));
+    const html = Views.renderProjectMap(IP({ releases: { status: 'ready', model: capped } }));
+    if (capped.truncated.capped) expect(html).toContain('beyond the 20');
+  });
+
+  test('a dashboard that has not landed yet does not look like an empty project', () => {
+    const html = Views.renderProjectMap(IP({ releases: { status: 'loading' } }));
+    expect(html).toContain('Loading the project dashboard');
+    expect(html).not.toContain('no releases on the dashboard yet');
+  });
+
+  test('a dashboard that failed says so on Status and leaves Overview intact', () => {
+    const failed = { releases: { status: 'error', error: 'The dashboard request failed.' } };
+    expect(Views.renderProjectMap(IP(failed))).toContain('The dashboard request failed.');
+    expect(Views.renderProjectMap(IP(Object.assign({ projectTab: 'Overview' }, failed))))
+      .toContain('>Destinations');
+  });
+});
+
+describe('The list and the project page draw the row from one source', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const src = fs.readFileSync(path.join(__dirname, 'views.js'), 'utf8');
+  const count = str => src.split(str).length - 1;
+
+  test('the controls, legend and environment heads are built in one place each', () => {
+    ['_relControls', '_relLegend', '_relEnvHeads'].forEach(fn => {
+      expect(count('function ' + fn + '(')).toBe(1);
+      // One definition plus at least two call sites: the list and the project page.
+      expect(count(fn + '(')).toBeGreaterThan(2);
+    });
+  });
+
+  test('row interactions are bound once and shared', () => {
+    expect(count('function _bindRelRows(')).toBe(1);
+    // The definition plus both binders.
+    expect(count('_bindRelRows(IP, root')).toBe(3);
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2501,3 +2501,68 @@ describe('Tenants — view', () => {
     expect(empty).toContain('No tenants in this space');
   });
 });
+
+describe('Tenants — sortable column headers', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const NOW = Date.parse('2026-08-17T12:00:00Z');
+  const model = data.tenantsModel({
+    now: NOW,
+    tenants: { total: 3, truncated: false, items: [
+      { Id: 'T1', Name: 'Alpha', TenantTags: [], ProjectEnvironments: { P1: ['E1'] } },
+      { Id: 'T2', Name: 'Bravo', TenantTags: [], ProjectEnvironments: { P1: ['E1'], P2: ['E1'], P3: ['E1'] } },
+      { Id: 'T3', Name: 'Charlie', TenantTags: [], ProjectEnvironments: { P1: ['E1'], P2: ['E1'] } }
+    ] },
+    dashboard: { Projects: [{ Id: 'P1', Name: 'One' }], Environments: [{ Id: 'E1', Name: 'Production' }], Items: [] },
+    tagSets: []
+  });
+  const render = (sort, dir) => Views.renderTenants({
+    tenants: { status: 'ready', model }, tenantSort: sort, tenantDir: dir });
+
+  test('every sortable column offers a control; Tags does not', () => {
+    const html = render();
+    ['Name', 'Projects', 'Environments', 'Last outcome'].forEach(k =>
+      expect(html).toContain('data-sort="' + k + '"'));
+    expect(html).not.toContain('data-sort="Tags"');
+  });
+
+  test('the active column reports its direction to assistive tech', () => {
+    const asc = render('Name', 'asc');
+    expect(asc).toContain('aria-sort="ascending"');
+    expect(render('Name', 'desc')).toContain('aria-sort="descending"');
+    // Only one column is ever the sorted one.
+    expect((asc.match(/aria-sort="(ascending|descending)"/g) || []).length).toBe(1);
+  });
+
+  test('each sort has a natural first direction', () => {
+    expect(data.tenantSortDir('Name')).toBe('asc');
+    expect(data.tenantSortDir('Projects')).toBe('desc');
+    expect(data.tenantSortDir('Last outcome')).toBe('desc');
+  });
+
+  test('sorting by a column orders by that column', () => {
+    expect(data.sortTenants(model.tenants, 'Projects').map(t => t.name)).toEqual(['Bravo', 'Charlie', 'Alpha']);
+    expect(data.sortTenants(model.tenants, 'Name').map(t => t.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  test('reversing a column reverses it', () => {
+    expect(data.sortTenants(model.tenants, 'Projects', 'asc').map(t => t.name)).toEqual(['Alpha', 'Charlie', 'Bravo']);
+  });
+
+  test('ties fall back to name so the order is stable', () => {
+    const tied = data.tenantsModel({
+      now: NOW,
+      tenants: { total: 2, items: [
+        { Id: 'B', Name: 'Beta', TenantTags: [], ProjectEnvironments: { P1: ['E1'] } },
+        { Id: 'A', Name: 'Aardvark', TenantTags: [], ProjectEnvironments: { P1: ['E1'] } }
+      ] },
+      dashboard: { Projects: [], Environments: [], Items: [] }, tagSets: []
+    });
+    expect(data.sortTenants(tied.tenants, 'Projects').map(t => t.name)).toEqual(['Aardvark', 'Beta']);
+  });
+
+  test('the dropdown and the headers offer the same set', () => {
+    const html = render();
+    data.TENANT_SORTS.forEach(s => expect(html).toContain(s));
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3122,3 +3122,48 @@ describe('Projects render as cards, not as a table', () => {
     expect(new Set(tracks).size).toBe(1);
   });
 });
+
+describe('Project cards: background, sticky header, inline toggle', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
+  const rule = re => (re.exec(css) || [''])[0];
+
+  test('the card sets its own surface as well as its background', () => {
+    // Both, or the version labels mask the line in the wrong colour.
+    const card = rule(/\.ip-rel-card \{[\s\S]*?\}/);
+    expect(card).toContain('--ip-rel-surface: var(--ip-rel-cardbg)');
+    expect(card).toContain('background: var(--ip-rel-surface)');
+  });
+
+  test('the card background is defined for both themes', () => {
+    expect(css).toContain('--ip-rel-cardbg: var(--color-grey-100)');
+    expect(css).toContain('--ip-rel-cardbg: var(--color-navy-800)');
+  });
+
+  test('the environment header sticks, with a background to sit on', () => {
+    const head = rule(/\.ip-rel-head \{ position: sticky[\s\S]*?\}/);
+    expect(head).toContain('position: sticky');
+    expect(head).toContain('top: 0');
+    expect(head).toContain('background: var(--background)');
+  });
+
+  test('a card cannot paint over the sticky header', () => {
+    const card = rule(/\.ip-rel-card \{[\s\S]*?\}/);
+    const head = rule(/\.ip-rel-head \{ position: sticky[\s\S]*?\}/);
+    const cardZ = Number(/z-index:\s*(\d+)/.exec(card)[1]);
+    const headZ = Number(/z-index:\s*(\d+)/.exec(head)[1]);
+    expect(/position:\s*relative/.test(card)).toBe(true);   // its own stacking context
+    expect(cardZ).toBeLessThan(headZ);
+  });
+
+  test('the environment name and its toggle share a line', () => {
+    // Two rules carry this selector; the direction is set in the later one, so
+    // check every block rather than whichever happens to come first.
+    const blocks = css.match(/\.ip-rel-envhead \{[\s\S]*?\}/g) || [];
+    expect(blocks.length).toBeGreaterThan(0);
+    const joined = blocks.join('\n');
+    expect(joined).toContain('flex-direction: row');
+    expect(joined).not.toContain('flex-direction: column');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2722,7 +2722,7 @@ describe('Tenant detail — view', () => {
   });
 
   test('what is not built yet is named rather than silently missing', () => {
-    expect(render()).toContain('need a request per connected project');
+    expect(render()).toContain('needs a request per connected project');
   });
 
   test('it links back to the list', () => {
@@ -2875,5 +2875,82 @@ describe('Unset variables live behind a tab, in amber', () => {
   test('the readiness card is amber too, not the failure tone', () => {
     const html = render(build([], [{ Id: 't1', Name: 'ApiKey' }]));
     expect(html).toContain('ip-rel-node-warning');
+  });
+});
+
+describe('Feature flags for one tenant', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const tenant = { Id: 'T1', TenantTags: ['Hosted/Reef'], Name: 'Mercy', ProjectEnvironments: { P1: ['E1'] } };
+  const env = o => Object.assign({ DeploymentEnvironmentId: 'E1', IsEnabled: true }, o);
+
+  test('exclusion beats everything else', () => {
+    expect(data.flagStateForTenant(env({ ExcludedTenantIds: ['T1'], TenantIds: ['T1'] }), tenant).key).toBe('excluded');
+    expect(data.flagStateForTenant(env({ ExcludedTenantTags: ['Hosted/Reef'] }), tenant).key).toBe('excluded');
+  });
+
+  test('named targeting is exact, and beats the percentage beside it', () => {
+    // Named tenants have it even at 0% rollout — that is what naming means.
+    expect(data.flagStateForTenant(env({ TenantIds: ['T1'], RolloutPercentage: 0 }), tenant).key).toBe('on');
+    expect(data.flagStateForTenant(env({ TenantIds: ['T9'] }), tenant).key).toBe('off');
+    expect(data.flagStateForTenant(env({ TenantIds: ['T9'] }), tenant).via).toBe('targeted-elsewhere');
+  });
+
+  test('a matching tag targets the tenant', () => {
+    expect(data.flagStateForTenant(env({ TenantTags: ['Hosted/Reef'] }), tenant).key).toBe('on');
+    expect(data.flagStateForTenant(env({ TenantTags: ['Hosted/Other'] }), tenant).key).toBe('off');
+  });
+
+  test('what cannot be decided from configuration is not guessed', () => {
+    expect(data.flagStateForTenant(env({ Segments: [{ Key: 'plan', Value: 'pro' }] }), tenant).key).toBe('segment');
+    expect(data.flagStateForTenant(env({ RolloutPercentage: 10 }), tenant).key).toBe('partial');
+  });
+
+  test('a disabled flag is off however it is targeted', () => {
+    expect(data.flagStateForTenant(env({ IsEnabled: false, TenantIds: ['T1'] }), tenant).key).toBe('off');
+  });
+
+  test('only flags actually on for the tenant are listed', () => {
+    const payload = { projectsRead: 1, byProject: { P1: { items: [
+      { Id: 'F1', Name: 'on-for-us', Environments: [env({ TenantIds: ['T1'] })] },
+      { Id: 'F2', Name: 'for-others', Environments: [env({ TenantIds: ['T9'] })] },
+      { Id: 'F3', Name: 'rolling', Environments: [env({ RolloutPercentage: 25 })] }
+    ], total: 3 } } };
+    const m = data.tenantFlagModel(payload, tenant, { P1: ['E1'] }, { E1: 'Production' }, { P1: 'Patient Records' });
+    expect(m.flags.map(f => f.name)).toEqual(['on-for-us', 'rolling']);
+    expect(m.total).toBe(3);
+    expect(m.liveCount).toBe(2);
+    expect(m.undecidedCount).toBe(1);
+  });
+
+  test('an unreadable project is counted, not silently dropped', () => {
+    const payload = { projectsRead: 2, byProject: { P1: { items: [], total: 0 }, P2: { error: true } } };
+    const m = data.tenantFlagModel(payload, tenant, { P1: ['E1'] }, {}, {});
+    expect(m.unreadableProjects).toBe(1);
+  });
+
+  test('the tab says when a state cannot be decided', () => {
+    const model = data.tenantDetailModel({
+      tenant: tenant,
+      dashboard: { Projects: [{ Id: 'P1', Name: 'Patient Records' }], Environments: [{ Id: 'E1', Name: 'Production' }], Items: [] }
+    });
+    const flags = { status: 'ready', model: data.tenantFlagModel(
+      { projectsRead: 1, byProject: { P1: { items: [{ Id: 'F3', Name: 'rolling',
+        Environments: [env({ RolloutPercentage: 25 })] }], total: 1 } } },
+      tenant, { P1: ['E1'] }, { E1: 'Production' }, { P1: 'Patient Records' }) };
+    const html = Views.renderTenantDetail({ spaceId: 'S', tenantTab: 'Flags', flags: flags,
+      tenantDetail: { status: 'ready', model } });
+    expect(html).toContain('25% rollout');
+    expect(html).toContain('decided when the flag is evaluated');
+  });
+
+  test('the flags tab only exists once flags have been asked for', () => {
+    const model = data.tenantDetailModel({ tenant: tenant,
+      dashboard: { Projects: [], Environments: [], Items: [] } });
+    const without = Views.renderTenantDetail({ spaceId: 'S', tenantDetail: { status: 'ready', model } });
+    expect(without).not.toContain('data-tenanttab="Flags"');
+    const withFlags = Views.renderTenantDetail({ spaceId: 'S', flags: { status: 'loading' },
+      tenantDetail: { status: 'ready', model } });
+    expect(withFlags).toContain('data-tenanttab="Flags"');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1231,9 +1231,12 @@ describe('sidebar composition', () => {
   const items = [...html.matchAll(/class="ip-nav-item" data-view="([^"]+)">([^<]+)</g)]
     .map(m => ({ view:m[1], label:m[2] }));
 
-  test('Paul\'s five, in his order, with Releases appended', () => {
+  test('Projects leads, then Paul\'s five in his order', () => {
     expect(items.map(i => i.view)).toEqual(
-      ['overview','targets','environments','workers','argocd','releases']);
+      ['projects','overview','targets','environments','workers','argocd']);
+  });
+  test('Projects sits above the Infrastructure heading', () => {
+    expect(html.indexOf('data-view="projects"')).toBeLessThan(html.indexOf('ip-sidebar-title'));
   });
 
   test('Machine Policies and Deployment Agents are no longer nav destinations', () => {
@@ -1318,7 +1321,7 @@ describe('Releases — model', () => {
       { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E3', ReleaseVersion: '9.1', State: 'Success', TenantId: 'T1', CompletedTime: '2026-08-14T02:00:00Z' },
       { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E3', ReleaseVersion: '9.0', State: 'Success', TenantId: 'T2', CompletedTime: '2026-08-12T02:00:00Z' }
     ]));
-    const prod = m.projects[0].cells[2].entries;
+    const prod = m.projects[0].cells.find(c => c.envName === 'Prod').entries;
     expect(prod.map(e => e.version)).toEqual(['9.1', '9.0']);
     expect(prod[0].tenantCount).toBe(1);
     expect(prod[0].tenantNames).toEqual(['Acme']);
@@ -1341,13 +1344,37 @@ describe('Releases — model', () => {
     expect(m.projects[0].links).toEqual([null, 'pale', 'strong']);
   });
 
-  test('an environment with nothing deployed keeps its place in the row', () => {
+  test('an environment nothing has reached is dropped from the grid, and named', () => {
     const m = data.releasesModel(withItems([
       { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' }
     ]));
-    expect(m.projects[0].cells).toHaveLength(3);
+    expect(m.environments.map(e => e.name)).toEqual(['Dev']);
+    expect(m.hiddenEnvironments.map(e => e.name)).toEqual(['Test', 'Prod']);
+  });
+
+  test('a gap for one project still shows while another project uses that environment', () => {
+    const two = Object.assign({}, base, {
+      Projects: [{ Id: 'P1', Name: 'Alpha' }, { Id: 'P2', Name: 'Beta' }],
+      Items: [
+        { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' },
+        { IsCurrent: true, ProjectId: 'P2', EnvironmentId: 'E3', ReleaseVersion: '2.0', State: 'Success' }
+      ]
+    });
+    const m = data.releasesModel(two);
+    // E2 is used by nobody and goes; E1 and E3 stay, so Alpha keeps an empty Prod cell.
+    expect(m.environments.map(e => e.name)).toEqual(['Dev', 'Prod']);
     expect(m.projects[0].cells[1].entries).toEqual([]);
     expect(m.projects[0].links[1]).toBe('none');
+  });
+
+  test('the hidden environments are reported in the view', () => {
+    const Views = require('./views');
+    const m = data.releasesModel(withItems([
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' }
+    ]));
+    const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
+    expect(html).toContain('nothing has been deployed to them');
+    expect(html).toContain('Test, Prod');
   });
 
   test('a capped project list is reported, not silently truncated', () => {
@@ -1393,14 +1420,15 @@ describe('Releases — many releases live in one environment', () => {
     expect(cell.tenantTotal).toBe(41);
   });
   test('the view names a few and summarises the rest', () => {
-    const html = Views.renderReleases({ releases: { status: 'ready', model: data.releasesModel(many) } });
+    const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(many) } });
     expect(html).toContain('more releases across 41 tenants');
+    expect(html).not.toContain('ip-rel-tenants" style');
     // Three named, not forty-one.
     expect((html.match(/ip-rel-ver/g) || []).length).toBe(3);
   });
   test('a single release needs no summary line', () => {
     const one = Object.assign({}, many, { Items: many.Items.slice(0, 1) });
-    const html = Views.renderReleases({ releases: { status: 'ready', model: data.releasesModel(one) } });
+    const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(one) } });
     expect(html).not.toContain('ip-rel-more');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1221,15 +1221,19 @@ describe('overview ring segments unhealthy in red', () => {
   });
 });
 
-describe('sidebar is down to Paul\'s five items', () => {
+// Paul's five-item sidebar (28 Jul walkthrough) gained a sixth on 14 Aug when
+// Releases was added. That reopens a decision Paul made, so the count is
+// asserted explicitly rather than loosely — if someone adds a seventh without
+// a conversation, this fails and the conversation happens.
+describe('sidebar composition', () => {
   const fs = require('fs');
   const html = fs.readFileSync(require('path').join(__dirname, 'index.html'), 'utf8');
   const items = [...html.matchAll(/class="ip-nav-item" data-view="([^"]+)">([^<]+)</g)]
     .map(m => ({ view:m[1], label:m[2] }));
 
-  test('five nav items, in the order Paul proposed', () => {
+  test('Paul\'s five, in his order, with Releases appended', () => {
     expect(items.map(i => i.view)).toEqual(
-      ['overview','targets','environments','workers','argocd']);
+      ['overview','targets','environments','workers','argocd','releases']);
   });
 
   test('Machine Policies and Deployment Agents are no longer nav destinations', () => {
@@ -1247,5 +1251,156 @@ describe('sidebar is down to Paul\'s five items', () => {
     // agent-versions pill still links straight to #agents
     expect(views).toContain("'agents'");
     expect(views).toContain("'machinepolicies'");
+  });
+});
+
+describe('Releases — state mapping', () => {
+  const data = require('./data');
+  test('queued and executing both read as in flight', () => {
+    expect(data.releaseStateKey('Queued')).toBe('running');
+    expect(data.releaseStateKey('Executing')).toBe('running');
+  });
+  test('cancelled and timed out stay distinct from failed', () => {
+    expect(data.releaseStateKey('Failed')).toBe('failed');
+    expect(data.releaseStateKey('TimedOut')).toBe('timedout');
+    expect(data.releaseStateKey('Canceled')).toBe('cancelled');
+  });
+  test('an unrecognised state degrades to unknown rather than success', () => {
+    expect(data.releaseStateKey('Something')).toBe('unknown');
+    expect(data.releaseStateKey(undefined)).toBe('unknown');
+  });
+});
+
+describe('Releases — link tone between environments', () => {
+  const data = require('./data');
+  test('a shared release reads as strong', () => {
+    expect(data.linkTone(['9.1'], ['9.1'])).toBe('strong');
+    expect(data.linkTone(['9.1', '9.0'], ['9.0'])).toBe('strong');
+  });
+  test('different releases read as drifted', () => {
+    expect(data.linkTone(['9.3'], ['9.1'])).toBe('pale');
+  });
+  test('an empty side draws no line at all', () => {
+    expect(data.linkTone([], ['9.1'])).toBe('none');
+    expect(data.linkTone(['9.1'], [])).toBe('none');
+  });
+});
+
+describe('Releases — model', () => {
+  const data = require('./data');
+  const base = {
+    Environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Test' }, { Id: 'E3', Name: 'Prod' }],
+    Projects: [{ Id: 'P1', Name: 'Portal', Slug: 'portal', ProjectGroupId: 'G1' }],
+    ProjectGroups: [{ Id: 'G1', Name: 'Cloud Platform' }],
+    Tenants: [{ Id: 'T1', Name: 'Acme' }, { Id: 'T2', Name: 'Globex' }],
+    ProjectLimit: 200,
+    IsFiltered: false,
+    Items: []
+  };
+  const withItems = items => Object.assign({}, base, { Items: items });
+
+  test('an empty payload yields no projects and does not throw', () => {
+    const m = data.releasesModel({});
+    expect(m.projects).toEqual([]);
+    expect(m.environments).toEqual([]);
+  });
+
+  test('only current deployments are counted', () => {
+    const m = data.releasesModel(withItems([
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' },
+      { IsCurrent: false, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '8.0', State: 'Success' }
+    ]));
+    expect(m.projects[0].cells[0].entries.map(e => e.version)).toEqual(['9.3']);
+  });
+
+  test('a tenant split leaves two releases live in one environment', () => {
+    const m = data.releasesModel(withItems([
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E3', ReleaseVersion: '9.1', State: 'Success', TenantId: 'T1', CompletedTime: '2026-08-14T02:00:00Z' },
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E3', ReleaseVersion: '9.0', State: 'Success', TenantId: 'T2', CompletedTime: '2026-08-12T02:00:00Z' }
+    ]));
+    const prod = m.projects[0].cells[2].entries;
+    expect(prod.map(e => e.version)).toEqual(['9.1', '9.0']);
+    expect(prod[0].tenantCount).toBe(1);
+    expect(prod[0].tenantNames).toEqual(['Acme']);
+  });
+
+  test('the most recent deployment decides the environment state', () => {
+    const m = data.releasesModel(withItems([
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success', CompletedTime: '2026-08-14T01:00:00Z' },
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Executing', CompletedTime: '2026-08-14T03:00:00Z' }
+    ]));
+    expect(m.projects[0].cells[0].entries[0].stateKey).toBe('running');
+  });
+
+  test('links describe drift across the row', () => {
+    const m = data.releasesModel(withItems([
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' },
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E2', ReleaseVersion: '9.1', State: 'Success' },
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E3', ReleaseVersion: '9.1', State: 'Success' }
+    ]));
+    expect(m.projects[0].links).toEqual([null, 'pale', 'strong']);
+  });
+
+  test('an environment with nothing deployed keeps its place in the row', () => {
+    const m = data.releasesModel(withItems([
+      { IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' }
+    ]));
+    expect(m.projects[0].cells).toHaveLength(3);
+    expect(m.projects[0].cells[1].entries).toEqual([]);
+    expect(m.projects[0].links[1]).toBe('none');
+  });
+
+  test('a capped project list is reported, not silently truncated', () => {
+    const capped = Object.assign({}, base, {
+      ProjectLimit: 1,
+      Projects: [{ Id: 'P1', Name: 'Portal' }],
+      Items: []
+    });
+    expect(data.releasesModel(capped).truncated.capped).toBe(true);
+    expect(data.releasesModel(base).truncated.capped).toBe(false);
+  });
+
+  test('a filtered dashboard is reported', () => {
+    const filtered = Object.assign({}, base, { IsFiltered: true });
+    expect(data.releasesModel(filtered).truncated.isFiltered).toBe(true);
+  });
+
+  test('projects are ordered by name', () => {
+    const two = Object.assign({}, base, {
+      Projects: [{ Id: 'P2', Name: 'Zebra' }, { Id: 'P1', Name: 'Alpha' }]
+    });
+    expect(data.releasesModel(two).projects.map(p => p.name)).toEqual(['Alpha', 'Zebra']);
+  });
+});
+
+describe('Releases — many releases live in one environment', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  // Cloud Platform has a cell holding 41 distinct versions across its tenants.
+  const many = {
+    Environments: [{ Id: 'E1', Name: 'Production' }],
+    Projects: [{ Id: 'P1', Name: 'Tenanted' }],
+    Tenants: Array.from({ length: 41 }, (_, i) => ({ Id: 'T' + i, Name: 'Tenant ' + i })),
+    Items: Array.from({ length: 41 }, (_, i) => ({
+      IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1',
+      ReleaseVersion: '1.' + i, State: 'Success', TenantId: 'T' + i,
+      CompletedTime: '2026-08-' + String(10 + (i % 4)).padStart(2, '0') + 'T00:00:00Z'
+    }))
+  };
+  test('the model keeps every version and reports the spread', () => {
+    const cell = data.releasesModel(many).projects[0].cells[0];
+    expect(cell.versionCount).toBe(41);
+    expect(cell.tenantTotal).toBe(41);
+  });
+  test('the view names a few and summarises the rest', () => {
+    const html = Views.renderReleases({ releases: { status: 'ready', model: data.releasesModel(many) } });
+    expect(html).toContain('more releases across 41 tenants');
+    // Three named, not forty-one.
+    expect((html.match(/ip-rel-ver/g) || []).length).toBe(3);
+  });
+  test('a single release needs no summary line', () => {
+    const one = Object.assign({}, many, { Items: many.Items.slice(0, 1) });
+    const html = Views.renderReleases({ releases: { status: 'ready', model: data.releasesModel(one) } });
+    expect(html).not.toContain('ip-rel-more');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -1610,14 +1610,56 @@ describe('Projects — column geometry', () => {
       { IsCurrent: true, ProjectId: 'P2', EnvironmentId: 'E1', ReleaseVersion: '1.0', State: 'Success' }
     ]
   };
-  test('every track uses the fixed column width, never a stretching fraction', () => {
+  test('columns are a share of the page, never a stretching fraction per group', () => {
     const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
-    expect(html).toContain('var(--ip-rel-col)');
+    expect(html).toContain('calc(100% / var(--ip-rel-cols))');
     expect(html).not.toContain('minmax(0,1fr)');
   });
-  test('a group with fewer environments still starts at the same left edge', () => {
+  test('the widest group sets the column count for the whole page', () => {
     const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(payload) } });
-    expect(html).toContain('repeat(2,var(--ip-rel-col))'); // Cloud
-    expect(html).toContain('repeat(1,var(--ip-rel-col))'); // Tools
+    // Cloud has two environments, Tools one — both size against 2.
+    expect(html).toContain('--ip-rel-cols:2');
+    expect(html).toContain('repeat(2,calc(100% / var(--ip-rel-cols)))');
+    expect(html).toContain('repeat(1,calc(100% / var(--ip-rel-cols)))');
+  });
+});
+
+describe('Project history — the age on the line', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const grid = [{ id: 'E1', name: 'Dev' }, { id: 'E2', name: 'Prod' }];
+  // _relWhen reads the real clock, so this fixture is anchored to it rather than
+  // to a fixed instant — otherwise the timestamps land in the future.
+  const NOW = Date.now();
+  const hoursAgo = h => new Date(NOW - h * 3600000).toISOString();
+
+  test('the label shows when the release arrived, not when it was cut', () => {
+    // Assembled a month ago, promoted to Production two hours ago. Inside a
+    // 24-hour window because it moved; the label must say so.
+    const prog = { Releases: [{
+      Release: { Id: 'R1', Version: '1.0', ChannelId: 'C1', Assembled: hoursAgo(720) },
+      Channel: { Id: 'C1', Name: 'Main' },
+      Deployments: { E2: [{ State: 'Success', CompletedTime: hoursAgo(2) }] } }] };
+    const m = data.progressionModel(prog, grid, 24, NOW);
+    expect(m.releases).toHaveLength(1);
+    const html = Views.renderProjects({
+      projectOpen: { P1: true },
+      projectHistory: { P1: { status: 'ready', model: m } },
+      releases: { status: 'ready', model: { environments: grid, groups: [{ id: 'G', name: 'G',
+        environments: grid, hiddenEnvironments: [],
+        projects: [{ id: 'P1', name: 'P', cells: [{ envId:'E1', envName:'Dev', entries: [] },
+          { envId:'E2', envName:'Prod', entries: [] }], links: [null, 'none'] }] }],
+        projects: [{ id: 'P1' }], truncated: {} } }
+    });
+    expect(html).toContain('2h ago');
+    expect(html).not.toContain('30d ago');
+  });
+
+  test('a release that never deployed still says when it was created', () => {
+    const prog = { Releases: [{
+      Release: { Id: 'R1', Version: '1.0', ChannelId: 'C1', Assembled: hoursAgo(3) },
+      Channel: { Id: 'C1', Name: 'Main' }, Deployments: {} }] };
+    const m = data.progressionModel(prog, grid, 24, NOW);
+    expect(m.releases[0].everDeployed).toBe(false);
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -4041,3 +4041,22 @@ describe('The list and the project page draw the row from one source', () => {
     expect(count('_bindRelRows(IP, root')).toBe(3);
   });
 });
+
+describe('Switching space lands on Projects', () => {
+  const Views = require('./views');
+
+  test('a detail page for the old space is not somewhere to stay', () => {
+    ['#tenants/Tenants-1', '#projects/Projects-9', '#targets/Machines-3', '#overview']
+      .forEach(from => {
+        const nav = Views.spaceSwitchNav(from);
+        expect(nav.hash).toBe('#projects');
+        expect(nav.rerender).toBe(false);   // the hash changes, so navigation renders
+      });
+  });
+
+  test('already on Projects, the switch has to redraw itself', () => {
+    // No hashchange fires when the hash does not change.
+    expect(Views.spaceSwitchNav('#projects')).toEqual({ hash: '#projects', rerender: true });
+    expect(Views.spaceSwitchNav('')).toEqual({ hash: '#projects', rerender: true });
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2271,3 +2271,44 @@ describe('An empty release window still shows what changed', () => {
     expect(html).toContain('30s → 60s');
   });
 });
+
+describe('A space we cannot read infrastructure in still has Projects', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const fs = require('fs');
+  const path = require('path');
+
+  test('only Projects is exempt from needing the estate', () => {
+    expect(data.viewNeedsEstate('projects')).toBe(false);
+    ['overview', 'targets', 'environments', 'workers', 'argocd', 'machinepolicies', 'agents']
+      .forEach(v => expect(data.viewNeedsEstate(v)).toBe(true));
+  });
+
+  test('the router gates the error view on that, not on spaceError alone', () => {
+    const router = fs.readFileSync(path.join(__dirname, 'router.js'), 'utf8');
+    expect(router).toContain('IP.spaceError && needsEstate');
+    // The old unconditional guard must be gone.
+    expect(router).not.toContain('if (IP.spaceError) {');
+  });
+
+  test('cold start cannot intercept Projects either', () => {
+    const router = fs.readFileSync(path.join(__dirname, 'router.js'), 'utf8');
+    expect(router).toContain('needsEstate && typeof Data !== \'undefined\' && Data.coldStartApplies');
+  });
+
+  test('the Projects view explains why the other sections are missing', () => {
+    const grid = [{ id: 'E1', name: 'Dev' }];
+    const model = {
+      environments: grid,
+      groups: [{ id: 'G1', name: 'Cloud', environments: grid, hiddenEnvironments: [],
+        projects: [{ id: 'P1', name: 'Portal',
+          cells: [{ envId: 'E1', envName: 'Dev', entries: [], versionCount: 0, tenantTotal: 0 }], links: [null] }] }],
+      projects: [{ id: 'P1' }], truncated: {}
+    };
+    const html = Views.renderProjects({ spaceError: 'Machines could not be read.',
+      releases: { status: 'ready', model } });
+    expect(html).toContain('Infrastructure cannot be read in this space');
+    // And it still renders the grid rather than an error.
+    expect(html).toContain('Portal');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3309,3 +3309,63 @@ describe('One card treatment across the dashboard', () => {
     });
   });
 });
+
+describe('Tenant description: one line, and never trusted', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const model = desc => data.tenantDetailModel({
+    tenant: { Id: 'T1', Name: 'Acme', TenantTags: [], Description: desc, ProjectEnvironments: {} },
+    dashboard: { Projects: [], Environments: [], Items: [] } });
+  const desc = d => {
+    const m = /<p class="ip-tn-desc"[\s\S]*?<\/p>/.exec(
+      Views.renderTenantDetail({ spaceId: 'S', tenantDetail: { status: 'ready', model: model(d) } }));
+    return m ? m[0] : '';
+  };
+  const tags = h => [...new Set([...h.matchAll(/<\/?([a-zA-Z][a-zA-Z0-9]*)/g)].map(m => m[1].toLowerCase()))];
+  const hrefs = h => [...h.matchAll(/href="([^"]*)"/g)].map(m => m[1]);
+
+  test('a markdown link becomes a real link', () => {
+    const out = desc('[License Details](https://octofront.com/cloud-subscriptions/1)');
+    expect(hrefs(out)).toEqual(['https://octofront.com/cloud-subscriptions/1']);
+    expect(out).toContain('>License Details<');
+  });
+
+  test('it is one line, whatever the field contains', () => {
+    const out = desc('[A](https://a.com)\r\n[B](https://b.com)\r\nplain');
+    // The title keeps the original text, newlines and all; the visible body is
+    // what has to be a single line.
+    const body = out.replace(/ title="[\s\S]*?"/, '');
+    expect(body).not.toMatch(/[\r\n]/);
+    expect(body).toContain(' · ');
+    expect(hrefs(out)).toHaveLength(2);
+  });
+
+  test('only http and https reach an href', () => {
+    expect(hrefs(desc('[x](javascript:alert(1))'))).toEqual([]);
+    expect(hrefs(desc('[x](data:text/html,<script>alert(1)</script>)'))).toEqual([]);
+  });
+
+  test('the field can never produce a tag other than the paragraph and its links', () => {
+    ['<img src=x onerror=alert(1)>', '<script>alert(1)</script>',
+     '[x](https://a.com" onmouseover="alert(1))', '" onmouseover="alert(1)'
+    ].forEach(input => {
+      expect(tags(desc(input)).every(t => t === 'p' || t === 'a')).toBe(true);
+    });
+  });
+
+  test('a label containing markup is escaped, not rendered', () => {
+    const out = desc('[<b>bold</b>](https://a.com)');
+    expect(tags(out).every(t => t === 'p' || t === 'a')).toBe(true);
+    expect(out).toContain('&lt;b&gt;');
+  });
+
+  test('no description renders nothing at all', () => {
+    expect(desc('')).toBe('');
+    expect(desc('   ')).toBe('');
+  });
+
+  test('it no longer uses the page subtitle styling', () => {
+    expect(desc('plain text')).toContain('ip-tn-desc');
+    expect(desc('plain text')).not.toContain('ip-sub');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3234,3 +3234,35 @@ describe('The divider follows the card open and shut', () => {
       .toBeGreaterThan(css.indexOf('.ip-rel-history-gutter::after { display: none; }'));
   });
 });
+
+describe('An open card looks like a card', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
+
+  test('opening does not restyle the card itself', () => {
+    // No blue border, no shadow change — the caret and the panel below already
+    // say it is open.
+    expect(css).not.toMatch(/\.ip-rel-card\.is-open \{/);
+    expect(css).not.toContain('.dark .ip-rel-card.is-open {');
+  });
+
+  test('the open class is still there for the divider to hang off', () => {
+    expect(css).toContain('.ip-rel-card.is-open .ip-rel-proj::after');
+    expect(css).toContain('.ip-rel-card.is-open .ip-rel-history-gutter::after');
+  });
+
+  test('the markup still marks an open card', () => {
+    const data = require('./data');
+    const Views = require('./views');
+    const model = data.releasesModel({
+      Environments: [{ Id: 'E1', Name: 'Dev' }],
+      ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }],
+      Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' }],
+      Items: [{ IsCurrent: true, ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '9.3', State: 'Success' }]
+    });
+    const html = Views.renderProjects({ projectOpen: { P1: true },
+      projectHistory: { P1: { status: 'loading' } }, releases: { status: 'ready', model } });
+    expect(html).toContain('ip-rel-card is-open');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3457,3 +3457,46 @@ describe('Project map', () => {
     expect(list).toContain('data-project="P1"');   // the row is still the toggle
   });
 });
+
+describe('Inputs and triggers share a column', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: data.projectMapModel({
+    project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+    process: { Steps: [{ Name: 'Deploy', Actions: [{ ActionType: 'Octopus.Script' }] }] },
+    channels: { Items: [] }, triggers: { Items: [{ Name: 'Nightly', Filter: { FilterType: 'OnceDailySchedule' } }] },
+    lifecycle: { Name: 'Std', Phases: [] }, feeds: { Items: [] }, environments: [], tenants: { TotalResults: 0 }
+  }) } });
+
+  // Walk div depth to find where the column actually ends, rather than trusting
+  // a lazy regex to guess it.
+  const column = (() => {
+    const start = html.indexOf('<div class="ip-pm-col">');
+    if (start === -1) return null;
+    const rest = html.slice(start);
+    const tok = /<div\b|<\/div>/g;
+    let depth = 0, m;
+    while ((m = tok.exec(rest))) {
+      depth += m[0] === '</div>' ? -1 : 1;
+      if (depth === 0) return rest.slice(0, m.index + m[0].length);
+    }
+    return null;
+  })();
+
+  test('the column exists and closes cleanly', () => {
+    expect(column).not.toBeNull();
+  });
+
+  test('it holds exactly the two panels, in order', () => {
+    expect((column.match(/<section/g) || []).length).toBe(2);
+    const headings = (column.match(/<h3>([^<]*)/g) || []).map(h => h.replace('<h3>', ''));
+    expect(headings).toEqual(['Inputs', 'Triggers']);
+  });
+
+  test('process, destinations and channels stay outside it', () => {
+    ['>Process', '>Destinations', '>Channels'].forEach(h => {
+      expect(column.indexOf(h)).toBe(-1);
+      expect(html.indexOf(h)).toBeGreaterThan(-1);
+    });
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3167,3 +3167,31 @@ describe('Project cards: background, sticky header, inline toggle', () => {
     expect(joined).not.toContain('flex-direction: column');
   });
 });
+
+describe('The project divider is the height of its text', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
+
+  test('the divider is a short segment, not a full-height border', () => {
+    const seg = /\.ip-rel-proj::after \{[\s\S]*?\}/.exec(css)[0];
+    expect(seg).toContain('height: 16px');
+    expect(seg).toContain('top: 12px');   // lines up with the project name
+  });
+
+  test('the border stays in the box so the columns do not shift', () => {
+    // Removing it outright would narrow the label column by a pixel and pull
+    // every environment column left of its heading.
+    expect(css).toContain('border-right-color: transparent');
+    expect(css).not.toContain('.ip-rel-proj { border-right: 0');
+  });
+
+  test('the header divider centres on its own text', () => {
+    const head = /\.ip-rel-head \.ip-rel-proj::after \{[\s\S]*?\}/.exec(css)[0];
+    expect(head).toContain('top: 50%');
+  });
+
+  test('the expanded gutter has no divider, having no text to divide', () => {
+    expect(css).toContain('.ip-rel-history-gutter::after { display: none; }');
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2312,3 +2312,66 @@ describe('A space we cannot read infrastructure in still has Projects', () => {
     expect(html).toContain('Portal');
   });
 });
+
+describe('A release is named where it stops, not everywhere it went', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const envs = [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Test' },
+                { Id: 'E3', Name: 'Preprod' }, { Id: 'E4', Name: 'Prod' }];
+  const build = items => data.releasesModel({
+    Environments: envs, ProjectGroups: [{ Id: 'G1', Name: 'Cloud' }],
+    Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' }],
+    Tenants: [{ Id: 'T1', Name: 'A' }, { Id: 'T2', Name: 'B' }], Items: items
+  });
+  const item = (env, ver, extra) => Object.assign({ IsCurrent: true, ProjectId: 'P1',
+    EnvironmentId: env, ReleaseVersion: ver, State: 'Success' }, extra || {});
+
+  test('only the furthest environment a version reaches is marked', () => {
+    const m = build([item('E1', '9.3'), item('E2', '9.3'), item('E3', '9.3'), item('E4', '9.1')]);
+    const cells = m.groups[0].projects[0].cells;
+    expect(cells.map(c => c.entries[0] && c.entries[0].isFurthest)).toEqual([false, false, true, true]);
+  });
+
+  test('the version is printed once, not once per environment', () => {
+    const m = build([item('E1', '9.3'), item('E2', '9.3'), item('E3', '9.3'), item('E4', '9.1')]);
+    const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
+    expect((html.match(/9\.3</g) || []).length).toBe(1);
+    expect((html.match(/9\.1</g) || []).length).toBe(1);
+  });
+
+  test('the nodes still appear in every environment the release is in', () => {
+    const m = build([item('E1', '9.3'), item('E2', '9.3'), item('E3', '9.3'), item('E4', '9.1')]);
+    const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
+    // Four environments hold something, so four head nodes.
+    expect((html.match(/ip-rel-node ip-rel-node-healthy/g) || []).length).toBe(4);
+  });
+
+  test('a failure is named where it happened, even mid-journey', () => {
+    const m = build([item('E1', '9.3'), item('E2', '9.3', { State: 'Failed' }), item('E3', '9.3')]);
+    const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
+    // Named at Test because it failed there, and at Preprod because it stops there.
+    expect((html.match(/9\.3</g) || []).length).toBe(2);
+    expect(html).toContain('Failed');
+  });
+
+  test('a tenant split names every entry, since its counts are per environment', () => {
+    // Both environments are mid-rollout, so both need their own counts named.
+    const m = build([
+      item('E3', '9.3', { TenantId: 'T1' }), item('E3', '9.1', { TenantId: 'T2' }),
+      item('E4', '9.3', { TenantId: 'T1' }), item('E4', '9.1', { TenantId: 'T2' })
+    ]);
+    const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
+    expect((html.match(/9\.3</g) || []).length).toBe(2);
+    expect((html.match(/9\.1</g) || []).length).toBe(2);
+  });
+
+  test('a single release passing through a split environment is still suppressed', () => {
+    // Preprod holds one release and is not a rollout, so it stays a bare node.
+    const m = build([
+      item('E3', '9.3', { TenantId: 'T1' }),
+      item('E4', '9.3', { TenantId: 'T1' }), item('E4', '9.1', { TenantId: 'T2' })
+    ]);
+    const html = Views.renderProjects({ releases: { status: 'ready', model: m } });
+    expect((html.match(/9\.3</g) || []).length).toBe(1);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3458,7 +3458,7 @@ describe('Project map', () => {
   });
 });
 
-describe('Inputs and triggers share a column', () => {
+describe('Inputs, triggers and channels share a column', () => {
   const data = require('./data');
   const Views = require('./views');
   const html = Views.renderProjectMap({ projectMap: { status: 'ready', model: data.projectMapModel({
@@ -3487,16 +3487,80 @@ describe('Inputs and triggers share a column', () => {
     expect(column).not.toBeNull();
   });
 
-  test('it holds exactly the two panels, in order', () => {
-    expect((column.match(/<section/g) || []).length).toBe(2);
+  test('it holds exactly the three panels, in order', () => {
+    expect((column.match(/<section/g) || []).length).toBe(3);
     const headings = (column.match(/<h3>([^<]*)/g) || []).map(h => h.replace('<h3>', ''));
-    expect(headings).toEqual(['Inputs', 'Triggers']);
+    expect(headings).toEqual(['Inputs', 'Triggers', 'Channels']);
   });
 
-  test('process, destinations and channels stay outside it', () => {
-    ['>Process', '>Destinations', '>Channels'].forEach(h => {
+  test('process and destinations stay outside it', () => {
+    ['>Process', '>Destinations'].forEach(h => {
       expect(column.indexOf(h)).toBe(-1);
       expect(html.indexOf(h)).toBeGreaterThan(-1);
     });
+  });
+
+  test('lifecycles sit above the grid, full width', () => {
+    expect(html.indexOf('>Lifecycles')).toBeGreaterThan(-1);
+    expect(html.indexOf('>Lifecycles')).toBeLessThan(html.indexOf('ip-pm-grid'));
+  });
+});
+
+describe('Project map — lifecycles', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const model = data.projectMapModel({
+    project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+    channels: { Items: [
+      { Name: 'Full', IsDefault: true, LifecycleId: 'L1', Rules: [] },
+      { Name: 'Hotfix', LifecycleId: 'L2', Rules: [] },
+      { Name: 'Beta', Rules: [] } ] },
+    lifecycle: { Id: 'L1', Name: 'Standard', Phases: [
+      { Name: 'Dev', OptionalDeploymentTargets: ['E1'] },
+      { Name: 'Prod', AutomaticDeploymentTargets: ['E2'] } ] },
+    lifecycles: [
+      { Id: 'L1', Name: 'Standard', Phases: [
+        { Name: 'Dev', OptionalDeploymentTargets: ['E1'] },
+        { Name: 'Prod', AutomaticDeploymentTargets: ['E2'] } ] },
+      { Id: 'L2', Name: 'Hotfix path', Phases: [{ Name: 'Straight to prod', OptionalDeploymentTargets: ['E2'] }] } ],
+    process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
+    environments: [{ Id: 'E1', Name: 'Dev' }, { Id: 'E2', Name: 'Production' }], tenants: { TotalResults: 0 }
+  });
+  const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
+
+  test('every lifecycle the project ships through is modelled, not just the default', () => {
+    expect(model.lifecycles.map(l => l.name)).toEqual(['Standard', 'Hotfix path']);
+    expect(model.lifecycles[0].isDefault).toBe(true);
+  });
+
+  test('a channel with no lifecycle of its own belongs to the default', () => {
+    expect(model.lifecycles[0].channels).toEqual(['Full', 'Beta']);
+    expect(model.lifecycles[1].channels).toEqual(['Hotfix']);
+  });
+
+  test('phases render in order with their environments', () => {
+    expect(html).toContain('Straight to prod');
+    expect((html.match(/ip-pm-phasebox/g) || []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('an automatic environment is marked as such', () => {
+    expect(html).toContain('ip-pm-auto');
+  });
+
+  test('destinations no longer repeats the phases', () => {
+    const dest = html.slice(html.indexOf('>Destinations'));
+    expect(dest).not.toContain('ip-pm-phasebox');
+  });
+
+  test('a lifecycle nothing routes through is still shown, and said to be unused', () => {
+    const orphan = data.projectMapModel({
+      project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' },
+      channels: { Items: [] },
+      lifecycle: { Id: 'L1', Name: 'Standard', Phases: [] },
+      lifecycles: [{ Id: 'L1', Name: 'Standard', Phases: [] }],
+      process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
+      environments: [], tenants: { TotalResults: 0 } });
+    expect(Views.renderProjectMap({ projectMap: { status: 'ready', model: orphan } }))
+      .toContain('no channel uses this');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -3540,9 +3540,8 @@ describe('Project map — lifecycles', () => {
 
   test('environments are named once, as columns', () => {
     expect(model.lifecycleEnvironments).toEqual(['Dev', 'Production']);
-    // Each environment heading appears once in the table head, not once per lifecycle.
-    const head = html.slice(html.indexOf('<thead>'), html.indexOf('</thead>'));
-    expect((head.match(/Production/g) || []).length).toBe(1);
+    // Once in the header, and nowhere else in the panel however many lifecycles.
+    expect((html.match(/ip-pm-colhead">Production/g) || []).length).toBe(1);
   });
 
   test('each lifecycle is a row across those columns', () => {
@@ -3551,12 +3550,21 @@ describe('Project map — lifecycles', () => {
     expect(html).toContain('Straight to prod');
   });
 
-  test('a lifecycle that never reaches an environment leaves the cell blank', () => {
-    expect(html).toContain('ip-pm-lccell is-absent');
+  test('a lifecycle that never reaches an environment gets no node there', () => {
+    // Hotfix reaches Production only, so its Dev cell carries no node.
+    const rows = html.split('ip-pm-lcrow').slice(2);       // skip the header row
+    const hotfix = rows.find(r => r.indexOf('Hotfix path') > -1);
+    expect((hotfix.match(/ip-pm-node/g) || []).length).toBe(1);
   });
 
-  test('an automatic environment is marked as such', () => {
-    expect(html).toContain('ip-pm-auto');
+  test('an automatic phase is drawn differently from an optional one', () => {
+    expect(html).toContain('ip-pm-node is-auto');
+  });
+
+  test('the phase number carries the grouping instead of repeated names', () => {
+    // Standard: Dev is phase 1, Prod is phase 2.
+    expect(html).toContain('>1</span>');
+    expect(html).toContain('>2</span>');
   });
 
   test('destinations no longer repeats the phases', () => {
@@ -3617,8 +3625,18 @@ describe('Lifecycle columns are ordered and shared', () => {
 
   test('an automatic phase is marked, an optional one is not', () => {
     const html = Views.renderProjectMap({ projectMap: { status: 'ready', model } });
-    expect(html).toContain('ip-pm-auto');
-    expect((html.match(/ip-pm-auto/g) || []).length).toBe(1);
+    // Only Standard's Prod phase is automatic, across all three lifecycles.
+    expect((html.match(/ip-pm-node is-auto/g) || []).length).toBe(1);
+  });
+
+  test('environments in the same phase share a number', () => {
+    const two = data.projectMapModel({
+      project: { Id: 'P1', Name: 'X', LifecycleId: 'L1' }, channels: { Items: [] },
+      lifecycle: { Id: 'L1', Name: 'One', Phases: [{ Name: 'Both', OptionalDeploymentTargets: ['E1', 'E2'] }] },
+      lifecycles: [{ Id: 'L1', Name: 'One', Phases: [{ Name: 'Both', OptionalDeploymentTargets: ['E1', 'E2'] }] }],
+      process: { Steps: [] }, triggers: { Items: [] }, feeds: { Items: [] },
+      environments: [{ Id: 'E1', Name: 'A' }, { Id: 'E2', Name: 'B' }], tenants: { TotalResults: 0 } });
+    expect(two.lifecycles[0].cells.map(c => c.phaseIndex)).toEqual([0, 0]);
   });
 
   test('a blank cell is explained rather than left ambiguous', () => {

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2811,10 +2811,69 @@ describe('Readiness is triangulated against what has deployed', () => {
         Templates: [{ Id: 't1', Name: 'ApiKey' }], Variables: { E3: {} } } } },
       now: NOW
     });
-    const html = Views.renderTenantDetail({ spaceId: 'S', tenantDetail: { status: 'ready', model } });
+    const overview = Views.renderTenantDetail({ spaceId: 'S', tenantDetail: { status: 'ready', model } });
     // It deployed three days ago with the value unset, so the page says so.
-    expect(html).not.toContain('would fail on configuration');
-    expect(html).toContain('Deployments have succeeded with these unset');
-    expect(html).toContain('deployed without it');
+    expect(overview).not.toContain('would fail on configuration');
+    expect(overview).toContain('Deployments have succeeded with these unset');
+    // The detail sits behind a tab rather than in the flow.
+    expect(overview).not.toContain('deployed without it');
+    const variables = Views.renderTenantDetail({ spaceId: 'S', tenantTab: 'Variables',
+      tenantDetail: { status: 'ready', model } });
+    expect(variables).toContain('deployed without it');
+  });
+});
+
+describe('Unset variables live behind a tab, in amber', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const NOW = Date.now();
+  const build = (items, templates) => data.tenantDetailModel({
+    tenant: { Id: 'T1', Name: 'T', TenantTags: [], ProjectEnvironments: { P1: ['E3'] } },
+    dashboard: { Projects: [{ Id: 'P1', Name: 'Patient Records' }], Environments: [{ Id: 'E3', Name: 'Production' }],
+      Items: items },
+    variables: { ProjectVariables: { P1: { ProjectId: 'P1', ProjectName: 'Patient Records',
+      Templates: templates, Variables: { E3: {} } } } },
+    now: NOW
+  });
+  const deployed = [{ IsCurrent: true, TenantId: 'T1', ProjectId: 'P1', EnvironmentId: 'E3',
+    ReleaseVersion: '1.0', State: 'Success', CompletedTime: new Date(NOW - 3 * 86400000).toISOString() }];
+  const render = (model, tab) => Views.renderTenantDetail({ spaceId: 'S', tenantTab: tab,
+    tenantDetail: { status: 'ready', model } });
+
+  test('a tab appears only when something is unset', () => {
+    const none = build(deployed, [{ Id: 't1', Name: 'ApiKey', DefaultValue: 'x' }]);
+    expect(render(none)).not.toContain('data-tenanttab');
+    const some = build(deployed, [{ Id: 't1', Name: 'ApiKey' }]);
+    expect(render(some)).toContain('data-tenanttab="Variables"');
+  });
+
+  test('the tab carries the count', () => {
+    const html = render(build(deployed, [{ Id: 't1', Name: 'ApiKey' }, { Id: 't2', Name: 'Secret' }]));
+    expect(html).toContain('ip-tn-tabcount');
+    expect(html).toContain('Unset variables');
+  });
+
+  test('the overview keeps the matrix rather than the variable list', () => {
+    const html = render(build(deployed, [{ Id: 't1', Name: 'ApiKey' }]));
+    expect(html).toContain('Deployment matrix');
+    expect(html).not.toContain('ip-tn-legend">A template is a request');
+  });
+
+  test('the variables tab shows the list and not the matrix', () => {
+    const html = render(build(deployed, [{ Id: 't1', Name: 'ApiKey' }]), 'Variables');
+    expect(html).toContain('A template is a request for a value');
+    expect(html).not.toContain('Deployment matrix');
+  });
+
+  test('unproven reads amber, never red', () => {
+    // Nothing has deployed, so the template is unproven — the strongest case.
+    const html = render(build([], [{ Id: 't1', Name: 'ApiKey' }]), 'Variables');
+    expect(html).toContain('ip-pill-warning');
+    expect(html).not.toContain('ip-pill-unhealthy');
+  });
+
+  test('the readiness card is amber too, not the failure tone', () => {
+    const html = render(build([], [{ Id: 't1', Name: 'ApiKey' }]));
+    expect(html).toContain('ip-rel-node-warning');
   });
 });

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -2954,3 +2954,75 @@ describe('Feature flags for one tenant', () => {
     expect(withFlags).toContain('data-tenanttab="Flags"');
   });
 });
+
+describe('Feature flag posture on the tenant overview', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const tenant = { Id: 'T1', TenantTags: [], Name: 'Mercy', ProjectEnvironments: { P1: ['E1', 'E2'] } };
+  const e1 = o => Object.assign({ DeploymentEnvironmentId: 'E1', IsEnabled: true }, o);
+  const e2 = o => Object.assign({ DeploymentEnvironmentId: 'E2', IsEnabled: true }, o);
+  const payload = { projectsRead: 1, byProject: { P1: { total: 5, items: [
+    { Id: 'A', Name: 'fully-on', DefaultIsEnabled: true, Environments: [e1({ RolloutPercentage: 100 }), e2({ RolloutPercentage: 100 })] },
+    { Id: 'B', Name: 'fully-off', DefaultIsEnabled: false, Environments: [e1({ IsEnabled: false }), e2({ IsEnabled: false })] },
+    { Id: 'C', Name: 'half-rolled', DefaultIsEnabled: true, Environments: [e1({ RolloutPercentage: 100 }), e2({ RolloutPercentage: 25 })] },
+    { Id: 'D', Name: 'prod-only', DefaultIsEnabled: false, Environments: [e1({ IsEnabled: false }), e2({ RolloutPercentage: 100 })] },
+    { Id: 'E', Name: 'default-on', DefaultIsEnabled: true, Environments: [] }
+  ] } } };
+  const model = data.tenantFlagModel(payload, tenant, { P1: ['E1', 'E2'] },
+    { E1: 'Staging', E2: 'Production' }, { P1: 'Patient Records' });
+
+  test('flags split into fully on, fully off and in between', () => {
+    expect(model.summary.fullyOn).toBe(2);       // fully-on, default-on
+    expect(model.summary.fullyOff).toBe(1);
+    expect(model.summary.betweenCount).toBe(2);  // half-rolled, prod-only
+  });
+
+  test('an environment with no override falls back to the flag default', () => {
+    expect(data.flagStateForTenant(undefined, tenant, true).key).toBe('on');
+    expect(data.flagStateForTenant(undefined, tenant, false).key).toBe('off');
+  });
+
+  test('in-between flags are named with what they are doing per environment', () => {
+    const half = model.summary.between.find(b => b.name === 'half-rolled');
+    expect(half.percent).toBe(25);
+    expect(half.states.map(s => s.envName + ':' + s.key)).toEqual(['Staging:on', 'Production:partial']);
+  });
+
+  test('a flag on in one environment and off in another counts as in between', () => {
+    const split = model.summary.between.find(b => b.name === 'prod-only');
+    expect(split.percent).toBeNull();
+    expect(split.states.map(s => s.key)).toEqual(['off', 'on']);
+  });
+
+  test('the overview panel shows the counts and names the in-between ones', () => {
+    const detail = data.tenantDetailModel({ tenant: tenant,
+      dashboard: { Projects: [{ Id: 'P1', Name: 'Patient Records' }],
+        Environments: [{ Id: 'E1', Name: 'Staging' }, { Id: 'E2', Name: 'Production' }], Items: [] } });
+    const html = Views.renderTenantDetail({ spaceId: 'S',
+      flags: { status: 'ready', model: model }, tenantDetail: { status: 'ready', model: detail } });
+    expect(html).toContain('fully on');
+    expect(html).toContain('fully off');
+    expect(html).toContain('in between');
+    expect(html).toContain('half-rolled');
+    expect(html).toContain('25%');
+  });
+
+  test('a tenant whose flags are all settled says so rather than showing an empty list', () => {
+    const settled = data.tenantFlagModel({ projectsRead: 1, byProject: { P1: { total: 1, items: [
+      { Id: 'A', Name: 'on', DefaultIsEnabled: true, Environments: [e1({ RolloutPercentage: 100 })] }
+    ] } } }, tenant, { P1: ['E1'] }, { E1: 'Staging' }, { P1: 'P' });
+    const detail = data.tenantDetailModel({ tenant: tenant,
+      dashboard: { Projects: [], Environments: [{ Id: 'E1', Name: 'Staging' }], Items: [] } });
+    const html = Views.renderTenantDetail({ spaceId: 'S',
+      flags: { status: 'ready', model: settled }, tenantDetail: { status: 'ready', model: detail } });
+    expect(html).toContain('settled one way or the other');
+  });
+
+  test('no panel before the flags have loaded', () => {
+    const detail = data.tenantDetailModel({ tenant: tenant,
+      dashboard: { Projects: [], Environments: [], Items: [] } });
+    const html = Views.renderTenantDetail({ spaceId: 'S', flags: { status: 'loading' },
+      tenantDetail: { status: 'ready', model: detail } });
+    expect(html).not.toContain('fully on');
+  });
+});

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -732,7 +732,13 @@ async function fetchProgression(spaceId, projectId) {
     + '?releaseHistoryCount=' + PROGRESSION_HISTORY);
 }
 
-function progressionModel(prog, gridEnvironments) {
+const HISTORY_WINDOWS = [
+  { label: '24 hours', hours: 24 },
+  { label: '7 days', hours: 24 * 7 },
+  { label: 'All', hours: null }
+];
+
+function progressionModel(prog, gridEnvironments, windowHours, now) {
   const p = prog || {};
   // Columns come from the grid, not from this payload, so an expanded row lines
   // up with the collapsed one above it.
@@ -780,17 +786,31 @@ function progressionModel(prog, gridEnvironments) {
     };
   });
 
+  // A release is in the window if it was created in it or moved in it. A release
+  // cut a month ago and promoted to Production this morning is this morning's
+  // news, and filtering on creation alone would hide it.
+  const cutoff = windowHours ? (now || Date.now()) - windowHours * 3600 * 1000 : null;
+  const latestTouch = r => {
+    let t = r.assembled ? Date.parse(r.assembled) : 0;
+    r.cells.forEach(c => { if (c.when) { const w = Date.parse(c.when); if (w > t) t = w; } });
+    return t;
+  };
+  const all = releases;
+  const shown = cutoff == null ? all : all.filter(r => latestTouch(r) >= cutoff);
+
   const channels = [];
-  releases.forEach(r => { if (r.channelName && channels.indexOf(r.channelName) === -1) channels.push(r.channelName); });
+  shown.forEach(r => { if (r.channelName && channels.indexOf(r.channelName) === -1) channels.push(r.channelName); });
 
   return {
     environments: envs,
-    releases: releases,
+    releases: shown,
+    totalReleases: all.length,
+    hiddenByWindow: all.length - shown.length,
     channels: channels,
-    neverDeployedCount: releases.filter(r => !r.everDeployed).length,
+    neverDeployedCount: shown.filter(r => !r.everDeployed).length,
     // The server caps history. Say when we are probably looking at a window
     // rather than the whole story.
-    windowed: releases.length >= PROGRESSION_HISTORY,
+    windowed: all.length >= PROGRESSION_HISTORY,
     historyCount: PROGRESSION_HISTORY
   };
 }
@@ -800,7 +820,7 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel,
   fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
-  fetchProgression, progressionModel }; }
+  fetchProgression, progressionModel, HISTORY_WINDOWS }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -809,5 +829,5 @@ if (typeof module !== 'undefined') {
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel,
     fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
-    fetchProgression, progressionModel };
+    fetchProgression, progressionModel, HISTORY_WINDOWS };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -625,18 +625,17 @@ function releasesModel(dash) {
     if (item.TenantId) agg.tenants.push(item.TenantId);
   });
 
-  // An environment nothing has ever been deployed to costs a column and tells
-  // you nothing. Dropped from the grid and named underneath instead, so the
-  // remaining columns get the width — and so a space with a dormant environment
-  // doesn't read as though the environment were missing.
-  const usedEnvIds = {};
-  Object.keys(byProject).forEach(pid => Object.keys(byProject[pid]).forEach(eid => { usedEnvIds[eid] = true; }));
-  const environments = allEnvironments.filter(e => usedEnvIds[e.id]);
-  const hiddenEnvironments = allEnvironments.filter(e => !usedEnvIds[e.id]);
+  // Projects are grouped the way the instance groups them, and each group gets
+  // its own columns. An environment is hidden per group rather than estate-wide,
+  // because a group that never touches Preprod shouldn't carry an empty column
+  // for it just because another group does. The cost is that two groups can show
+  // different columns, which is why each group renders its own header row.
+  const groupOf = {};
+  (d.ProjectGroups || []).forEach(g => { groupOf[g.Id] = g.Name; });
 
-  const projects = (d.Projects || []).map(p => {
+  const buildProject = (p, envList) => {
     const envMap = byProject[p.Id] || {};
-    const cells = environments.map(env => {
+    const cells = envList.map(env => {
       const vers = envMap[env.id] || {};
       const entries = Object.keys(vers).map(v => {
         const a = vers[v];
@@ -649,10 +648,6 @@ function releasesModel(dash) {
           tenantNames: a.tenants.map(id => tenantNames[id] || id)
         };
       }).sort((x, y) => String(y.when || '').localeCompare(String(x.when || '')));
-      // A tenanted project can have dozens of releases live in one environment at
-      // once — 41 in one cell on Cloud Platform. The cell reports the spread so
-      // the view can name the newest and summarise the rest instead of stacking
-      // forty labels into a column.
       const tenantTotal = entries.reduce((n, e) => n + e.tenantCount, 0);
       return {
         envId: env.id, envName: env.name, entries: entries,
@@ -661,13 +656,42 @@ function releasesModel(dash) {
     });
     const links = cells.map((c, i) =>
       i === 0 ? null : linkTone(cells[i - 1].entries.map(e => e.version), c.entries.map(e => e.version)));
-    const deployed = cells.reduce((n, c) => n + (c.entries.length ? 1 : 0), 0);
     return {
       id: p.Id, name: p.Name, slug: p.Slug,
-      groupId: p.ProjectGroupId, groupName: groupNames[p.ProjectGroupId] || '',
-      cells: cells, links: links, deployedCount: deployed
+      groupId: p.ProjectGroupId, groupName: groupOf[p.ProjectGroupId] || '',
+      cells: cells, links: links,
+      deployedCount: cells.reduce((n, c) => n + (c.entries.length ? 1 : 0), 0)
+    };
+  };
+
+  const byGroup = {};
+  (d.Projects || []).forEach(p => {
+    const gid = p.ProjectGroupId || '';
+    (byGroup[gid] || (byGroup[gid] = [])).push(p);
+  });
+
+  const groups = Object.keys(byGroup).map(gid => {
+    const members = byGroup[gid];
+    const used = {};
+    members.forEach(p => Object.keys(byProject[p.Id] || {}).forEach(eid => { used[eid] = true; }));
+    const envs = allEnvironments.filter(e => used[e.id]);
+    const hidden = allEnvironments.filter(e => !used[e.id]);
+    return {
+      id: gid,
+      name: groupOf[gid] || 'Ungrouped',
+      environments: envs,
+      hiddenEnvironments: hidden,
+      projects: members.map(p => buildProject(p, envs)).sort((a, b) => String(a.name).localeCompare(String(b.name)))
     };
   }).sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+  // Kept flat as well, so callers that only want a count or a lookup don't have
+  // to walk the groups.
+  const projects = groups.reduce((all, g) => all.concat(g.projects), []);
+  const usedEnvIds = {};
+  Object.keys(byProject).forEach(pid => Object.keys(byProject[pid]).forEach(eid => { usedEnvIds[eid] = true; }));
+  const environments = allEnvironments.filter(e => usedEnvIds[e.id]);
+  const hiddenEnvironments = allEnvironments.filter(e => !usedEnvIds[e.id]);
 
   // The server caps how many projects the dashboard returns. Reporting the cap
   // matters more here than elsewhere: a capped list looks exactly like a small
@@ -675,6 +699,7 @@ function releasesModel(dash) {
   return {
     environments: environments,
     hiddenEnvironments: hiddenEnvironments,
+    groups: groups,
     projects: projects,
     truncated: {
       projectLimit: typeof d.ProjectLimit === 'number' ? d.ProjectLimit : null,
@@ -685,11 +710,97 @@ function releasesModel(dash) {
   };
 }
 
+
+// ─── Project history (expanded row) ──────────────────────────────────────────
+// /progression returns the recent releases for one project, newest first, with
+// a Deployments map keyed by environment. Two things about it shape the model:
+//
+//   Releases from every channel arrive in one list. Lag is therefore counted
+//   within a channel — a Main release is not "two behind" because two
+//   Pre-Release builds were cut after it.
+//
+//   Plenty of releases were never deployed anywhere. They are kept, because a
+//   release that got created and went nowhere is a fact about the project, and
+//   dropping it would make the history look tidier than the project is.
+//
+// releaseHistoryCount is capped at 100 by the server and counts per channel.
+
+const PROGRESSION_HISTORY = 30;
+
+async function fetchProgression(spaceId, projectId) {
+  return fetchJson('/api/' + spaceId + '/progression/' + encodeURIComponent(projectId)
+    + '?releaseHistoryCount=' + PROGRESSION_HISTORY);
+}
+
+function progressionModel(prog, gridEnvironments) {
+  const p = prog || {};
+  // Columns come from the grid, not from this payload, so an expanded row lines
+  // up with the collapsed one above it.
+  const envs = (gridEnvironments || []).map(e => ({ id: e.id, name: e.name }));
+  const seenPerChannel = {};
+
+  const releases = (p.Releases || []).map(entry => {
+    const rel = entry.Release || {};
+    const channelName = (entry.Channel && entry.Channel.Name) || '';
+    const channelId = rel.ChannelId || (entry.Channel && entry.Channel.Id) || '';
+    // The list is newest first, so the count already seen in this channel is
+    // how many newer releases sit in front of this one.
+    const lag = seenPerChannel[channelId] || 0;
+    seenPerChannel[channelId] = lag + 1;
+
+    const deployments = entry.Deployments || {};
+    const cells = envs.map(env => {
+      const items = deployments[env.id] || [];
+      let stateKey = null, when = null, tenants = 0;
+      items.forEach(it => {
+        const at = it.CompletedTime || it.StartTime || it.QueueTime || it.Created || null;
+        if (!when || (at && at > when)) { when = at; stateKey = releaseStateKey(it.State); }
+        if (it.TenantId) tenants++;
+      });
+      return {
+        envId: env.id, envName: env.name,
+        deployed: items.length > 0,
+        stateKey: stateKey || null,
+        stateLabel: stateKey ? releaseStateLabel(stateKey) : '',
+        when: when, tenantCount: tenants, count: items.length
+      };
+    });
+
+    const reachedIdx = cells.reduce((last, c, i) => (c.deployed ? i : last), -1);
+    return {
+      version: rel.Version,
+      releaseId: rel.Id,
+      channelId: channelId,
+      channelName: channelName,
+      assembled: rel.Assembled || null,
+      lag: lag,
+      cells: cells,
+      frontier: reachedIdx,
+      everDeployed: reachedIdx >= 0
+    };
+  });
+
+  const channels = [];
+  releases.forEach(r => { if (r.channelName && channels.indexOf(r.channelName) === -1) channels.push(r.channelName); });
+
+  return {
+    environments: envs,
+    releases: releases,
+    channels: channels,
+    neverDeployedCount: releases.filter(r => !r.everDeployed).length,
+    // The server caps history. Say when we are probably looking at a window
+    // rather than the whole story.
+    windowed: releases.length >= PROGRESSION_HISTORY,
+    historyCount: PROGRESSION_HISTORY
+  };
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel,
-  fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone }; }
+  fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
+  fetchProgression, progressionModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -697,5 +808,6 @@ if (typeof module !== 'undefined') {
     machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel,
-    fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone };
+    fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
+    fetchProgression, progressionModel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1783,7 +1783,7 @@ function projectMapModel(payload) {
   const phases = phasesOf(src.lifecycle || {});
 
   const channelItems = ((src.channels || {}).Items) || [];
-  const lifecycles = (src.lifecycles || []).map(lc => ({
+  const rawLifecycles = (src.lifecycles || []).map(lc => ({
     id: lc.Id, name: lc.Name,
     isDefault: lc.Id === project.LifecycleId,
     // Which channels ship through it. A channel with no lifecycle of its own
@@ -1793,6 +1793,34 @@ function projectMapModel(payload) {
       .map(c => c.Name),
     phases: phasesOf(lc)
   }));
+
+  // The environments are the columns, named once, and the lifecycles are rows
+  // across them. Order follows the default lifecycle's phases first, so the
+  // columns read as a progression rather than as whatever order the API
+  // happened to return; anything only another lifecycle reaches is appended.
+  const columns = [];
+  const addEnv = name => { if (name && columns.indexOf(name) === -1) columns.push(name); };
+  const ordered = rawLifecycles.slice().sort((a, b) => (b.isDefault ? 1 : 0) - (a.isDefault ? 1 : 0));
+  ordered.forEach(lc => lc.phases.forEach(ph => {
+    ph.automatic.forEach(addEnv);
+    ph.optional.forEach(addEnv);
+  }));
+
+  const lifecycles = rawLifecycles.map(lc => {
+    const where = {};
+    lc.phases.forEach((ph, i) => {
+      ph.automatic.forEach(e => { where[e] = { phase: ph.name, index: i, automatic: true }; });
+      ph.optional.forEach(e => { if (!where[e]) where[e] = { phase: ph.name, index: i, automatic: false }; });
+    });
+    return Object.assign({}, lc, {
+      cells: columns.map(envNameCol => {
+        const hit = where[envNameCol];
+        return hit
+          ? { environment: envNameCol, reached: true, phase: hit.phase, phaseIndex: hit.index, automatic: hit.automatic }
+          : { environment: envNameCol, reached: false };
+      })
+    });
+  });
 
   const triggers = (((src.triggers || {}).Items) || []).map(t => {
     const l = triggerLabel(t);
@@ -1817,6 +1845,7 @@ function projectMapModel(payload) {
     processError: src.processError ? 'The deployment process could not be read.' : null,
     lifecycle: (src.lifecycle || {}).Name || '',
     lifecycles: lifecycles,
+    lifecycleEnvironments: columns,
     phases: phases,
     channels: (((src.channels || {}).Items) || []).map(c => ({
       name: c.Name, isDefault: !!c.IsDefault,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1558,8 +1558,10 @@ async function fetchTenantFlags(spaceId, projectIds) {
     truncated: (projectIds || []).length > ids.length };
 }
 
-function flagStateForTenant(env, tenant) {
-  if (!env) return { key: 'inherit' };
+function flagStateForTenant(env, tenant, defaultOn) {
+  // No override for this environment means the flag's own default applies.
+  // Treating that as unknown left flags out of the count that are plainly on.
+  if (!env) return { key: defaultOn ? 'on' : 'off', via: 'default' };
   const tags = (tenant && tenant.TenantTags) || [];
   const id = tenant && tenant.Id;
   const has = (list, v) => (list || []).indexOf(v) !== -1;
@@ -1596,23 +1598,47 @@ function tenantFlagModel(payload, tenant, connectedEnvIdsByProject, envName, pro
       const byEnv = {};
       (f.Environments || []).forEach(e => { byEnv[e.DeploymentEnvironmentId] = e; });
       const cells = envs.map(eid => {
-        const st = flagStateForTenant(byEnv[eid], tenant);
+        const st = flagStateForTenant(byEnv[eid], tenant, !!f.DefaultIsEnabled);
         return { envId: eid, envName: (envName || {})[eid] || eid, key: st.key,
           percent: st.percent, via: st.via };
       });
       // A flag that is off or inherited everywhere for this tenant is not news
       // on a tenant page; the project page is where those live.
       const live = cells.some(c => c.key === 'on' || c.key === 'partial' || c.key === 'segment');
+      const undecided = cells.some(c => c.key === 'partial' || c.key === 'segment');
+      // Fully on, fully off, or somewhere in between. "In between" covers both
+      // a flag on in one environment and off in another, and one part-way
+      // through a rollout — either way it is not settled for this tenant.
+      const allOn = cells.length > 0 && cells.every(c => c.key === 'on');
+      const allOff = cells.length > 0 && cells.every(c => c.key === 'off' || c.key === 'excluded');
+      const settled = allOn ? 'on' : (allOff ? 'off' : 'between');
       flags.push({ id: f.Id, name: f.Name, projectId: pid, projectName: (projectName || {})[pid] || pid,
-        cells: cells, live: live,
-        undecided: cells.some(c => c.key === 'partial' || c.key === 'segment') });
+        cells: cells, live: live, undecided: undecided, settled: settled });
     });
   });
 
   flags.sort((a, b) => String(a.name).localeCompare(String(b.name)));
   const live = flags.filter(f => f.live);
+  const between = flags.filter(f => f.settled === 'between').map(f => ({
+    id: f.id, name: f.name, projectName: f.projectName, undecided: f.undecided,
+    // What it is doing, environment by environment, so "in between" is never
+    // just a bucket someone has to go and investigate.
+    states: f.cells.map(c => ({ envName: c.envName, key: c.key, percent: c.percent, via: c.via })),
+    // The clearest single number, where there is one.
+    percent: (function () {
+      const pct = f.cells.filter(c => c.percent != null).map(c => c.percent);
+      return pct.length ? Math.max.apply(null, pct) : null;
+    })()
+  }));
+
   return {
     flags: live,
+    summary: {
+      fullyOn: flags.filter(f => f.settled === 'on').length,
+      fullyOff: flags.filter(f => f.settled === 'off').length,
+      between: between,
+      betweenCount: between.length
+    },
     total: flags.length,
     liveCount: live.length,
     undecidedCount: live.filter(f => f.undecided).length,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -654,6 +654,13 @@ function releasesModel(dash) {
         versionCount: entries.length, tenantTotal: tenantTotal
       };
     });
+    // A release sitting in four environments does not need naming four times —
+    // the line and the nodes already say it is the same one. Mark the furthest
+    // environment each version reaches; that is the only place worth a label.
+    const furthest = {};
+    cells.forEach((c, i) => c.entries.forEach(e => { furthest[e.version] = i; }));
+    cells.forEach((c, i) => c.entries.forEach(e => { e.isFurthest = furthest[e.version] === i; }));
+
     const links = cells.map((c, i) =>
       i === 0 ? null : linkTone(cells[i - 1].entries.map(e => e.version), c.entries.map(e => e.version)));
     return {

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1697,7 +1697,8 @@ async function fetchProjectMap(spaceId, projectId) {
     soft(fetchJson('/api/' + spaceId + '/lifecycles/' + encodeURIComponent(project.LifecycleId))),
     soft(fetchJson('/api/' + spaceId + '/feeds?take=100')),
     soft(fetchJson('/api/' + spaceId + '/environments/all')),
-    soft(fetchJson('/api/' + spaceId + '/tenants?projectId=' + encodeURIComponent(projectId) + '&take=1'))
+    soft(fetchJson('/api/' + spaceId + '/tenants?projectId=' + encodeURIComponent(projectId) + '&take=1')),
+    soft(fetchTenantMachines(spaceId))
   ]);
   const channels = ((parts[1].v || {}).Items) || [];
   const defaultLifecycle = parts[3].v;
@@ -1721,7 +1722,8 @@ async function fetchProjectMap(spaceId, projectId) {
     lifecycle: defaultLifecycle, lifecycleError: parts[3].err,
     lifecycles: lifecycles,
     feeds: parts[4].v, environments: parts[5].v,
-    tenants: parts[6].v, tenantsError: parts[6].err
+    tenants: parts[6].v, tenantsError: parts[6].err,
+    machines: parts[7].v, machinesError: parts[7].err
   };
 }
 
@@ -1740,6 +1742,62 @@ function triggerLabel(trigger) {
   if (/Feed|Package/i.test(kind)) return { kind: 'Package', detail: 'When a new package is pushed' };
   if (/Git/i.test(kind)) return { kind: 'Git', detail: 'On a change in the repository' };
   return { kind: 'Trigger', detail: actionTypeLabel(kind) };
+}
+
+
+/** What a project deploys to, and what shape that estate is in.
+ *
+ *  Octopus picks targets by role, within the environments the lifecycle allows.
+ *  A project with no roles on any step — a Terraform or script project, which is
+ *  common — selects no targets at all, and that is a fact about the project
+ *  rather than an empty estate. The two must not look the same.
+ */
+function projectTargets(machines, roles, environmentIds, tenantedMode) {
+  if (!machines) return null;
+  const list = (machines.items) || [];
+  const wantRoles = roles || [];
+  const wantEnvs = environmentIds || [];
+  if (!wantRoles.length) {
+    return { selectsByRole: false, matched: [], total: 0,
+      healthy: 0, unhealthy: 0, disabled: 0, byRole: [], byEnvironment: [], tenanted: null };
+  }
+  const matched = list.filter(m =>
+    (m.Roles || []).some(r => wantRoles.indexOf(r) !== -1)
+    && (!wantEnvs.length || (m.EnvironmentIds || []).some(e => wantEnvs.indexOf(e) !== -1)));
+
+  const counts = { healthy: 0, unhealthy: 0, disabled: 0 };
+  matched.forEach(m => { counts[healthKey(m.HealthStatus, m.IsDisabled)]++; });
+
+  const byRole = wantRoles.map(r => ({ role: r,
+    count: matched.filter(m => (m.Roles || []).indexOf(r) !== -1).length })).filter(x => x.count);
+
+  const byEnvironment = {};
+  matched.forEach(m => (m.EnvironmentIds || []).forEach(e => {
+    if (wantEnvs.length && wantEnvs.indexOf(e) === -1) return;
+    byEnvironment[e] = (byEnvironment[e] || 0) + 1;
+  }));
+
+  // How the matched targets take part in tenanted deployments — the answer to
+  // "will this actually reach my tenants" is here rather than in the count.
+  const participation = {};
+  matched.forEach(m => {
+    const p = m.TenantedDeploymentParticipation || 'Untenanted';
+    participation[p] = (participation[p] || 0) + 1;
+  });
+  const dedicated = matched.filter(m => (m.TenantIds || []).length).length;
+  const byTag = matched.filter(m => (m.TenantTags || []).length).length;
+
+  return {
+    selectsByRole: true,
+    matched: matched.map(m => ({ id: m.Id, name: m.Name, health: m.HealthStatus,
+      disabled: !!m.IsDisabled, roles: m.Roles || [] })),
+    total: matched.length,
+    healthy: counts.healthy, unhealthy: counts.unhealthy, disabled: counts.disabled,
+    byRole: byRole,
+    byEnvironment: byEnvironment,
+    tenanted: tenantedMode === 'Untenanted' ? null
+      : { participation: participation, dedicated: dedicated, byTag: byTag }
+  };
 }
 
 function projectMapModel(payload) {
@@ -1775,6 +1833,8 @@ function projectMapModel(payload) {
   }));
 
   const persistence = project.PersistenceSettings || {};
+  const envIdsOf = lc => (lc.Phases || []).reduce((all, ph) =>
+    all.concat(ph.AutomaticDeploymentTargets || [], ph.OptionalDeploymentTargets || []), []);
   const phasesOf = lc => (lc.Phases || []).map(ph => ({
     name: ph.Name,
     optional: (ph.OptionalDeploymentTargets || []).map(id => envName[id] || id),
@@ -1822,6 +1882,9 @@ function projectMapModel(payload) {
     });
   });
 
+  const allRoles = [...new Set(process.flatMap(st => st.roles))];
+  const lifecycleEnvIds = [...new Set((src.lifecycles || []).reduce((all, lc) => all.concat(envIdsOf(lc)), []))];
+
   const triggers = (((src.triggers || {}).Items) || []).map(t => {
     const l = triggerLabel(t);
     return { name: t.Name, kind: l.kind, detail: l.detail, disabled: !!t.IsDisabled };
@@ -1850,7 +1913,18 @@ function projectMapModel(payload) {
     channels: (((src.channels || {}).Items) || []).map(c => ({
       name: c.Name, isDefault: !!c.IsDefault,
       lifecycleId: c.LifecycleId, rules: (c.Rules || []).length })),
-    roles: [...new Set(process.flatMap(st => st.roles))]
+    roles: allRoles,
+    lifecycleEnvironmentIds: lifecycleEnvIds,
+    targets: (function () {
+      const t = projectTargets(src.machines, allRoles, lifecycleEnvIds, project.TenantedDeploymentMode || 'Untenanted');
+      if (!t) return null;
+      return Object.assign({}, t, {
+        byEnvironment: Object.keys(t.byEnvironment).map(id => ({ environment: envName[id] || id, count: t.byEnvironment[id] }))
+          .sort((a, b) => b.count - a.count)
+      });
+    })(),
+    targetsError: src.machinesError
+      ? 'Deployment targets cannot be read in this space, so what this project deploys to is unknown.' : null
   };
 }
 
@@ -1868,7 +1942,7 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
   fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
   fetchTenantFlags, tenantFlagModel, flagStateForTenant,
-  fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel }; }
+  fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1886,5 +1960,5 @@ if (typeof module !== 'undefined') {
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
     fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
     fetchTenantFlags, tenantFlagModel, flagStateForTenant,
-    fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel };
+    fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1230,16 +1230,37 @@ function tenantsModel(payload) {
 /** Actionability, not alphabet: what is broken, then what has never run, then
  *  what is not wired up, then name. Sorting 1,228 tenants by name puts the ones
  *  that need someone on page nine. */
-const TENANT_SORTS = ['Actionability', 'Name', 'Last activity'];
+const TENANT_SORTS = ['Actionability', 'Name', 'Projects', 'Environments', 'Last outcome'];
 
-function sortTenants(rows, sort) {
+/** Every sort has a natural first direction: names read A–Z, counts and dates
+ *  read biggest and newest first. Clicking a header a second time reverses it. */
+const TENANT_SORT_DEFAULT_DIR = {
+  Actionability: 'asc', Name: 'asc', Projects: 'desc', Environments: 'desc', 'Last outcome': 'desc'
+};
+
+function tenantSortDir(sort) {
+  return TENANT_SORT_DEFAULT_DIR[sort] || 'asc';
+}
+
+function sortTenants(rows, sort, dir) {
   const copy = rows.slice();
-  if (sort === 'Name') return copy.sort((a, b) => String(a.name).localeCompare(String(b.name)));
-  if (sort === 'Last activity') return copy.sort((a, b) => (b.outcomeAt || 0) - (a.outcomeAt || 0));
-  const rank = r => r.needsAttention ? 0 : (r.neverDeployed ? 1 : (r.notConnected ? 2 : 3));
-  return copy.sort((a, b) => (rank(a) - rank(b))
-    || ((b.outcomeAt || 0) - (a.outcomeAt || 0))
-    || String(a.name).localeCompare(String(b.name)));
+  const direction = dir === 'asc' || dir === 'desc' ? dir : tenantSortDir(sort);
+  const flip = direction === (TENANT_SORT_DEFAULT_DIR[sort] || 'asc') ? 1 : -1;
+  const byName = (a, b) => String(a.name).localeCompare(String(b.name));
+
+  let cmp;
+  if (sort === 'Name') cmp = byName;
+  else if (sort === 'Projects') cmp = (a, b) => (b.connectedProjectIds.length - a.connectedProjectIds.length) || byName(a, b);
+  else if (sort === 'Environments') cmp = (a, b) => (b.environmentsOn.length - a.environmentsOn.length) || byName(a, b);
+  else if (sort === 'Last outcome') cmp = (a, b) => ((b.outcomeAt || 0) - (a.outcomeAt || 0)) || byName(a, b);
+  else {
+    // Actionability: what is broken, then what has never run, then what is not
+    // wired up, then name. Sorting 1,228 tenants alphabetically puts the ones
+    // that need someone on page nine.
+    const rank = r => r.needsAttention ? 0 : (r.neverDeployed ? 1 : (r.notConnected ? 2 : 3));
+    cmp = (a, b) => (rank(a) - rank(b)) || ((b.outcomeAt || 0) - (a.outcomeAt || 0)) || byName(a, b);
+  }
+  return copy.sort((a, b) => flip * cmp(a, b));
 }
 
 function filterTenants(rows, query, selected) {
@@ -1290,7 +1311,7 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable,
   viewNeedsEstate,
   fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
-  parseTenantTag, tenantOutcomeKey, TENANT_SORTS }; }
+  parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1305,5 +1326,5 @@ if (typeof module !== 'undefined') {
     fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue,
     viewNeedsEstate,
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
-    parseTenantTag, tenantOutcomeKey, TENANT_SORTS };
+    parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -94,14 +94,33 @@ async function hydrateSpace(sp) {
     return [];
   });
   try {
+    // Machines are the one resource the rest of the estate is derived from, so
+    // how they fail decides whether the space is usable at all:
+    //
+    //   403 or 401 — a permissions boundary inside the space. The environments,
+    //     worker pools and tenants that did come back are worth showing, and
+    //     claiming the space is unreadable hides them for no reason.
+    //   anything else — a genuinely failed read. The space is unreliable and
+    //     saying so is better than rendering half of it, which is the original
+    //     decision here and still the right one.
+    let machinesError = null;
+    const machineFetch = fetchJson('/api/' + sp.Id + '/machines/all').catch(e => {
+      machinesError = e || new Error('machines');
+      failed.push('machines');
+      if (e && e.auth) auth = true;
+      return [];
+    });
     const [envs, policies, tenants, machines, workerpools, workers] = await Promise.all([
       soft('environments', '/api/' + sp.Id + '/environments/all'),
       soft('policies',     '/api/' + sp.Id + '/machinepolicies/all'),
       soft('tenants',      '/api/' + sp.Id + '/tenants/all'),
-      fetchJson('/api/' + sp.Id + '/machines/all'),
+      machineFetch,
       soft('workerpools',  '/api/' + sp.Id + '/workerpools/all'),
       soft('workers',      '/api/' + sp.Id + '/workers/all')
     ]);
+    if (machinesError && !machinesError.auth) return null;
+    // Nothing at all came back: a space you cannot read, worth saying plainly.
+    if (failed.length === 6) return null;
     return { sp, envs, policies, tenants, machines, workerpools, workers, failed, auth };
   } catch (e) { return null; }
 }
@@ -240,6 +259,9 @@ function filterEnvRows(rows, query, mode) {
 // were already on is a dead end, and a space with no targets can still hold environments,
 // machine policies and a route out via the add-target walkthrough.
 function coldStartApplies(view, estate) {
+  // Being unable to read targets is not the same as having none, and inviting
+  // someone to add infrastructure they simply cannot see would be wrong.
+  if (estate && estate.failed && estate.failed.machines) return false;
   return view === 'overview' && isEmptyEstate(estate);
 }
 
@@ -340,7 +362,7 @@ function buildEstate(perSpace) {
   });
   // Which resources couldn't be read for the spaces in scope. A view consults this before
   // telling the user a collection is empty.
-  const failed = { environments:false, policies:false, tenants:false, workerpools:false, workers:false };
+  const failed = { environments:false, policies:false, tenants:false, workerpools:false, workers:false, machines:false };
   perSpace.forEach(s => (s.failed || []).forEach(k => { if (k in failed) failed[k] = true; }));
   return { targets, workers, environments, policies, failed,
     overview: overviewModel(targets, workers) };

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -554,15 +554,138 @@ function applyFilters(targets, filters, search) {
   });
 }
 
+
+// ─── Releases ────────────────────────────────────────────────────────────────
+// "What is running in each environment" is one request. The project dashboard
+// returns every deployment the server considers current, one item per
+// project/environment/tenant — so an untenanted project yields a single item in
+// an environment and a tenanted one yields several, which is how a part-way
+// rollout shows two releases living in Production at once.
+//
+// It is fetched on first visit to the section rather than during boot. Boot
+// already costs six requests per space, and someone who never opens Releases
+// should not pay for it.
+
+async function fetchDashboard(spaceId) {
+  return fetchJson('/api/' + spaceId + '/dashboard');
+}
+
+// Task states collapse to the four outcomes worth drawing differently. Queued
+// and Executing are both "in flight" to a reader; Canceled and TimedOut are
+// their own thing and are deliberately not folded into failed, because a
+// deployment someone stopped is a different fact from one that broke.
+function releaseStateKey(state) {
+  if (state === 'Success') return 'success';
+  if (state === 'Executing' || state === 'Queued') return 'running';
+  if (state === 'Failed') return 'failed';
+  if (state === 'TimedOut') return 'timedout';
+  if (state === 'Canceled' || state === 'Cancelled') return 'cancelled';
+  return 'unknown';
+}
+function releaseStateLabel(key) {
+  if (key === 'success') return 'Succeeded';
+  if (key === 'running') return 'In progress';
+  if (key === 'failed') return 'Failed';
+  if (key === 'timedout') return 'Timed out';
+  if (key === 'cancelled') return 'Cancelled';
+  return 'Unknown';
+}
+
+// A boundary between two environments is strong when they hold a release in
+// common — the change has flowed through — and pale when they hold different
+// ones. Either side being empty means there is nothing to compare, so no line
+// is drawn at all rather than a line implying a relationship.
+function linkTone(prevVersions, versions) {
+  if (!prevVersions.length || !versions.length) return 'none';
+  return prevVersions.some(v => versions.indexOf(v) !== -1) ? 'strong' : 'pale';
+}
+
+function releasesModel(dash) {
+  const d = dash || {};
+  const environments = (d.Environments || []).map(e => ({ id: e.Id, name: e.Name }));
+  const tenantNames = {};
+  (d.Tenants || []).forEach(t => { tenantNames[t.Id] = t.Name; });
+  const groupNames = {};
+  (d.ProjectGroups || []).forEach(g => { groupNames[g.Id] = g.Name; });
+
+  // project id -> env id -> version -> aggregate
+  const byProject = {};
+  (d.Items || []).forEach(item => {
+    if (!item || !item.IsCurrent) return;
+    const pid = item.ProjectId, eid = item.EnvironmentId, ver = item.ReleaseVersion;
+    if (!pid || !eid || ver == null) return;
+    const envs = byProject[pid] || (byProject[pid] = {});
+    const vers = envs[eid] || (envs[eid] = {});
+    const when = item.CompletedTime || item.StartTime || item.QueueTime || item.Created || null;
+    const agg = vers[ver] || (vers[ver] = { version: ver, stateKey: null, when: null, tenants: [] });
+    // Most recent item wins the state, so an environment mid-redeploy reads as
+    // in progress rather than showing whichever item happened to come first.
+    if (!agg.when || (when && when > agg.when)) { agg.when = when; agg.stateKey = releaseStateKey(item.State); }
+    if (!agg.stateKey) agg.stateKey = releaseStateKey(item.State);
+    if (item.TenantId) agg.tenants.push(item.TenantId);
+  });
+
+  const projects = (d.Projects || []).map(p => {
+    const envMap = byProject[p.Id] || {};
+    const cells = environments.map(env => {
+      const vers = envMap[env.id] || {};
+      const entries = Object.keys(vers).map(v => {
+        const a = vers[v];
+        return {
+          version: a.version,
+          stateKey: a.stateKey || 'unknown',
+          stateLabel: releaseStateLabel(a.stateKey || 'unknown'),
+          when: a.when,
+          tenantCount: a.tenants.length,
+          tenantNames: a.tenants.map(id => tenantNames[id] || id)
+        };
+      }).sort((x, y) => String(y.when || '').localeCompare(String(x.when || '')));
+      // A tenanted project can have dozens of releases live in one environment at
+      // once — 41 in one cell on Cloud Platform. The cell reports the spread so
+      // the view can name the newest and summarise the rest instead of stacking
+      // forty labels into a column.
+      const tenantTotal = entries.reduce((n, e) => n + e.tenantCount, 0);
+      return {
+        envId: env.id, envName: env.name, entries: entries,
+        versionCount: entries.length, tenantTotal: tenantTotal
+      };
+    });
+    const links = cells.map((c, i) =>
+      i === 0 ? null : linkTone(cells[i - 1].entries.map(e => e.version), c.entries.map(e => e.version)));
+    const deployed = cells.reduce((n, c) => n + (c.entries.length ? 1 : 0), 0);
+    return {
+      id: p.Id, name: p.Name, slug: p.Slug,
+      groupId: p.ProjectGroupId, groupName: groupNames[p.ProjectGroupId] || '',
+      cells: cells, links: links, deployedCount: deployed
+    };
+  }).sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+  // The server caps how many projects the dashboard returns. Reporting the cap
+  // matters more here than elsewhere: a capped list looks exactly like a small
+  // instance, and someone reading "3 projects" has no way to tell which it is.
+  return {
+    environments: environments,
+    projects: projects,
+    truncated: {
+      projectLimit: typeof d.ProjectLimit === 'number' ? d.ProjectLimit : null,
+      isFiltered: !!d.IsFiltered,
+      shown: projects.length,
+      capped: typeof d.ProjectLimit === 'number' && projects.length >= d.ProjectLimit
+    }
+  };
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
-  vkey, majorVersion, versionBand, deriveLatest, agentsModel }; }
+  vkey, majorVersion, versionBand, deriveLatest, agentsModel,
+  fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
     healthLabel, healthKey, healthKeyLabel, commLabel, kindLabel, typeGroup, envCat, extractVersion, osLabel, osVersionLabel,
     machineToTarget, buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
     workersModel, workerFacets, applyWorkerFilters,
-    vkey, majorVersion, versionBand, deriveLatest, agentsModel };
+    vkey, majorVersion, versionBand, deriveLatest, agentsModel,
+    fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1093,10 +1093,190 @@ function variableChangeLabel(change) {
 // dashboard directly, so a space whose machines we are not permitted to read
 // still has a working Projects tab — /machines/all can 403 while /dashboard
 // returns 200, which is exactly the case on Cloud Platform.
-const ESTATE_FREE_VIEWS = ['projects'];
+const ESTATE_FREE_VIEWS = ['projects', 'tenants'];
 
 function viewNeedsEstate(view) {
   return ESTATE_FREE_VIEWS.indexOf(view) === -1;
+}
+
+
+// ─── Tenants ─────────────────────────────────────────────────────────────────
+// A tenant has no health status of its own, so its state has to be composed
+// from facts that are independent of each other and must stay that way:
+//
+//   Connection    can it be deployed to at all
+//   Last outcome  did the last attempt work
+//   Currency      is what runs on it current (needs a project scope — see below)
+//   Readiness     would a deployment succeed on config
+//
+// Merging those into one badge would hide which of four different problems a
+// tenant has. Readiness is absent here on purpose: it needs a request per
+// tenant, which is fine on a detail page and impossible across a list.
+//
+// The list costs three requests regardless of tenant count — the tenant pages,
+// one dashboard, and the tag sets — because the dashboard already carries every
+// tenant's current deployments.
+
+const TENANT_PAGE = 100;
+const TENANT_MAX_PAGES = 20;
+const STUCK_DAYS = 7;
+
+async function fetchTenants(spaceId) {
+  let items = [], total = null, page = 0;
+  while (page < TENANT_MAX_PAGES) {
+    const res = await fetchJson('/api/' + spaceId + '/tenants?skip=' + (page * TENANT_PAGE) + '&take=' + TENANT_PAGE);
+    const batch = (res && res.Items) || [];
+    if (total == null) total = res && typeof res.TotalResults === 'number' ? res.TotalResults : batch.length;
+    items = items.concat(batch);
+    if (!batch.length || items.length >= total) break;
+    page++;
+  }
+  return { items: items, total: total == null ? items.length : total, truncated: items.length < (total || 0) };
+}
+
+async function fetchTagSets(spaceId) {
+  return fetchJson('/api/' + spaceId + '/tagsets/all');
+}
+
+/** Tenant tags arrive as "SetName/TagName". The sets are whatever the instance
+ *  defines, so the facet groups are read from the data rather than assumed. */
+function parseTenantTag(raw) {
+  const str = String(raw || '');
+  const slash = str.indexOf('/');
+  if (slash === -1) return { set: '', name: str, raw: str };
+  return { set: str.slice(0, slash), name: str.slice(slash + 1), raw: str };
+}
+
+function tenantOutcomeKey(state, at, now) {
+  const key = releaseStateKey(state);
+  // A task still running after a week is not "in progress" in any useful sense.
+  if (key === 'running' && at && ((now || Date.now()) - at) > STUCK_DAYS * 86400000) return 'stuck';
+  return key;
+}
+
+function tenantsModel(payload) {
+  const src = payload || {};
+  const tenants = (src.tenants && src.tenants.items) || [];
+  const dash = src.dashboard || {};
+  const now = src.now || Date.now();
+
+  const projectName = {};
+  (dash.Projects || []).forEach(p => { projectName[p.Id] = p.Name; });
+  const envName = {};
+  (dash.Environments || []).forEach(e => { envName[e.Id] = e.Name; });
+
+  // One pass over the dashboard: every tenant's current deployments.
+  const byTenant = {};
+  (dash.Items || []).forEach(i => {
+    if (!i || !i.TenantId || !i.IsCurrent) return;
+    (byTenant[i.TenantId] || (byTenant[i.TenantId] = [])).push(i);
+  });
+
+  const rows = tenants.map(t => {
+    const items = byTenant[t.Id] || [];
+    const pairs = t.ProjectEnvironments || {};
+    const connectedProjects = Object.keys(pairs);
+    const pairCount = connectedProjects.reduce((n, pid) => n + ((pairs[pid] || []).length), 0);
+
+    let last = null;
+    items.forEach(i => {
+      const at = Date.parse(i.CompletedTime || i.StartTime || i.QueueTime || i.Created || 0) || 0;
+      if (!last || at > last.at) last = { at: at, state: i.State, projectId: i.ProjectId };
+    });
+
+    const projectsOn = {}; const envsOn = {};
+    items.forEach(i => { projectsOn[i.ProjectId] = true; envsOn[i.EnvironmentId] = true; });
+
+    const outcome = last ? tenantOutcomeKey(last.state, last.at, now) : null;
+    return {
+      id: t.Id, name: t.Name, slug: t.Slug, disabled: !!t.IsDisabled,
+      description: t.Description || '',
+      tags: (t.TenantTags || []).map(parseTenantTag),
+      connected: pairCount > 0,
+      pairCount: pairCount,
+      connectedProjectIds: connectedProjects,
+      projectsOn: Object.keys(projectsOn),
+      environmentsOn: Object.keys(envsOn).map(id => envName[id] || id),
+      deployed: items.length > 0,
+      outcome: outcome,
+      outcomeLabel: outcome ? (outcome === 'stuck' ? 'Stuck' : releaseStateLabel(outcome)) : '',
+      outcomeAt: last ? last.at : null,
+      outcomeProject: last ? (projectName[last.projectId] || '') : '',
+      // Four independent facts, never merged into one score.
+      needsAttention: outcome === 'failed' || outcome === 'timedout' || outcome === 'stuck',
+      neverDeployed: pairCount > 0 && items.length === 0,
+      notConnected: pairCount === 0
+    };
+  });
+
+  return {
+    tenants: rows,
+    total: (src.tenants && src.tenants.total) || rows.length,
+    truncated: !!(src.tenants && src.tenants.truncated),
+    tagSets: (src.tagSets || []).map(ts => ({
+      name: ts.Name,
+      tags: (ts.Tags || []).map(tag => ({ name: tag.Name, colour: tag.Color || '' }))
+    })),
+    projects: (dash.Projects || []).map(p => ({ id: p.Id, name: p.Name })),
+    environments: (dash.Environments || []).map(e => ({ id: e.Id, name: e.Name })),
+    counts: {
+      needsAttention: rows.filter(r => r.needsAttention).length,
+      neverDeployed: rows.filter(r => r.neverDeployed).length,
+      notConnected: rows.filter(r => r.notConnected).length
+    }
+  };
+}
+
+/** Actionability, not alphabet: what is broken, then what has never run, then
+ *  what is not wired up, then name. Sorting 1,228 tenants by name puts the ones
+ *  that need someone on page nine. */
+const TENANT_SORTS = ['Actionability', 'Name', 'Last activity'];
+
+function sortTenants(rows, sort) {
+  const copy = rows.slice();
+  if (sort === 'Name') return copy.sort((a, b) => String(a.name).localeCompare(String(b.name)));
+  if (sort === 'Last activity') return copy.sort((a, b) => (b.outcomeAt || 0) - (a.outcomeAt || 0));
+  const rank = r => r.needsAttention ? 0 : (r.neverDeployed ? 1 : (r.notConnected ? 2 : 3));
+  return copy.sort((a, b) => (rank(a) - rank(b))
+    || ((b.outcomeAt || 0) - (a.outcomeAt || 0))
+    || String(a.name).localeCompare(String(b.name)));
+}
+
+function filterTenants(rows, query, selected) {
+  const q = String(query || '').trim().toLowerCase();
+  const sel = selected || {};
+  const tagsWanted = Object.keys(sel.tags || {}).filter(k => sel.tags[k]);
+  const envsWanted = Object.keys(sel.environments || {}).filter(k => sel.environments[k]);
+  const projWanted = Object.keys(sel.projects || {}).filter(k => sel.projects[k]);
+  const stateWanted = Object.keys(sel.state || {}).filter(k => sel.state[k]);
+
+  return rows.filter(r => {
+    if (q && String(r.name).toLowerCase().indexOf(q) === -1
+        && String(r.id).toLowerCase().indexOf(q) === -1) return false;
+    if (tagsWanted.length && !tagsWanted.every(t => r.tags.some(x => x.raw === t))) return false;
+    if (envsWanted.length && !envsWanted.some(e => r.environmentsOn.indexOf(e) !== -1)) return false;
+    if (projWanted.length && !projWanted.some(p => r.connectedProjectIds.indexOf(p) !== -1)) return false;
+    if (stateWanted.length) {
+      const has = stateWanted.some(st =>
+        (st === 'needs-attention' && r.needsAttention) ||
+        (st === 'never-deployed' && r.neverDeployed) ||
+        (st === 'not-connected' && r.notConnected));
+      if (!has) return false;
+    }
+    return true;
+  });
+}
+
+/** Facet counts are computed against everything else that is selected, so a
+ *  count never promises rows that clicking it would not produce. */
+function tenantFacets(rows, query, selected) {
+  const count = (key, value) => {
+    const probe = JSON.parse(JSON.stringify(selected || {}));
+    probe[key] = probe[key] || {};
+    probe[key][value] = true;
+    return filterTenants(rows, query, probe).length;
+  };
+  return { count: count };
 }
 
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1108,7 +1288,9 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
   fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
   fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable,
-  viewNeedsEstate }; }
+  viewNeedsEstate,
+  fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
+  parseTenantTag, tenantOutcomeKey, TENANT_SORTS }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1121,5 +1303,7 @@ if (typeof module !== 'undefined') {
     fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
     fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
     fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue,
-    viewNeedsEstate };
+    viewNeedsEstate,
+    fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
+    parseTenantTag, tenantOutcomeKey, TENANT_SORTS };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1344,40 +1344,80 @@ async function fetchTenantMachines(spaceId) {
   return { items: items, total: total == null ? items.length : total, truncated: items.length < (total || 0) };
 }
 
-function tenantReadiness(variables, connectedEnvIdsByProject, envName) {
+// Readiness, triangulated against what has actually deployed.
+//
+// Two things were wrong when this only diffed templates against values. It
+// counted a template once per environment, so two unset templates across three
+// environments read as "6 missing variables". And it asserted that a deployment
+// would fail, which live data contradicts: tenants with unset templates have
+// deployed successfully, because a tenant variable template is a request for a
+// value, not a guarantee the process uses it.
+//
+// So the count is distinct templates, the environments are reported beside them,
+// and any pair that has already deployed successfully is marked as proven — an
+// unset value that a real deployment survived is not a blocker, whatever the
+// template says.
+function tenantReadiness(variables, connectedEnvIdsByProject, envName, succeededPairs) {
   const v = variables || {};
+  const proven = succeededPairs || {};
   const missing = [];
-  let templates = 0;
   const blocks = [];
-  Object.keys(v.ProjectVariables || {}).forEach(pid => blocks.push({ scope: 'project', id: pid, block: v.ProjectVariables[pid] }));
-  Object.keys(v.LibraryVariables || {}).forEach(lid => blocks.push({ scope: 'library', id: lid, block: v.LibraryVariables[lid] }));
+  Object.keys(v.ProjectVariables || {}).forEach(pid =>
+    blocks.push({ scope: 'project', id: pid, block: v.ProjectVariables[pid] }));
+  Object.keys(v.LibraryVariables || {}).forEach(lid =>
+    blocks.push({ scope: 'library', id: lid, block: v.LibraryVariables[lid] }));
+
+  // Library sets are not owned by one project, so they are checked against every
+  // environment this tenant is connected to anywhere.
+  const allEnvIds = [];
+  Object.keys(connectedEnvIdsByProject || {}).forEach(pid =>
+    (connectedEnvIdsByProject[pid] || []).forEach(eid => { if (allEnvIds.indexOf(eid) === -1) allEnvIds.push(eid); }));
 
   blocks.forEach(entry => {
     const b = entry.block || {};
     const tmpl = b.Templates || [];
     if (!tmpl.length) return;
-    // Only environments this tenant is actually connected to can be missing a
-    // value; asking for one it never deploys to would invent a problem.
+    const projectId = b.ProjectId || entry.id;
     const envs = entry.scope === 'project'
-      ? ((connectedEnvIdsByProject || {})[entry.ProjectId || b.ProjectId || entry.id] || [])
-      : Object.keys(b.Variables || {});
-    const scopeName = b.ProjectName || b.LibraryVariableSetName || '';
-    envs.forEach(envId => {
-      const values = (b.Variables || {})[envId] || {};
-      tmpl.forEach(t => {
-        templates++;
+      ? ((connectedEnvIdsByProject || {})[projectId] || [])
+      : allEnvIds;
+
+    tmpl.forEach(t => {
+      const hasDefault = !(t.DefaultValue === undefined || t.DefaultValue === null || t.DefaultValue === '');
+      if (hasDefault) return;
+      const unsetIn = [];
+      let anyProven = false;
+      envs.forEach(envId => {
+        const values = (b.Variables || {})[envId] || {};
         const supplied = values[t.Id];
-        const hasValue = !(supplied === undefined || supplied === null || supplied === '');
-        const hasDefault = !(t.DefaultValue === undefined || t.DefaultValue === null || t.DefaultValue === '');
-        if (!hasValue && !hasDefault) {
-          missing.push({ scope: scopeName, environment: (envName || {})[envId] || envId,
-            name: t.Label || t.Name || t.Id });
+        if (supplied === undefined || supplied === null || supplied === '') {
+          unsetIn.push({ envId: envId, environment: (envName || {})[envId] || envId,
+            proven: !!proven[projectId + '|' + envId] });
+          if (proven[projectId + '|' + envId]) anyProven = true;
         }
       });
+      if (unsetIn.length) {
+        missing.push({
+          templateId: t.Id, name: t.Label || t.Name || t.Id,
+          scope: b.ProjectName || b.LibraryVariableSetName || '',
+          scopeKind: entry.scope,
+          environments: unsetIn.map(u => u.environment),
+          // Deployed successfully somewhere with this unset: evidently optional.
+          proven: anyProven
+        });
+      }
     });
   });
 
-  return { missing: missing, count: missing.length, templates: templates, ready: missing.length === 0 };
+  const unproven = missing.filter(m => !m.proven);
+  return {
+    missing: missing,
+    count: missing.length,                 // distinct templates, not template × environment
+    pairCount: missing.reduce((n, m) => n + m.environments.length, 0),
+    unprovenCount: unproven.length,
+    proven: missing.length > 0 && unproven.length === 0,
+    ready: missing.length === 0
+  };
 }
 
 function matchTenantTargets(machines, tenant) {
@@ -1453,6 +1493,14 @@ function tenantDetailModel(payload) {
   const connectedEnvIdsByProject = {};
   projectIds.forEach(pid => { connectedEnvIdsByProject[pid] = pairs[pid] || []; });
 
+  // Which project-environment pairs have actually deployed successfully. An
+  // unset variable on a pair that has shipped is not the blocker the template
+  // implies, and saying otherwise contradicts what the tenant has been doing.
+  const succeededPairs = {};
+  items.forEach(i => {
+    if (releaseStateKey(i.State) === 'success') succeededPairs[i.ProjectId + '|' + i.EnvironmentId] = true;
+  });
+
   const activity = items.slice().sort((a, b) =>
     (Date.parse(b.CompletedTime || b.StartTime || 0) || 0) - (Date.parse(a.CompletedTime || a.StartTime || 0) || 0))
     .slice(0, 8).map(i => {
@@ -1470,7 +1518,8 @@ function tenantDetailModel(payload) {
     connection: { connected: pairCount > 0, pairCount: pairCount, projectCount: projectIds.length },
     lastOutcome: last ? { key: lastKey, label: lastKey === 'stuck' ? 'Stuck' : releaseStateLabel(lastKey),
       when: last.at, projectName: projectName[last.projectId] || '' } : null,
-    readiness: src.variables ? tenantReadiness(src.variables, connectedEnvIdsByProject, envName) : null,
+    readiness: src.variables
+      ? tenantReadiness(src.variables, connectedEnvIdsByProject, envName, succeededPairs) : null,
     readinessError: src.variablesError || null,
     environments: orderedEnvIds.map(id => ({ id: id, name: envName[id] || id })),
     matrix: matrix,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1300,6 +1300,182 @@ function tenantFacets(rows, query, selected) {
   return { count: count };
 }
 
+
+// ─── Tenant detail ───────────────────────────────────────────────────────────
+// The four facts again, one tenant deep. Two of them cost a request each and
+// are worth it here in a way they are not across a list.
+//
+// Readiness: /tenants/{id}/variables returns Templates (what a project requires
+// of its tenants) beside Variables, keyed by environment and then by template
+// id. A template is satisfied by a value for that environment or by its own
+// DefaultValue; anything else is missing, and a deployment would fail on it.
+//
+// Infrastructure: a target is DEDICATED when it names the tenant in TenantIds
+// and SHARED when one of its TenantTags matches one of the tenant's. Machines
+// can 403 — Cloud Platform does — so the panel degrades rather than blocking
+// the page.
+
+const TENANT_MACHINE_PAGE = 100;
+const TENANT_MACHINE_MAX_PAGES = 10;
+
+async function fetchTenant(spaceId, tenantId) {
+  return fetchJson('/api/' + spaceId + '/tenants/' + encodeURIComponent(tenantId));
+}
+
+async function fetchTenantVariables(spaceId, tenantId) {
+  return fetchJson('/api/' + spaceId + '/tenants/' + encodeURIComponent(tenantId) + '/variables');
+}
+
+async function fetchTenantMachines(spaceId) {
+  let items = [], total = null, page = 0;
+  while (page < TENANT_MACHINE_MAX_PAGES) {
+    const res = await fetchJson('/api/' + spaceId + '/machines?skip=' + (page * TENANT_MACHINE_PAGE)
+      + '&take=' + TENANT_MACHINE_PAGE);
+    const batch = (res && res.Items) || [];
+    if (total == null) total = res && typeof res.TotalResults === 'number' ? res.TotalResults : batch.length;
+    items = items.concat(batch);
+    if (!batch.length || items.length >= total) break;
+    page++;
+  }
+  return { items: items, total: total == null ? items.length : total, truncated: items.length < (total || 0) };
+}
+
+function tenantReadiness(variables, connectedEnvIdsByProject, envName) {
+  const v = variables || {};
+  const missing = [];
+  let templates = 0;
+  const blocks = [];
+  Object.keys(v.ProjectVariables || {}).forEach(pid => blocks.push({ scope: 'project', id: pid, block: v.ProjectVariables[pid] }));
+  Object.keys(v.LibraryVariables || {}).forEach(lid => blocks.push({ scope: 'library', id: lid, block: v.LibraryVariables[lid] }));
+
+  blocks.forEach(entry => {
+    const b = entry.block || {};
+    const tmpl = b.Templates || [];
+    if (!tmpl.length) return;
+    // Only environments this tenant is actually connected to can be missing a
+    // value; asking for one it never deploys to would invent a problem.
+    const envs = entry.scope === 'project'
+      ? ((connectedEnvIdsByProject || {})[entry.ProjectId || b.ProjectId || entry.id] || [])
+      : Object.keys(b.Variables || {});
+    const scopeName = b.ProjectName || b.LibraryVariableSetName || '';
+    envs.forEach(envId => {
+      const values = (b.Variables || {})[envId] || {};
+      tmpl.forEach(t => {
+        templates++;
+        const supplied = values[t.Id];
+        const hasValue = !(supplied === undefined || supplied === null || supplied === '');
+        const hasDefault = !(t.DefaultValue === undefined || t.DefaultValue === null || t.DefaultValue === '');
+        if (!hasValue && !hasDefault) {
+          missing.push({ scope: scopeName, environment: (envName || {})[envId] || envId,
+            name: t.Label || t.Name || t.Id });
+        }
+      });
+    });
+  });
+
+  return { missing: missing, count: missing.length, templates: templates, ready: missing.length === 0 };
+}
+
+function matchTenantTargets(machines, tenant) {
+  const list = (machines && machines.items) || [];
+  const wantedTags = (tenant && tenant.TenantTags) || [];
+  const dedicated = [], shared = [];
+  list.forEach(m => {
+    if ((m.TenantIds || []).indexOf(tenant.Id) !== -1) {
+      dedicated.push({ id: m.Id, name: m.Name, health: m.HealthStatus, disabled: !!m.IsDisabled,
+        environmentIds: m.EnvironmentIds || [], via: null });
+      return;
+    }
+    const hit = (m.TenantTags || []).find(tag => wantedTags.indexOf(tag) !== -1);
+    if (hit) shared.push({ id: m.Id, name: m.Name, health: m.HealthStatus, disabled: !!m.IsDisabled,
+      environmentIds: m.EnvironmentIds || [], via: hit });
+  });
+  const all = dedicated.concat(shared);
+  return {
+    dedicated: dedicated, shared: shared, total: all.length,
+    healthy: all.filter(t => healthKey(t.health, t.disabled) === 'healthy').length,
+    // A tenant with no matching target has deployments that resolve to nothing.
+    orphaned: all.length === 0
+  };
+}
+
+function tenantDetailModel(payload) {
+  const src = payload || {};
+  const tenant = src.tenant || {};
+  const dash = src.dashboard || {};
+  const now = src.now || Date.now();
+
+  const projectName = {}; (dash.Projects || []).forEach(p => { projectName[p.Id] = p.Name; });
+  const envName = {}; (dash.Environments || []).forEach(e => { envName[e.Id] = e.Name; });
+
+  const pairs = tenant.ProjectEnvironments || {};
+  const projectIds = Object.keys(pairs);
+  const pairCount = projectIds.reduce((n, pid) => n + ((pairs[pid] || []).length), 0);
+
+  const items = (dash.Items || []).filter(i => i && i.TenantId === tenant.Id && i.IsCurrent);
+  const byKey = {};
+  items.forEach(i => { byKey[i.ProjectId + '|' + i.EnvironmentId] = i; });
+
+  // Columns are the environments this tenant is connected to anywhere, so the
+  // matrix has no column that is blank for every row.
+  const envIds = [];
+  projectIds.forEach(pid => (pairs[pid] || []).forEach(eid => { if (envIds.indexOf(eid) === -1) envIds.push(eid); }));
+  const orderedEnvIds = (dash.Environments || []).map(e => e.Id).filter(id => envIds.indexOf(id) !== -1)
+    .concat(envIds.filter(id => !(dash.Environments || []).some(e => e.Id === id)));
+
+  const matrix = projectIds.map(pid => ({
+    projectId: pid,
+    projectName: projectName[pid] || pid,
+    cells: orderedEnvIds.map(eid => {
+      const connected = (pairs[pid] || []).indexOf(eid) !== -1;
+      const item = byKey[pid + '|' + eid];
+      if (!connected) return { envId: eid, envName: envName[eid] || eid, connected: false, deployed: false };
+      if (!item) return { envId: eid, envName: envName[eid] || eid, connected: true, deployed: false };
+      const at = Date.parse(item.CompletedTime || item.StartTime || item.QueueTime || item.Created || 0) || null;
+      const key = tenantOutcomeKey(item.State, at, now);
+      return { envId: eid, envName: envName[eid] || eid, connected: true, deployed: true,
+        version: item.ReleaseVersion, stateKey: key,
+        stateLabel: key === 'stuck' ? 'Stuck' : releaseStateLabel(key), when: at };
+    })
+  })).sort((a, b) => String(a.projectName).localeCompare(String(b.projectName)));
+
+  let last = null;
+  items.forEach(i => {
+    const at = Date.parse(i.CompletedTime || i.StartTime || i.QueueTime || i.Created || 0) || 0;
+    if (!last || at > last.at) last = { at: at, state: i.State, projectId: i.ProjectId };
+  });
+  const lastKey = last ? tenantOutcomeKey(last.state, last.at, now) : null;
+
+  const connectedEnvIdsByProject = {};
+  projectIds.forEach(pid => { connectedEnvIdsByProject[pid] = pairs[pid] || []; });
+
+  const activity = items.slice().sort((a, b) =>
+    (Date.parse(b.CompletedTime || b.StartTime || 0) || 0) - (Date.parse(a.CompletedTime || a.StartTime || 0) || 0))
+    .slice(0, 8).map(i => {
+      const at = Date.parse(i.CompletedTime || i.StartTime || i.QueueTime || 0) || null;
+      const key = tenantOutcomeKey(i.State, at, now);
+      return { projectName: projectName[i.ProjectId] || i.ProjectId, envName: envName[i.EnvironmentId] || i.EnvironmentId,
+        version: i.ReleaseVersion, stateKey: key, stateLabel: key === 'stuck' ? 'Stuck' : releaseStateLabel(key),
+        when: at, taskId: i.TaskId || '' };
+    });
+
+  return {
+    id: tenant.Id, name: tenant.Name || '', description: tenant.Description || '',
+    disabled: !!tenant.IsDisabled,
+    tags: (tenant.TenantTags || []).map(parseTenantTag),
+    connection: { connected: pairCount > 0, pairCount: pairCount, projectCount: projectIds.length },
+    lastOutcome: last ? { key: lastKey, label: lastKey === 'stuck' ? 'Stuck' : releaseStateLabel(lastKey),
+      when: last.at, projectName: projectName[last.projectId] || '' } : null,
+    readiness: src.variables ? tenantReadiness(src.variables, connectedEnvIdsByProject, envName) : null,
+    readinessError: src.variablesError || null,
+    environments: orderedEnvIds.map(id => ({ id: id, name: envName[id] || id })),
+    matrix: matrix,
+    infrastructure: src.machines ? matchTenantTargets(src.machines, tenant) : null,
+    infrastructureError: src.machinesError || null,
+    activity: activity
+  };
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
@@ -1311,7 +1487,8 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable,
   viewNeedsEstate,
   fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
-  parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir }; }
+  parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
+  fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1326,5 +1503,6 @@ if (typeof module !== 'undefined') {
     fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue,
     viewNeedsEstate,
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
-    parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir };
+    parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
+    fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1081,6 +1081,17 @@ function variableChangeLabel(change) {
   return before + ' → ' + after;
 }
 
+
+// Which views depend on the infrastructure estate. Projects reads the project
+// dashboard directly, so a space whose machines we are not permitted to read
+// still has a working Projects tab — /machines/all can 403 while /dashboard
+// returns 200, which is exactly the case on Cloud Platform.
+const ESTATE_FREE_VIEWS = ['projects'];
+
+function viewNeedsEstate(view) {
+  return ESTATE_FREE_VIEWS.indexOf(view) === -1;
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
@@ -1089,7 +1100,8 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchProgression, progressionModel, HISTORY_WINDOWS,
   fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
   fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
-  fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable }; }
+  fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable,
+  viewNeedsEstate }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1101,5 +1113,6 @@ if (typeof module !== 'undefined') {
     fetchProgression, progressionModel, HISTORY_WINDOWS,
     fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
     fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
-    fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue };
+    fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue,
+    viewNeedsEstate };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -880,13 +880,38 @@ function flagEnvState(env) {
   if (!env) return { key: 'inherit', percent: null };
   if (!env.IsEnabled) return { key: 'off', percent: null };
   const pct = env.RolloutPercentage != null ? env.RolloutPercentage : env.ClientRolloutPercentage;
+  // Enabled at 0% is the first step of a staged rollout and reaches nobody, so
+  // it is off. The tenant resolver has always said so; this one said "on".
+  if (pct === 0) return { key: 'off', percent: 0 };
   if (pct != null && pct > 0 && pct < 100) return { key: 'partial', percent: pct };
   return { key: 'on', percent: pct == null ? 100 : pct };
 }
 
+/** What a flag does in one environment of a grid, with no override meaning the
+ *  flag's own default. Both project-level flag models resolve it this way; a
+ *  model that skipped the default called a flag "on everywhere" on the strength
+ *  of the one environment somebody had configured. */
+function flagStateInGrid(flag, envId) {
+  const envs = flag.Environments || [];
+  let found = null;
+  envs.forEach(e => { if (e.DeploymentEnvironmentId === envId) found = e; });
+  if (found) return flagEnvState(found);
+  return { key: flag.DefaultIsEnabled ? 'on' : 'off', percent: null, viaDefault: true };
+}
+
 /** A flag is in flight when it is part-way somewhere: a percentage between 0
  *  and 100, or on in one environment and off in another. */
-function flagIsInFlight(flag) {
+function flagIsInFlight(flag, gridEnvironments) {
+  // Against a grid, every environment counts — including the ones with no
+  // override, which fall back to the default. Without one, only configured
+  // environments can be compared, which is what the callers without a grid get.
+  const ids = (gridEnvironments || []).map(e => e.id);
+  if (ids.length) {
+    const states = {};
+    ids.forEach(id => { states[flagStateInGrid(flag, id).key] = true; });
+    if (states.partial) return true;
+    return !!(states.on && states.off);
+  }
   const envs = flag.Environments || [];
   if (!envs.length) return false;
   if (envs.some(e => flagEnvState(e).key === 'partial')) return true;
@@ -900,7 +925,7 @@ function featureFlagModel(payload, gridEnvironments) {
   const all = src.items || [];
   const envs = (gridEnvironments || []).map(e => ({ id: e.id, name: e.name }));
 
-  const inFlight = all.filter(flagIsInFlight).map(f => {
+  const inFlight = all.filter(f => flagIsInFlight(f, envs)).map(f => {
     const byEnv = {};
     (f.Environments || []).forEach(e => { byEnv[e.DeploymentEnvironmentId] = e; });
     const cells = envs.map(env => {
@@ -919,12 +944,15 @@ function featureFlagModel(payload, gridEnvironments) {
     };
   }).sort((a, b) => String(a.name).localeCompare(String(b.name)));
 
+  // Counted over the grid with the default resolved, so these agree with the
+  // project page's own flag panel. Counting over configured environments only
+  // called a flag on in one environment "on everywhere".
   const settled = { onEverywhere: 0, offEverywhere: 0, noOverrides: 0 };
   all.forEach(f => {
-    if (flagIsInFlight(f)) return;
-    const envs2 = f.Environments || [];
-    if (!envs2.length) settled.noOverrides++;
-    else if (envs2.every(e => e.IsEnabled)) settled.onEverywhere++;
+    if (flagIsInFlight(f, envs)) return;
+    if (!(f.Environments || []).length || !envs.length) { settled.noOverrides++; return; }
+    const states = envs.map(env => flagStateInGrid(f, env.id).key);
+    if (states.every(k => k === 'on')) settled.onEverywhere++;
     else settled.offEverywhere++;
   });
 
@@ -973,12 +1001,16 @@ function flagChangeModel(events, gridEnvironments, windowHours, now) {
         const before = (ctx.Environments || [])[idx] || null;
         const envId = (after && after.DeploymentEnvironmentId)
           || (before && before.DeploymentEnvironmentId) || null;
-        // Only environments the grid is showing; an override for an environment
-        // this project never deploys to has no column to sit in.
-        if (!envId || !(envId in envName)) return;
+        if (!envId) return;
+        // An override for an environment this grid does not show has no column
+        // to sit in, but dropping it made a real audit entry disappear without
+        // trace. It is kept and marked, the way variable changes already are, so
+        // the band can say how many it is not showing.
+        const inGrid = envId in envName;
         changes.push({
           id: ev.Id + ':' + dIndex, flagName: name, scope: 'environment',
-          envId: envId, envName: envName[envId], occurred: at,
+          envId: envId, envName: inGrid ? envName[envId] : '', scopedElsewhere: !inGrid,
+          occurred: at,
           before: before ? flagEnvState(before) : null,
           after: after ? flagEnvState(after) : null,
           username: ev.Username || ''
@@ -1004,7 +1036,7 @@ function flagChangeModel(events, gridEnvironments, windowHours, now) {
 function flagChangeLabel(change) {
   const side = st => {
     if (!st) return 'no override';
-    if (st.key === 'off') return 'Off';
+    if (st.key === 'off') return st.percent === 0 ? '0%' : 'Off';
     if (st.key === 'partial') return st.percent + '%';
     if (st.key === 'on') return st.percent != null && st.percent < 100 ? st.percent + '%' : 'On';
     return 'default';
@@ -1063,16 +1095,29 @@ function variableChangeModel(events, gridEnvironments, windowHours, now) {
     if (cutoff != null && at < cutoff) return;
     const vars = ctx.Variables || [];
 
+    // A JSON Patch path points into the document as it stands when that op is
+    // applied, not into the original. An add or remove earlier in the same event
+    // shifts every index after it, so replaying the ops against a working copy
+    // is the only way the index means what it says. Reading them all against the
+    // original named the wrong variable whenever an event did more than one thing.
+    const working = vars.slice();
+
     (cd.Differences || []).forEach((d, dIndex) => {
       const path = String(d.path || '');
       const valueMatch = /^\/Variables\/(\d+)\/Value$/.exec(path);
       const wholeMatch = /^\/Variables\/(\d+)$/.exec(path);
-      if (!valueMatch && !wholeMatch) return;
+      if (!valueMatch && !wholeMatch) {
+        // Still has to move the working copy along, or the next index is wrong.
+        applyVariablePatch(working, d);
+        return;
+      }
 
       const idx = Number((valueMatch || wholeMatch)[1]);
-      const before = vars[idx] || null;
-      const after = wholeMatch ? (d.value || null) : null;
+      const op = String(d.op || '').toLowerCase();
+      const before = working[idx] || null;
+      const after = (wholeMatch && op !== 'remove') ? (d.value || null) : null;
       const subject = before || after;
+      applyVariablePatch(working, d);
       if (!subject) return;
 
       const sensitive = isSensitiveVariable(before) || isSensitiveVariable(after);
@@ -1083,7 +1128,10 @@ function variableChangeModel(events, gridEnvironments, windowHours, now) {
       changes.push({
         id: ev.Id + ':' + dIndex,
         name: subject.Name || '(unnamed)',
-        kind: wholeMatch ? 'added' : 'value',
+        // The op was never read, so a deletion was announced as an addition on
+        // the day the variable disappeared.
+        kind: !wholeMatch ? 'value'
+          : (op === 'remove' ? 'removed' : (op === 'replace' ? 'replaced' : 'added')),
         sensitive: sensitive,
         // Never carry a sensitive value through, placeholder or not.
         before: sensitive || !valueMatch ? null : shortValue(before ? before.Value : null),
@@ -1100,10 +1148,23 @@ function variableChangeModel(events, gridEnvironments, windowHours, now) {
   return changes.sort((a, b) => b.occurred - a.occurred);
 }
 
+/** Applies just enough of a JSON Patch op to keep array indices aligned. */
+function applyVariablePatch(list, d) {
+  const path = String((d && d.path) || '');
+  const whole = /^\/Variables\/(\d+)$/.exec(path);
+  if (!whole) return;
+  const idx = Number(whole[1]);
+  const op = String((d && d.op) || '').toLowerCase();
+  if (op === 'add') list.splice(idx, 0, d.value || null);
+  else if (op === 'remove') list.splice(idx, 1);
+  else if (op === 'replace') list[idx] = d.value || null;
+}
 function variableChangeLabel(change) {
   if (!change) return '';
+  if (change.kind === 'removed') return change.sensitive ? 'secret deleted' : 'deleted';
   if (change.sensitive) return 'secret changed';
   if (change.kind === 'added') return 'added';
+  if (change.kind === 'replaced') return 'replaced';
   const before = change.before === '' ? 'empty' : change.before;
   const after = change.after === '' ? 'empty' : change.after;
   if (before == null && after == null) return 'changed';
@@ -1180,6 +1241,22 @@ function tenantOutcomeKey(state, at, now) {
   return key;
 }
 
+/** The server caps how many projects the dashboard returns. Every deployment
+ *  fact on the tenant pages comes out of that same payload, so a tenant whose
+ *  projects sit beyond the cap reads as never deployed. The projects list has
+ *  always said when it was capped; the tenant views inherited the data and not
+ *  the caveat. */
+function dashboardCap(dash) {
+  const d = dash || {};
+  const shown = (d.Projects || []).length;
+  return {
+    projectLimit: typeof d.ProjectLimit === 'number' ? d.ProjectLimit : null,
+    isFiltered: !!d.IsFiltered,
+    shown: shown,
+    capped: (typeof d.ProjectLimit === 'number' && shown >= d.ProjectLimit) || !!d.IsFiltered
+  };
+}
+
 function tenantsModel(payload) {
   const src = payload || {};
   const tenants = (src.tenants && src.tenants.items) || [];
@@ -1239,6 +1316,7 @@ function tenantsModel(payload) {
     tenants: rows,
     total: (src.tenants && src.tenants.total) || rows.length,
     truncated: !!(src.tenants && src.tenants.truncated),
+    dashboardCap: dashboardCap(dash),
     tagSets: (src.tagSets || []).map(ts => ({
       name: ts.Name,
       tags: (ts.Tags || []).map(tag => ({ name: tag.Name, colour: tag.Color || '' }))
@@ -1404,11 +1482,28 @@ function tenantReadiness(variables, connectedEnvIdsByProject, envName, succeeded
       ? ((connectedEnvIdsByProject || {})[projectId] || [])
       : allEnvIds;
 
+    // Two different payload shapes under one name. A project's variables are
+    // keyed environment then template, because a tenant can answer differently
+    // per environment. A library set's are keyed by template alone — the answer
+    // is per tenant. Reading a library set the project way finds nothing under
+    // an environment id and reports every common variable unset.
+    const isLibrary = entry.scope === 'library';
     tmpl.forEach(t => {
       const hasDefault = !(t.DefaultValue === undefined || t.DefaultValue === null || t.DefaultValue === '');
       if (hasDefault) return;
       const unsetIn = [];
       let anyProven = false;
+      if (isLibrary) {
+        const supplied = (b.Variables || {})[t.Id];
+        if (supplied === undefined || supplied === null || supplied === '') {
+          // One answer covers every environment, so it is one finding, not one
+          // per environment — counting it per environment inflated the total.
+          const provenAnywhere = envs.some(envId => proven[projectId + '|' + envId]);
+          missing.push({ name: t.Label || t.Name || t.Id, scope: b.LibraryVariableSetName || entry.id,
+            environments: [], proven: provenAnywhere });
+        }
+        return;
+      }
       envs.forEach(envId => {
         const values = (b.Variables || {})[envId] || {};
         const supplied = values[t.Id];
@@ -1460,8 +1555,13 @@ function matchTenantTargets(machines, tenant) {
   return {
     dedicated: dedicated, shared: shared, total: all.length,
     healthy: all.filter(t => healthKey(t.health, t.disabled) === 'healthy').length,
-    // A tenant with no matching target has deployments that resolve to nothing.
-    orphaned: all.length === 0
+    // Only true when the whole estate was read. Against a capped list, no match
+    // means the targets may be among the machines we never fetched, and saying
+    // "resolves to nothing" would be an assertion the read cannot support.
+    orphaned: all.length === 0 && !(machines && machines.truncated),
+    truncated: !!(machines && machines.truncated),
+    estateRead: (machines && machines.items ? machines.items.length : 0),
+    estateTotal: (machines && machines.total) || 0
   };
 }
 
@@ -1547,6 +1647,7 @@ function tenantDetailModel(payload) {
     matrix: matrix,
     infrastructure: src.machines ? matchTenantTargets(src.machines, tenant) : null,
     infrastructureError: src.machinesError || null,
+    dashboardCap: dashboardCap(dash),
     activity: activity
   };
 }
@@ -1769,10 +1870,13 @@ function projectFlagModel(payload, environmentIds, envName) {
       return { envId: id, envName: names[id] || id, key: st.key, percent: st.percent,
         viaDefault: !e, tenantCount: e ? ((e.TenantIds || []).length + (e.TenantTags || []).length) : 0 };
     });
+    // No environments is no evidence, not evidence of drift. These used to fall
+    // through to "between" and be reported as rolling out from nothing.
     const allOn = cells.length > 0 && cells.every(c => c.key === 'on');
     const allOff = cells.length > 0 && cells.every(c => c.key === 'off');
+    const settled = !cells.length ? 'unscoped' : (allOn ? 'on' : (allOff ? 'off' : 'between'));
     return { id: f.Id, name: f.Name, slug: f.Slug, defaultOn: !!f.DefaultIsEnabled,
-      cells: cells, settled: allOn ? 'on' : (allOff ? 'off' : 'between') };
+      cells: cells, settled: settled };
   }).sort((a, b) => String(a.name).localeCompare(String(b.name)));
 
   const between = flags.filter(f => f.settled === 'between');
@@ -1802,12 +1906,22 @@ function projectTargets(machines, roles, environmentIds, tenantedMode) {
   const wantRoles = roles || [];
   const wantEnvs = environmentIds || [];
   if (!wantRoles.length) {
-    return { selectsByRole: false, matched: [], total: 0,
+    return { selectsByRole: false, scopeUnknown: false, matched: [], total: 0,
       healthy: 0, unhealthy: 0, disabled: 0, byRole: [], byEnvironment: [], tenanted: null };
+  }
+  // An empty environment list used to match every environment, so a project on
+  // the built-in Default Lifecycle (no phases) counted targets across the whole
+  // estate while the same page said it reached no environments. Unknown scope is
+  // reported as unknown rather than resolved against everything.
+  if (!wantEnvs.length) {
+    return { selectsByRole: true, scopeUnknown: true, matched: [], total: 0,
+      healthy: 0, unhealthy: 0, disabled: 0, byRole: [], byEnvironment: {}, tenanted: null,
+      truncated: !!(machines && machines.truncated), estateRead: list.length,
+      estateTotal: (machines && machines.total) || list.length };
   }
   const matched = list.filter(m =>
     (m.Roles || []).some(r => wantRoles.indexOf(r) !== -1)
-    && (!wantEnvs.length || (m.EnvironmentIds || []).some(e => wantEnvs.indexOf(e) !== -1)));
+    && (m.EnvironmentIds || []).some(e => wantEnvs.indexOf(e) !== -1));
 
   const counts = { healthy: 0, unhealthy: 0, disabled: 0 };
   matched.forEach(m => { counts[healthKey(m.HealthStatus, m.IsDisabled)]++; });
@@ -1833,6 +1947,9 @@ function projectTargets(machines, roles, environmentIds, tenantedMode) {
 
   return {
     selectsByRole: true,
+    truncated: !!(machines && machines.truncated),
+    estateRead: list.length,
+    estateTotal: (machines && machines.total) || list.length,
     matched: matched.map(m => ({ id: m.Id, name: m.Name, health: m.HealthStatus,
       disabled: !!m.IsDisabled, roles: m.Roles || [] })),
     total: matched.length,
@@ -1950,6 +2067,14 @@ function projectMapModel(payload) {
     triggers: triggers,
     process: process,
     processError: src.processError ? 'The deployment process could not be read.' : null,
+    // fetchProjectMap soft-catches each of these so one failure cannot cost the
+    // page. Dropping the errors here turned every one of them into a confident
+    // zero: "no triggers configured" for a 403, when every project has at least
+    // a Default channel and a lifecycle.
+    channelsError: src.channelsError ? 'Channels could not be read for this project.' : null,
+    triggersError: src.triggersError ? 'Triggers could not be read for this project.' : null,
+    tenantsError: src.tenantsError ? 'Connected tenants could not be counted.' : null,
+    lifecycleError: src.lifecycleError ? 'Lifecycles could not be read for this project.' : null,
     lifecycle: (src.lifecycle || {}).Name || '',
     lifecycles: lifecycles,
     lifecycleEnvironments: columns,
@@ -2003,7 +2128,7 @@ if (typeof module !== 'undefined') {
     fetchProgression, progressionModel, HISTORY_WINDOWS,
     fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
     fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
-    fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue,
+    fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue, applyVariablePatch,
     viewNeedsEstate,
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -732,6 +732,8 @@ async function fetchProgression(spaceId, projectId) {
     + '?releaseHistoryCount=' + PROGRESSION_HISTORY);
 }
 
+const GROUPINGS = ['Time', 'Type'];
+
 const HISTORY_WINDOWS = [
   { label: '24 hours', hours: 24 },
   { label: '7 days', hours: 24 * 7 },
@@ -900,13 +902,95 @@ function featureFlagModel(payload, gridEnvironments) {
   return { flags: inFlight, total: src.total || all.length, settled: settled, truncated: !!src.truncated };
 }
 
+
+// ─── Feature flag changes ────────────────────────────────────────────────────
+// Current state has no timestamp, so seeing a flag flip next to the release it
+// shipped with means reading the audit trail. Each event carries DocumentContext
+// (the document BEFORE the change) and Differences (a JSON patch describing the
+// change), which together give both ends of the arrow.
+//
+// Environment overrides arrive as a whole-object add or replace at
+// /Environments/N. An `add` has no before-state at that index, which is a real
+// distinction: no override existed, which is not the same as the flag being off.
+
+const FLAG_EVENT_TAKE = 100;
+
+async function fetchFlagEvents(spaceId, projectId) {
+  return fetchJson('/api/' + spaceId + '/events?documentTypes=FeatureToggles&projects='
+    + encodeURIComponent(projectId) + '&take=' + FLAG_EVENT_TAKE);
+}
+
+function flagChangeModel(events, gridEnvironments, windowHours, now) {
+  const items = (events && events.Items) || [];
+  const envName = {};
+  (gridEnvironments || []).forEach(e => { envName[e.id] = e.name; });
+  const cutoff = windowHours ? (now || Date.now()) - windowHours * 3600 * 1000 : null;
+
+  const changes = [];
+  items.forEach((ev, evIndex) => {
+    const cd = ev.ChangeDetails || {};
+    const ctx = cd.DocumentContext || {};
+    const name = ctx.Name || '';
+    const at = ev.Occurred ? Date.parse(ev.Occurred) : null;
+    if (at == null || isNaN(at)) return;
+    if (cutoff != null && at < cutoff) return;
+
+    (cd.Differences || []).forEach((d, dIndex) => {
+      const path = String(d.path || '');
+      const envMatch = /^\/Environments\/(\d+)$/.exec(path);
+      if (envMatch) {
+        const idx = Number(envMatch[1]);
+        const after = d.value || null;
+        const before = (ctx.Environments || [])[idx] || null;
+        const envId = (after && after.DeploymentEnvironmentId)
+          || (before && before.DeploymentEnvironmentId) || null;
+        // Only environments the grid is showing; an override for an environment
+        // this project never deploys to has no column to sit in.
+        if (!envId || !(envId in envName)) return;
+        changes.push({
+          id: ev.Id + ':' + dIndex, flagName: name, scope: 'environment',
+          envId: envId, envName: envName[envId], occurred: at,
+          before: before ? flagEnvState(before) : null,
+          after: after ? flagEnvState(after) : null,
+          username: ev.Username || ''
+        });
+        return;
+      }
+      if (path === '/DefaultIsEnabled') {
+        changes.push({
+          id: ev.Id + ':' + dIndex, flagName: name, scope: 'default',
+          envId: null, envName: '', occurred: at,
+          before: { key: ctx.DefaultIsEnabled ? 'on' : 'off', percent: null },
+          after: { key: d.value ? 'on' : 'off', percent: null },
+          username: ev.Username || ''
+        });
+      }
+    });
+  });
+
+  return changes.sort((a, b) => b.occurred - a.occurred);
+}
+
+/** "Off → 10%" — the arrow the whole audit reconstruction exists to produce. */
+function flagChangeLabel(change) {
+  const side = st => {
+    if (!st) return 'no override';
+    if (st.key === 'off') return 'Off';
+    if (st.key === 'partial') return st.percent + '%';
+    if (st.key === 'on') return st.percent != null && st.percent < 100 ? st.percent + '%' : 'On';
+    return 'default';
+  };
+  return side(change.before) + ' → ' + side(change.after);
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel,
   fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
   fetchProgression, progressionModel, HISTORY_WINDOWS,
-  fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight }; }
+  fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
+  fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -916,5 +1000,6 @@ if (typeof module !== 'undefined') {
     vkey, majorVersion, versionBand, deriveLatest, agentsModel,
     fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
     fetchProgression, progressionModel, HISTORY_WINDOWS,
-    fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight };
+    fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
+    fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1096,7 +1096,11 @@ function variableChangeLabel(change) {
 const ESTATE_FREE_VIEWS = ['projects', 'tenants'];
 
 function viewNeedsEstate(view) {
-  return ESTATE_FREE_VIEWS.indexOf(view) === -1;
+  // Detail routes carry an id — "tenants/Tenants-1" is still the tenants view.
+  // Matching the whole hash meant a tenant page counted as an infrastructure
+  // view, so cold start intercepted it with the first-run screen.
+  const base = String(view || '').split('/')[0];
+  return ESTATE_FREE_VIEWS.indexOf(base) === -1;
 }
 
 

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1698,7 +1698,8 @@ async function fetchProjectMap(spaceId, projectId) {
     soft(fetchJson('/api/' + spaceId + '/feeds?take=100')),
     soft(fetchJson('/api/' + spaceId + '/environments/all')),
     soft(fetchJson('/api/' + spaceId + '/tenants?projectId=' + encodeURIComponent(projectId) + '&take=1')),
-    soft(fetchTenantMachines(spaceId))
+    soft(fetchTenantMachines(spaceId)),
+    soft(fetchFeatureToggles(spaceId, projectId))
   ]);
   const channels = ((parts[1].v || {}).Items) || [];
   const defaultLifecycle = parts[3].v;
@@ -1723,7 +1724,8 @@ async function fetchProjectMap(spaceId, projectId) {
     lifecycles: lifecycles,
     feeds: parts[4].v, environments: parts[5].v,
     tenants: parts[6].v, tenantsError: parts[6].err,
-    machines: parts[7].v, machinesError: parts[7].err
+    machines: parts[7].v, machinesError: parts[7].err,
+    flags: parts[8].v, flagsError: parts[8].err
   };
 }
 
@@ -1744,6 +1746,48 @@ function triggerLabel(trigger) {
   return { kind: 'Trigger', detail: actionTypeLabel(kind) };
 }
 
+
+/** Where a project's feature flags stand across the environments its lifecycles
+ *  reach.
+ *
+ *  A flag with no setting for an environment falls back to its default, so the
+ *  default has to be resolved before "fully on" means anything — otherwise a
+ *  flag on by default everywhere reads as having no state at all.
+ */
+function projectFlagModel(payload, environmentIds, envName) {
+  const src = payload || {};
+  const all = src.items || [];
+  const envs = environmentIds || [];
+  const names = envName || {};
+
+  const flags = all.map(f => {
+    const byEnv = {};
+    (f.Environments || []).forEach(e => { byEnv[e.DeploymentEnvironmentId] = e; });
+    const cells = envs.map(id => {
+      const e = byEnv[id];
+      const st = e ? flagEnvState(e) : { key: f.DefaultIsEnabled ? 'on' : 'off', percent: null };
+      return { envId: id, envName: names[id] || id, key: st.key, percent: st.percent,
+        viaDefault: !e, tenantCount: e ? ((e.TenantIds || []).length + (e.TenantTags || []).length) : 0 };
+    });
+    const allOn = cells.length > 0 && cells.every(c => c.key === 'on');
+    const allOff = cells.length > 0 && cells.every(c => c.key === 'off');
+    return { id: f.Id, name: f.Name, slug: f.Slug, defaultOn: !!f.DefaultIsEnabled,
+      cells: cells, settled: allOn ? 'on' : (allOff ? 'off' : 'between') };
+  }).sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+  const between = flags.filter(f => f.settled === 'between');
+  return {
+    scoped: envs.length > 0,
+    environments: envs.map(id => names[id] || id),
+    flags: flags,
+    between: between,
+    fullyOn: flags.filter(f => f.settled === 'on').length,
+    fullyOff: flags.filter(f => f.settled === 'off').length,
+    betweenCount: between.length,
+    total: src.total || all.length,
+    truncated: !!src.truncated
+  };
+}
 
 /** What a project deploys to, and what shape that estate is in.
  *
@@ -1924,7 +1968,12 @@ function projectMapModel(payload) {
       });
     })(),
     targetsError: src.machinesError
-      ? 'Deployment targets cannot be read in this space, so what this project deploys to is unknown.' : null
+      ? 'Deployment targets cannot be read in this space, so what this project deploys to is unknown.' : null,
+    flags: src.flags ? projectFlagModel(src.flags, lifecycleEnvIds, envName) : null,
+    flagsError: src.flagsError
+      ? (/^(404|400)\b/.test(String(src.flagsError.code || ''))
+          ? 'Feature flags are not available on this instance.'
+          : 'Feature flags could not be read for this project.') : null
   };
 }
 
@@ -1942,7 +1991,7 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
   fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
   fetchTenantFlags, tenantFlagModel, flagStateForTenant,
-  fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets }; }
+  fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets, projectFlagModel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1960,5 +2009,5 @@ if (typeof module !== 'undefined') {
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
     fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
     fetchTenantFlags, tenantFlagModel, flagStateForTenant,
-    fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets };
+    fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets, projectFlagModel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1699,12 +1699,27 @@ async function fetchProjectMap(spaceId, projectId) {
     soft(fetchJson('/api/' + spaceId + '/environments/all')),
     soft(fetchJson('/api/' + spaceId + '/tenants?projectId=' + encodeURIComponent(projectId) + '&take=1'))
   ]);
+  const channels = ((parts[1].v || {}).Items) || [];
+  const defaultLifecycle = parts[3].v;
+  const extraIds = [];
+  channels.forEach(c => {
+    if (c.LifecycleId && c.LifecycleId !== project.LifecycleId && extraIds.indexOf(c.LifecycleId) === -1) {
+      extraIds.push(c.LifecycleId);
+    }
+  });
+  const extras = await Promise.all(extraIds.slice(0, 6).map(id =>
+    soft(fetchJson('/api/' + spaceId + '/lifecycles/' + encodeURIComponent(id)))));
+  const lifecycles = [];
+  if (defaultLifecycle) lifecycles.push(defaultLifecycle);
+  extras.forEach(r => { if (r.v) lifecycles.push(r.v); });
+
   return {
     project: project, branch: branch,
     process: parts[0].v, processError: parts[0].err,
     channels: parts[1].v, channelsError: parts[1].err,
     triggers: parts[2].v, triggersError: parts[2].err,
-    lifecycle: parts[3].v, lifecycleError: parts[3].err,
+    lifecycle: defaultLifecycle, lifecycleError: parts[3].err,
+    lifecycles: lifecycles,
     feeds: parts[4].v, environments: parts[5].v,
     tenants: parts[6].v, tenantsError: parts[6].err
   };
@@ -1760,10 +1775,23 @@ function projectMapModel(payload) {
   }));
 
   const persistence = project.PersistenceSettings || {};
-  const phases = ((src.lifecycle || {}).Phases || []).map(ph => ({
+  const phasesOf = lc => (lc.Phases || []).map(ph => ({
     name: ph.Name,
     optional: (ph.OptionalDeploymentTargets || []).map(id => envName[id] || id),
     automatic: (ph.AutomaticDeploymentTargets || []).map(id => envName[id] || id)
+  }));
+  const phases = phasesOf(src.lifecycle || {});
+
+  const channelItems = ((src.channels || {}).Items) || [];
+  const lifecycles = (src.lifecycles || []).map(lc => ({
+    id: lc.Id, name: lc.Name,
+    isDefault: lc.Id === project.LifecycleId,
+    // Which channels ship through it. A channel with no lifecycle of its own
+    // uses the project's, so it belongs to the default.
+    channels: channelItems
+      .filter(c => (c.LifecycleId || project.LifecycleId) === lc.Id)
+      .map(c => c.Name),
+    phases: phasesOf(lc)
   }));
 
   const triggers = (((src.triggers || {}).Items) || []).map(t => {
@@ -1788,6 +1816,7 @@ function projectMapModel(payload) {
     process: process,
     processError: src.processError ? 'The deployment process could not be read.' : null,
     lifecycle: (src.lifecycle || {}).Name || '',
+    lifecycles: lifecycles,
     phases: phases,
     channels: (((src.channels || {}).Items) || []).map(c => ({
       name: c.Name, isDefault: !!c.IsDefault,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1670,6 +1670,132 @@ function tenantFlagModel(payload, tenant, connectedEnvIdsByProject, envName, pro
   };
 }
 
+
+// ─── Project map ─────────────────────────────────────────────────────────────
+// What someone new to a project needs to know, in one place: what goes in, what
+// starts a deployment, what it does, and where it lands.
+//
+// One thing to know about the sources. A version-controlled project keeps its
+// variables in Git, so the ordinary variable set comes back empty — the real
+// ones are at /projects/{id}/{branch}/variables. Reading only the variable set
+// would show "no variables" on every VCS project and look perfectly correct.
+
+async function fetchProjectMap(spaceId, projectId) {
+  const project = await fetchJson('/api/' + spaceId + '/projects/' + encodeURIComponent(projectId));
+  const branch = ((project.PersistenceSettings || {}).DefaultBranch) || null;
+  const soft = pr => pr.then(v => ({ v: v })).catch(e => ({ err: e }));
+
+  const processPath = project.IsVersionControlled && branch
+    ? '/api/' + spaceId + '/projects/' + encodeURIComponent(projectId) + '/'
+      + encodeURIComponent(branch) + '/deploymentprocesses'
+    : '/api/' + spaceId + '/deploymentprocesses/' + encodeURIComponent(project.DeploymentProcessId);
+
+  const parts = await Promise.all([
+    soft(fetchJson(processPath)),
+    soft(fetchJson('/api/' + spaceId + '/projects/' + encodeURIComponent(projectId) + '/channels')),
+    soft(fetchJson('/api/' + spaceId + '/projects/' + encodeURIComponent(projectId) + '/triggers')),
+    soft(fetchJson('/api/' + spaceId + '/lifecycles/' + encodeURIComponent(project.LifecycleId))),
+    soft(fetchJson('/api/' + spaceId + '/feeds?take=100')),
+    soft(fetchJson('/api/' + spaceId + '/environments/all')),
+    soft(fetchJson('/api/' + spaceId + '/tenants?projectId=' + encodeURIComponent(projectId) + '&take=1'))
+  ]);
+  return {
+    project: project, branch: branch,
+    process: parts[0].v, processError: parts[0].err,
+    channels: parts[1].v, channelsError: parts[1].err,
+    triggers: parts[2].v, triggersError: parts[2].err,
+    lifecycle: parts[3].v, lifecycleError: parts[3].err,
+    feeds: parts[4].v, environments: parts[5].v,
+    tenants: parts[6].v, tenantsError: parts[6].err
+  };
+}
+
+/** "Octopus.TerraformApply" reads as machinery; "Terraform apply" reads as a step. */
+function actionTypeLabel(type) {
+  const raw = String(type || '').replace(/^Octopus\./, '');
+  if (!raw) return 'Step';
+  return raw.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/^./, c => c.toUpperCase());
+}
+
+function triggerLabel(trigger) {
+  const filter = trigger.Filter || {};
+  const kind = String(filter.FilterType || '');
+  if (/Schedule/i.test(kind)) return { kind: 'Schedule', detail: actionTypeLabel(kind) };
+  if (/Machine/i.test(kind)) return { kind: 'Target', detail: 'When a deployment target changes' };
+  if (/Feed|Package/i.test(kind)) return { kind: 'Package', detail: 'When a new package is pushed' };
+  if (/Git/i.test(kind)) return { kind: 'Git', detail: 'On a change in the repository' };
+  return { kind: 'Trigger', detail: actionTypeLabel(kind) };
+}
+
+function projectMapModel(payload) {
+  const src = payload || {};
+  const project = src.project || {};
+  const feedName = {}; ((src.feeds || {}).Items || []).forEach(f => { feedName[f.Id] = { name: f.Name, type: f.FeedType }; });
+  const envName = {}; (src.environments || []).forEach(e => { envName[e.Id] = e.Name; });
+
+  const steps = ((src.process || {}).Steps) || [];
+  const process = steps.map((st, i) => {
+    const actions = st.Actions || [];
+    const roles = String((st.Properties || {})['Octopus.Action.TargetRoles'] || '')
+      .split(',').map(r => r.trim()).filter(Boolean);
+    const packages = actions.flatMap(a => (a.Packages || []).map(pk => ({
+      packageId: pk.PackageId, feedId: pk.FeedId,
+      feed: (feedName[pk.FeedId] || {}).name || pk.FeedId,
+      feedType: (feedName[pk.FeedId] || {}).type || '' })));
+    return {
+      number: i + 1, name: st.Name,
+      type: actionTypeLabel((actions[0] || {}).ActionType),
+      disabled: actions.every(a => a.IsDisabled),
+      roles: roles, packages: packages
+    };
+  });
+
+  // Inputs are what the process consumes: packages by feed, plus the repository
+  // when the project is version-controlled.
+  const byFeed = {};
+  process.forEach(st => st.packages.forEach(pk => {
+    const key = pk.feed + '|' + pk.feedType;
+    (byFeed[key] || (byFeed[key] = { feed: pk.feed, feedType: pk.feedType, packages: [] }));
+    if (byFeed[key].packages.indexOf(pk.packageId) === -1) byFeed[key].packages.push(pk.packageId);
+  }));
+
+  const persistence = project.PersistenceSettings || {};
+  const phases = ((src.lifecycle || {}).Phases || []).map(ph => ({
+    name: ph.Name,
+    optional: (ph.OptionalDeploymentTargets || []).map(id => envName[id] || id),
+    automatic: (ph.AutomaticDeploymentTargets || []).map(id => envName[id] || id)
+  }));
+
+  const triggers = (((src.triggers || {}).Items) || []).map(t => {
+    const l = triggerLabel(t);
+    return { name: t.Name, kind: l.kind, detail: l.detail, disabled: !!t.IsDisabled };
+  });
+
+  return {
+    id: project.Id, name: project.Name || '', slug: project.Slug,
+    description: project.Description || '',
+    groupId: project.ProjectGroupId,
+    disabled: !!project.IsDisabled,
+    tenantedMode: project.TenantedDeploymentMode || 'Untenanted',
+    tenantCount: (src.tenants || {}).TotalResults || 0,
+    versionControlled: !!project.IsVersionControlled,
+    git: project.IsVersionControlled
+      ? { url: persistence.Url || '', branch: src.branch || persistence.DefaultBranch || '', basePath: persistence.BasePath || '' }
+      : null,
+    autoCreateRelease: !!project.AutoCreateRelease,
+    inputs: Object.keys(byFeed).map(k => byFeed[k]),
+    triggers: triggers,
+    process: process,
+    processError: src.processError ? 'The deployment process could not be read.' : null,
+    lifecycle: (src.lifecycle || {}).Name || '',
+    phases: phases,
+    channels: (((src.channels || {}).Items) || []).map(c => ({
+      name: c.Name, isDefault: !!c.IsDefault,
+      lifecycleId: c.LifecycleId, rules: (c.Rules || []).length })),
+    roles: [...new Set(process.flatMap(st => st.roles))]
+  };
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
@@ -1683,7 +1809,8 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
   parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
   fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
-  fetchTenantFlags, tenantFlagModel, flagStateForTenant }; }
+  fetchTenantFlags, tenantFlagModel, flagStateForTenant,
+  fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1700,5 +1827,6 @@ if (typeof module !== 'undefined') {
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
     fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
-    fetchTenantFlags, tenantFlagModel, flagStateForTenant };
+    fetchTenantFlags, tenantFlagModel, flagStateForTenant,
+    fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -602,7 +602,7 @@ function linkTone(prevVersions, versions) {
 
 function releasesModel(dash) {
   const d = dash || {};
-  const environments = (d.Environments || []).map(e => ({ id: e.Id, name: e.Name }));
+  const allEnvironments = (d.Environments || []).map(e => ({ id: e.Id, name: e.Name }));
   const tenantNames = {};
   (d.Tenants || []).forEach(t => { tenantNames[t.Id] = t.Name; });
   const groupNames = {};
@@ -624,6 +624,15 @@ function releasesModel(dash) {
     if (!agg.stateKey) agg.stateKey = releaseStateKey(item.State);
     if (item.TenantId) agg.tenants.push(item.TenantId);
   });
+
+  // An environment nothing has ever been deployed to costs a column and tells
+  // you nothing. Dropped from the grid and named underneath instead, so the
+  // remaining columns get the width — and so a space with a dormant environment
+  // doesn't read as though the environment were missing.
+  const usedEnvIds = {};
+  Object.keys(byProject).forEach(pid => Object.keys(byProject[pid]).forEach(eid => { usedEnvIds[eid] = true; }));
+  const environments = allEnvironments.filter(e => usedEnvIds[e.id]);
+  const hiddenEnvironments = allEnvironments.filter(e => !usedEnvIds[e.id]);
 
   const projects = (d.Projects || []).map(p => {
     const envMap = byProject[p.Id] || {};
@@ -665,6 +674,7 @@ function releasesModel(dash) {
   // instance, and someone reading "3 projects" has no way to tell which it is.
   return {
     environments: environments,
+    hiddenEnvironments: hiddenEnvironments,
     projects: projects,
     truncated: {
       projectLimit: typeof d.ProjectLimit === 'number' ? d.ProjectLimit : null,

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -815,12 +815,98 @@ function progressionModel(prog, gridEnvironments, windowHours, now) {
   };
 }
 
+
+// ─── Feature flags ───────────────────────────────────────────────────────────
+// Flags are project-scoped, so they join the expanded row alongside its release
+// history. skip and take are REQUIRED — the endpoint 400s without them — and
+// the list is long: Octopus Server carries 191 flags.
+//
+// Almost none of them are news. Of those 191, 146 are on in every environment
+// they are set in and 24 have no environment override at all. What is worth a
+// row is a flag mid-journey: partially rolled out, or on in some environments
+// and off in others. The rest are counted, not drawn.
+
+const FLAG_PAGE = 100;
+const FLAG_MAX_PAGES = 4;
+
+async function fetchFeatureToggles(spaceId, projectId) {
+  const base = '/api/' + spaceId + '/projects/' + encodeURIComponent(projectId) + '/featuretoggles';
+  let items = [], total = null, page = 0;
+  // Bounded: four pages, then we stop and say so. An unbounded loop over a
+  // paged endpoint is exactly what the dashboard guidelines warn against.
+  while (page < FLAG_MAX_PAGES) {
+    const res = await fetchJson(base + '?skip=' + (page * FLAG_PAGE) + '&take=' + FLAG_PAGE);
+    const batch = (res && res.Items) || [];
+    if (total == null) total = res && typeof res.TotalResults === 'number' ? res.TotalResults : batch.length;
+    items = items.concat(batch);
+    if (!batch.length || items.length >= total) break;
+    page++;
+  }
+  return { items: items, total: total == null ? items.length : total, truncated: items.length < (total || 0) };
+}
+
+function flagEnvState(env) {
+  if (!env) return { key: 'inherit', percent: null };
+  if (!env.IsEnabled) return { key: 'off', percent: null };
+  const pct = env.RolloutPercentage != null ? env.RolloutPercentage : env.ClientRolloutPercentage;
+  if (pct != null && pct > 0 && pct < 100) return { key: 'partial', percent: pct };
+  return { key: 'on', percent: pct == null ? 100 : pct };
+}
+
+/** A flag is in flight when it is part-way somewhere: a percentage between 0
+ *  and 100, or on in one environment and off in another. */
+function flagIsInFlight(flag) {
+  const envs = flag.Environments || [];
+  if (!envs.length) return false;
+  if (envs.some(e => flagEnvState(e).key === 'partial')) return true;
+  const states = {};
+  envs.forEach(e => { states[flagEnvState(e).key] = true; });
+  return !!(states.on && states.off);
+}
+
+function featureFlagModel(payload, gridEnvironments) {
+  const src = payload || {};
+  const all = src.items || [];
+  const envs = (gridEnvironments || []).map(e => ({ id: e.id, name: e.name }));
+
+  const inFlight = all.filter(flagIsInFlight).map(f => {
+    const byEnv = {};
+    (f.Environments || []).forEach(e => { byEnv[e.DeploymentEnvironmentId] = e; });
+    const cells = envs.map(env => {
+      const e = byEnv[env.id];
+      const st = flagEnvState(e);
+      const tenantCount = e ? ((e.TenantIds || []).length + (e.TenantTags || []).length) : 0;
+      return { envId: env.id, envName: env.name, state: st.key, percent: st.percent, tenantCount: tenantCount };
+    });
+    return {
+      id: f.Id, name: f.Name, slug: f.Slug,
+      defaultOn: !!f.DefaultIsEnabled,
+      cells: cells,
+      // Furthest environment it is live in at all, so the label can ride the
+      // line the way a release does.
+      frontier: cells.reduce((last, c, i) => (c.state === 'on' || c.state === 'partial' ? i : last), -1)
+    };
+  }).sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+  const settled = { onEverywhere: 0, offEverywhere: 0, noOverrides: 0 };
+  all.forEach(f => {
+    if (flagIsInFlight(f)) return;
+    const envs2 = f.Environments || [];
+    if (!envs2.length) settled.noOverrides++;
+    else if (envs2.every(e => e.IsEnabled)) settled.onEverywhere++;
+    else settled.offEverywhere++;
+  });
+
+  return { flags: inFlight, total: src.total || all.length, settled: settled, truncated: !!src.truncated };
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
   vkey, majorVersion, versionBand, deriveLatest, agentsModel,
   fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
-  fetchProgression, progressionModel, HISTORY_WINDOWS }; }
+  fetchProgression, progressionModel, HISTORY_WINDOWS,
+  fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -829,5 +915,6 @@ if (typeof module !== 'undefined') {
     workersModel, workerFacets, applyWorkerFilters,
     vkey, majorVersion, versionBand, deriveLatest, agentsModel,
     fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
-    fetchProgression, progressionModel, HISTORY_WINDOWS };
+    fetchProgression, progressionModel, HISTORY_WINDOWS,
+    fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1529,6 +1529,99 @@ function tenantDetailModel(payload) {
   };
 }
 
+
+// ─── Feature flags for one tenant ────────────────────────────────────────────
+// Flags are project-scoped, so a tenant's flags are the flags of the projects
+// it is connected to — one request per project, which is affordable on a single
+// tenant page and was not across a list.
+//
+// Resolving a flag for a tenant follows the order Octopus applies:
+//   excluded by id or tag   → off for this tenant, whatever else the flag says
+//   named tenants present   → on only if this tenant is one of them
+//   tagged tenants present  → on only if one of its tags matches
+//   otherwise               → the flag's own enabled state and rollout
+//
+// Two things cannot be resolved from configuration and are reported as
+// undecided rather than guessed: a percentage rollout, which picks tenants at
+// evaluation time, and a segment, which is a rule about end users.
+
+const TENANT_FLAG_MAX_PROJECTS = 6;
+
+async function fetchTenantFlags(spaceId, projectIds) {
+  const ids = (projectIds || []).slice(0, TENANT_FLAG_MAX_PROJECTS);
+  const byProject = {};
+  for (let i = 0; i < ids.length; i++) {
+    try { byProject[ids[i]] = await fetchFeatureToggles(spaceId, ids[i]); }
+    catch (e) { byProject[ids[i]] = { items: [], total: 0, error: true }; }
+  }
+  return { byProject: byProject, projectsRead: ids.length,
+    truncated: (projectIds || []).length > ids.length };
+}
+
+function flagStateForTenant(env, tenant) {
+  if (!env) return { key: 'inherit' };
+  const tags = (tenant && tenant.TenantTags) || [];
+  const id = tenant && tenant.Id;
+  const has = (list, v) => (list || []).indexOf(v) !== -1;
+  const tagHit = list => (list || []).some(t => tags.indexOf(t) !== -1);
+
+  if (has(env.ExcludedTenantIds, id) || tagHit(env.ExcludedTenantTags)) return { key: 'excluded' };
+  if (!env.IsEnabled) return { key: 'off' };
+
+  const named = (env.TenantIds || []).length || (env.TenantTags || []).length;
+  if (named) {
+    const targeted = has(env.TenantIds, id) || tagHit(env.TenantTags);
+    // Named targeting is exact: a tenant on the list has it, one not on the
+    // list does not, regardless of the percentage beside it.
+    return targeted ? { key: 'on', via: 'targeted' } : { key: 'off', via: 'targeted-elsewhere' };
+  }
+  if ((env.Segments || []).length) return { key: 'segment' };
+
+  const pct = env.RolloutPercentage != null ? env.RolloutPercentage : env.ClientRolloutPercentage;
+  if (pct != null && pct > 0 && pct < 100) return { key: 'partial', percent: pct };
+  if (pct === 0) return { key: 'off' };
+  return { key: 'on' };
+}
+
+function tenantFlagModel(payload, tenant, connectedEnvIdsByProject, envName, projectName) {
+  const byProject = (payload && payload.byProject) || {};
+  const flags = [];
+  let unreadable = 0;
+
+  Object.keys(byProject).forEach(pid => {
+    const bucket = byProject[pid] || {};
+    if (bucket.error) { unreadable++; return; }
+    const envs = (connectedEnvIdsByProject || {})[pid] || [];
+    (bucket.items || []).forEach(f => {
+      const byEnv = {};
+      (f.Environments || []).forEach(e => { byEnv[e.DeploymentEnvironmentId] = e; });
+      const cells = envs.map(eid => {
+        const st = flagStateForTenant(byEnv[eid], tenant);
+        return { envId: eid, envName: (envName || {})[eid] || eid, key: st.key,
+          percent: st.percent, via: st.via };
+      });
+      // A flag that is off or inherited everywhere for this tenant is not news
+      // on a tenant page; the project page is where those live.
+      const live = cells.some(c => c.key === 'on' || c.key === 'partial' || c.key === 'segment');
+      flags.push({ id: f.Id, name: f.Name, projectId: pid, projectName: (projectName || {})[pid] || pid,
+        cells: cells, live: live,
+        undecided: cells.some(c => c.key === 'partial' || c.key === 'segment') });
+    });
+  });
+
+  flags.sort((a, b) => String(a.name).localeCompare(String(b.name)));
+  const live = flags.filter(f => f.live);
+  return {
+    flags: live,
+    total: flags.length,
+    liveCount: live.length,
+    undecidedCount: live.filter(f => f.undecided).length,
+    unreadableProjects: unreadable,
+    truncated: !!(payload && payload.truncated),
+    projectsRead: (payload && payload.projectsRead) || 0
+  };
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
@@ -1541,7 +1634,8 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   viewNeedsEstate,
   fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
   parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
-  fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets }; }
+  fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
+  fetchTenantFlags, tenantFlagModel, flagStateForTenant }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1557,5 +1651,6 @@ if (typeof module !== 'undefined') {
     viewNeedsEstate,
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
-    fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets };
+    fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
+    fetchTenantFlags, tenantFlagModel, flagStateForTenant };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -983,6 +983,104 @@ function flagChangeLabel(change) {
   return side(change.before) + ' → ' + side(change.after);
 }
 
+
+// ─── Variable changes ────────────────────────────────────────────────────────
+// Same reconstruction as flags: DocumentContext holds the variables before the
+// change, Differences the patch. Three things are particular to variables.
+//
+//   Scope.Environment places a change in columns. A variable scoped to two
+//   environments changed once, so it is one row marking two columns rather than
+//   two rows. Variables with no environment scope apply everywhere.
+//
+//   Sensitive values are never shown. The audit returns a fixed-width
+//   placeholder for them — identical on both sides of the change — so there is
+//   no before and after to render even if we wanted one. The row says a secret
+//   changed, which is the whole truth available.
+//
+//   A variable change alters nothing already deployed. Variables are snapshotted
+//   into a release when it is created, so the change lands with the next one.
+
+const VARIABLE_EVENT_TAKE = 100;
+const VALUE_MAX = 40;
+
+async function fetchVariableEvents(spaceId, projectId) {
+  return fetchJson('/api/' + spaceId + '/events?documentTypes=variableset&projects='
+    + encodeURIComponent(projectId) + '&take=' + VARIABLE_EVENT_TAKE);
+}
+
+function isSensitiveVariable(v) {
+  return !!(v && (v.Type === 'Sensitive' || v.IsSensitive));
+}
+
+function shortValue(v) {
+  if (v == null) return '';
+  const str = String(v);
+  if (!str.length) return 'empty';
+  return str.length > VALUE_MAX ? str.slice(0, VALUE_MAX - 1) + '…' : str;
+}
+
+function variableChangeModel(events, gridEnvironments, windowHours, now) {
+  const items = (events && events.Items) || [];
+  const envName = {};
+  (gridEnvironments || []).forEach(e => { envName[e.id] = e.name; });
+  const cutoff = windowHours ? (now || Date.now()) - windowHours * 3600 * 1000 : null;
+
+  const changes = [];
+  items.forEach(ev => {
+    const cd = ev.ChangeDetails || {};
+    const ctx = cd.DocumentContext || {};
+    const at = ev.Occurred ? Date.parse(ev.Occurred) : null;
+    if (at == null || isNaN(at)) return;
+    if (cutoff != null && at < cutoff) return;
+    const vars = ctx.Variables || [];
+
+    (cd.Differences || []).forEach((d, dIndex) => {
+      const path = String(d.path || '');
+      const valueMatch = /^\/Variables\/(\d+)\/Value$/.exec(path);
+      const wholeMatch = /^\/Variables\/(\d+)$/.exec(path);
+      if (!valueMatch && !wholeMatch) return;
+
+      const idx = Number((valueMatch || wholeMatch)[1]);
+      const before = vars[idx] || null;
+      const after = wholeMatch ? (d.value || null) : null;
+      const subject = before || after;
+      if (!subject) return;
+
+      const sensitive = isSensitiveVariable(before) || isSensitiveVariable(after);
+      const scopeEnvs = ((subject.Scope && subject.Scope.Environment) || [])
+        .filter(id => id in envName);
+      const hasEnvScope = !!((subject.Scope && subject.Scope.Environment) || []).length;
+
+      changes.push({
+        id: ev.Id + ':' + dIndex,
+        name: subject.Name || '(unnamed)',
+        kind: wholeMatch ? 'added' : 'value',
+        sensitive: sensitive,
+        // Never carry a sensitive value through, placeholder or not.
+        before: sensitive || !valueMatch ? null : shortValue(before ? before.Value : null),
+        after: sensitive || !valueMatch ? null : shortValue(d.value),
+        envIds: scopeEnvs,
+        // Scoped somewhere this grid does not show, versus scoped nowhere.
+        scopedElsewhere: hasEnvScope && !scopeEnvs.length,
+        occurred: at,
+        username: ev.Username || ''
+      });
+    });
+  });
+
+  return changes.sort((a, b) => b.occurred - a.occurred);
+}
+
+function variableChangeLabel(change) {
+  if (!change) return '';
+  if (change.sensitive) return 'secret changed';
+  if (change.kind === 'added') return 'added';
+  const before = change.before === '' ? 'empty' : change.before;
+  const after = change.after === '' ? 'empty' : change.after;
+  if (before == null && after == null) return 'changed';
+  return before + ' → ' + after;
+}
+
 if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
   buildEstate, isEmptyEstate, coldStartApplies, filterEnvRows, emptyKind, taskKind, machineActivityModel, eventsModel, fetchMachineDetail, overviewModel, environmentsModel, policiesModel, buildFacets, applyFilters,
   workersModel, workerFacets, applyWorkerFilters, machineToTarget, typeGroup, healthKeyLabel, osVersionLabel,
@@ -990,7 +1088,8 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
   fetchProgression, progressionModel, HISTORY_WINDOWS,
   fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
-  fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS }; }
+  fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
+  fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable }; }
 
 if (typeof module !== 'undefined') {
   module.exports = { setServerUrl, apiUrl, fetchJson, readConfig, loadSpaces, hydrateSpace,
@@ -1001,5 +1100,6 @@ if (typeof module !== 'undefined') {
     fetchDashboard, releasesModel, releaseStateKey, releaseStateLabel, linkTone,
     fetchProgression, progressionModel, HISTORY_WINDOWS,
     fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
-    fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS };
+    fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
+    fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue };
 }

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -14,6 +14,12 @@
     <!-- sidebar (216px) -->
     <aside class="ip-sidebar">
       <div id="ip-space-switch" class="ip-space-switch"></div>
+      <!-- Projects sits above Infrastructure: it is what the estate exists to
+           deliver, and it is a destination people arrive wanting rather than a
+           part of the infrastructure model. -->
+      <nav class="ip-nav ip-nav-lead">
+        <a href="#projects"     class="ip-nav-item" data-view="projects">Projects</a>
+      </nav>
       <div class="ip-sidebar-title">Infrastructure</div>
       <!-- Five items, per Paul Stovell's feedback on the 28 Jul walkthrough. Machine Policies
            and Deployment Agents are rare destinations and are now tabs inside Deployment
@@ -24,7 +30,6 @@
         <a href="#environments" class="ip-nav-item" data-view="environments">Environments</a>
         <a href="#workers"      class="ip-nav-item" data-view="workers">Workers &amp; Worker Pools</a>
         <a href="#argocd"       class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
-        <a href="#releases"     class="ip-nav-item" data-view="releases">Releases</a>
       </nav>
       <div id="ip-theme-toggle" class="ip-theme-toggle"></div>
     </aside>

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -30,6 +30,7 @@
         <a href="#environments" class="ip-nav-item" data-view="environments">Environments</a>
         <a href="#workers"      class="ip-nav-item" data-view="workers">Workers &amp; Worker Pools</a>
         <a href="#argocd"       class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
+        <a href="#tenants"      class="ip-nav-item" data-view="tenants">Tenants</a>
       </nav>
       <div id="ip-theme-toggle" class="ip-theme-toggle"></div>
     </aside>

--- a/dashboards/infrastructureprealpha/index.html
+++ b/dashboards/infrastructureprealpha/index.html
@@ -24,6 +24,7 @@
         <a href="#environments" class="ip-nav-item" data-view="environments">Environments</a>
         <a href="#workers"      class="ip-nav-item" data-view="workers">Workers &amp; Worker Pools</a>
         <a href="#argocd"       class="ip-nav-item" data-view="argocd">Argo CD Instances</a>
+        <a href="#releases"     class="ip-nav-item" data-view="releases">Releases</a>
       </nav>
       <div id="ip-theme-toggle" class="ip-theme-toggle"></div>
     </aside>

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -9,15 +9,19 @@ const Router = (function () {
   }
   function render() {
     const el = document.getElementById('main-content');
-    // A space that failed to hydrate has no estate to route over, and rendering views
-    // against it would show zeros as though the space were empty.
-    if (IP.spaceError) { el.innerHTML = Views.stateView('error', IP.spaceError); return; }
     const hash = (window.location.hash || '#overview').slice(1);
+    // A space that failed to hydrate has no estate to route over, and rendering
+    // infrastructure views against it would show zeros as though the space were
+    // empty. Projects is not one of those views: it reads the project dashboard
+    // directly, so being unable to read machines does not cost you the projects.
+    const needsEstate = typeof Data !== 'undefined' && Data.viewNeedsEstate
+      ? Data.viewNeedsEstate(hash) : true;
+    if (IP.spaceError && needsEstate) { el.innerHTML = Views.stateView('error', IP.spaceError); return; }
     // Cold-start greets you on the landing view when there's no infrastructure; it never
     // intercepts an explicit nav click. Every other view renders itself and shows its own
     // empty state, so a space with no targets can still reach its environments, its
     // machine policies, and the add-target walkthrough.
-    if (typeof Data !== 'undefined' && Data.coldStartApplies && Data.coldStartApplies(hash, IP.estate)) {
+    if (needsEstate && typeof Data !== 'undefined' && Data.coldStartApplies && Data.coldStartApplies(hash, IP.estate)) {
       Onboarding.renderFirstRun(IP);
       return;
     }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -1,6 +1,6 @@
 'use strict';
 const Router = (function () {
-  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd','projects'];
+  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd','projects','tenants'];
   // Views that render inside the Deployment Targets section shell.
   const IP_TARGET_SECTION_VIEWS = ['targets','agents','machinepolicies'];
   function setActive(view) {
@@ -65,6 +65,36 @@ const Router = (function () {
     else if (view === 'workers') { el.innerHTML = Views.renderWorkers(IP); Views.bindWorkers && Views.bindWorkers(IP); }
     else if (view === 'agents') { el.innerHTML = Views.renderAgents(IP); Views.bindAgents && Views.bindAgents(IP); }
     else if (view === 'argocd') { el.innerHTML = Views.renderArgo(IP); }
+    else if (view === 'tenants') {
+      // Three requests regardless of tenant count: the tenant pages, one
+      // dashboard (which already carries every tenant's current deployments)
+      // and the tag sets that drive the facet groups.
+      const needed = !IP.tenants || IP.tenants.spaceId !== IP.spaceId;
+      if (needed) { IP.tenants = { status: 'loading', spaceId: IP.spaceId }; IP.tenantSel = {}; IP.tenantPage = 0; }
+      el.innerHTML = Views.renderTenants(IP);
+      Views.bindTenants && Views.bindTenants(IP);
+      if (needed && Data.fetchTenants) {
+        const wanted = IP.spaceId;
+        Promise.all([
+          Data.fetchTenants(wanted),
+          Data.fetchDashboard(wanted),
+          Data.fetchTagSets(wanted).catch(() => [])
+        ])
+          .then(res => {
+            if (IP.spaceId !== wanted) return;
+            IP.tenants = { status: 'ready', spaceId: wanted,
+              model: Data.tenantsModel({ tenants: res[0], dashboard: res[1], tagSets: res[2] }) };
+            render();
+          })
+          .catch(e => {
+            if (IP.spaceId !== wanted) return;
+            IP.tenants = { status: 'error', spaceId: wanted,
+              error: e && e.auth ? 'Your session isn\'t authenticated. Sign in to Octopus and reopen this dashboard.'
+                : (e && e.code) || 'The tenant request failed.' };
+            render();
+          });
+      }
+    }
     else if (view === 'projects') {
       // The project dashboard isn't in the boot payload — it's one request, made
       // the first time someone opens this section, and re-made when they switch

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -1,6 +1,6 @@
 'use strict';
 const Router = (function () {
-  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd'];
+  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd','releases'];
   // Views that render inside the Deployment Targets section shell.
   const IP_TARGET_SECTION_VIEWS = ['targets','agents','machinepolicies'];
   function setActive(view) {
@@ -61,6 +61,31 @@ const Router = (function () {
     else if (view === 'workers') { el.innerHTML = Views.renderWorkers(IP); Views.bindWorkers && Views.bindWorkers(IP); }
     else if (view === 'agents') { el.innerHTML = Views.renderAgents(IP); Views.bindAgents && Views.bindAgents(IP); }
     else if (view === 'argocd') { el.innerHTML = Views.renderArgo(IP); }
+    else if (view === 'releases') {
+      // The project dashboard isn't in the boot payload — it's one request, made
+      // the first time someone opens this section, and re-made when they switch
+      // space. Keyed on spaceId so a switch can't leave the previous space's
+      // releases on screen.
+      const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
+      if (needed) IP.releases = { status: 'loading', spaceId: IP.spaceId };
+      el.innerHTML = Views.renderReleases(IP);
+      if (needed && Data.fetchDashboard) {
+        const wanted = IP.spaceId;
+        Data.fetchDashboard(wanted)
+          .then(d => {
+            if (IP.spaceId !== wanted) return;
+            IP.releases = { status: 'ready', spaceId: wanted, model: Data.releasesModel(d) };
+            render();
+          })
+          .catch(e => {
+            if (IP.spaceId !== wanted) return;
+            const msg = e && e.auth ? 'Your session isn\'t authenticated. Sign in to Octopus and reopen this dashboard.'
+              : (e && e.code) || 'The dashboard request failed.';
+            IP.releases = { status: 'error', spaceId: wanted, error: msg };
+            render();
+          });
+      }
+    }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
   function init() { window.addEventListener('hashchange', render); render(); }

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -60,7 +60,7 @@ const Router = (function () {
       if (stale) IP.tenantDetail = { status: 'loading', tenantId: tenantId, spaceId: IP.spaceId };
       el.innerHTML = Views.renderTenantDetail(IP);
       Views.bindTenantDetail && Views.bindTenantDetail(IP);
-      if (stale) { IP.tenantTab = 'Overview'; }
+      if (stale) { IP.tenantTab = 'Overview'; IP.flags = null; }
       if (stale) {
         const wantedSpace = IP.spaceId;
         const stillWanted = () => IP.spaceId === wantedSpace
@@ -85,6 +85,29 @@ const Router = (function () {
                 variables: res[2].v, variablesError: res[2].err,
                 machines: res[3].mach, machinesError: res[3].err }) };
             render();
+
+            // Flags are one request per connected project, so they follow the
+            // page rather than holding it up. Failing leaves the rest intact.
+            const tenantDoc = res[0] || {};
+            const projectIds = Object.keys(tenantDoc.ProjectEnvironments || {});
+            const envNames = {}; ((res[1] || {}).Environments || []).forEach(e => { envNames[e.Id] = e.Name; });
+            const projNames = {}; ((res[1] || {}).Projects || []).forEach(pr => { projNames[pr.Id] = pr.Name; });
+            const connected = {}; projectIds.forEach(pid => { connected[pid] = tenantDoc.ProjectEnvironments[pid] || []; });
+            if (projectIds.length) {
+              IP.flags = { status: 'loading' };
+              Data.fetchTenantFlags(wantedSpace, projectIds)
+                .then(payload => {
+                  if (!stillWanted()) return;
+                  IP.flags = { status: 'ready',
+                    model: Data.tenantFlagModel(payload, tenantDoc, connected, envNames, projNames) };
+                  render();
+                })
+                .catch(() => {
+                  if (!stillWanted()) return;
+                  IP.flags = { status: 'error', error: 'Feature flags could not be read for this tenant\'s projects.' };
+                  render();
+                });
+            }
           })
           .catch(e => {
             if (!stillWanted()) return;

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -58,8 +58,20 @@ const Router = (function () {
       let projectId; try { projectId = decodeURIComponent(rawP); } catch (e) { projectId = rawP; }
       const staleP = !IP.projectMap || IP.projectMap.projectId !== projectId
         || IP.projectMap.spaceId !== IP.spaceId;
-      if (staleP) IP.projectMap = { status: 'loading', projectId: projectId, spaceId: IP.spaceId };
+      if (staleP) { IP.projectMap = { status: 'loading', projectId: projectId, spaceId: IP.spaceId };
+        IP.projectTab = 'Status'; }
+      ensureReleases();
+      IP.projectOpen = IP.projectOpen || {};
+      if (IP.projectOpen[projectId] === undefined) IP.projectOpen[projectId] = true;
       el.innerHTML = Views.renderProjectMap(IP);
+      Views.bindProjectMap && Views.bindProjectMap(IP);
+      // The history and flags are only fetchable once the dashboard has given us
+      // the environment columns to place them in. Until then this is a no-op and
+      // the dashboard's own render() brings us back.
+      if (IP.projectOpen[projectId] && IP.releases && IP.releases.status === 'ready') {
+        if (IP.loadProjectHistory) IP.loadProjectHistory(projectId);
+        if (IP.loadProjectFlags) IP.loadProjectFlags(projectId);
+      }
       if (staleP) {
         const wantedSpace = IP.spaceId;
         Data.fetchProjectMap(wantedSpace, projectId)
@@ -188,134 +200,146 @@ const Router = (function () {
       }
     }
     else if (view === 'projects') {
-      // The project dashboard isn't in the boot payload — it's one request, made
-      // the first time someone opens this section, and re-made when they switch
-      // space. Keyed on spaceId so a switch can't leave the previous space's
-      // releases on screen.
-      const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
-      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.flagEventsRaw = {}; IP.varEventsRaw = {}; IP.projectOpen = {}; }
+      ensureReleases();
       el.innerHTML = Views.renderProjects(IP);
       Views.bindProjects && Views.bindProjects(IP);
-      // Expanding a project fetches its release history once and keeps it for
-      // the session. Re-render is driven from here so the view stays a pure
-      // string builder.
-      // Columns come from the group the project sits in, not the estate-wide
-      // set, or an expanded row would not line up with the grid it opened from.
-      const gridFor = projectId => {
-        const model = IP.releases && IP.releases.model;
-        const group = model && (model.groups || []).find(g => g.projects.some(p => p.id === projectId));
-        return group ? group.environments : (model ? model.environments : []);
-      };
-      const windowHours = () => {
-        const label = IP.historyWindow || (Data.HISTORY_WINDOWS[0] && Data.HISTORY_WINDOWS[0].label);
-        const w = Data.HISTORY_WINDOWS.find(x => x.label === label);
-        return w ? w.hours : null;
-      };
-      // The raw payload is kept so changing the window re-filters what we
-      // already have instead of asking the server again.
-      IP.rebuildHistories = function () {
-        IP.progressionRaw = IP.progressionRaw || {};
-        IP.projectHistory = IP.projectHistory || {};
-        Object.keys(IP.progressionRaw).forEach(pid => {
-          IP.projectHistory[pid] = { status: 'ready',
-            model: Data.progressionModel(IP.progressionRaw[pid], gridFor(pid), windowHours()) };
-        });
-        IP.flagEventsRaw = IP.flagEventsRaw || {};
-        Object.keys(IP.flagEventsRaw).forEach(pid => {
-          const cur = IP.projectFlags && IP.projectFlags[pid];
-          if (cur && cur.status === 'ready') {
-            cur.changes = Data.flagChangeModel(IP.flagEventsRaw[pid], gridFor(pid), windowHours());
-          }
-        });
-        IP.varEventsRaw = IP.varEventsRaw || {};
-        Object.keys(IP.varEventsRaw).forEach(pid => {
-          const cur = IP.projectFlags && IP.projectFlags[pid];
-          if (cur && cur.status === 'ready') {
-            cur.variables = Data.variableChangeModel(IP.varEventsRaw[pid], gridFor(pid), windowHours());
-          }
-        });
-      };
-      // Flags are a second, independent request on expand. It failing must not
-      // take the release history with it, so they are tracked separately.
-      IP.loadProjectFlags = function (projectId) {
-        IP.projectFlags = IP.projectFlags || {};
-        if (IP.projectFlags[projectId]) return;
-        IP.projectFlags[projectId] = { status: 'loading' };
-        const wantedSpace = IP.spaceId;
-        // Two requests: current state, and the audit trail that gives the
-        // changes timestamps. Events failing leaves the current state usable.
-        // Three requests: current flag state, plus the two audit trails that
-        // give flag and variable changes their timestamps. Either trail may
-        // fail on its own without taking the others down.
-        Promise.all([
-          Data.fetchFeatureToggles(wantedSpace, projectId),
-          Data.fetchFlagEvents(wantedSpace, projectId).catch(() => ({ Items: [] })),
-          Data.fetchVariableEvents(wantedSpace, projectId).catch(() => ({ Items: [] }))
-        ])
-          .then(res => {
-            if (IP.spaceId !== wantedSpace) return;
-            IP.flagEventsRaw = IP.flagEventsRaw || {};
-            IP.varEventsRaw = IP.varEventsRaw || {};
-            IP.flagEventsRaw[projectId] = res[1];
-            IP.varEventsRaw[projectId] = res[2];
-            IP.projectFlags[projectId] = { status: 'ready',
-              model: Data.featureFlagModel(res[0], gridFor(projectId)),
-              changes: Data.flagChangeModel(res[1], gridFor(projectId), windowHours()),
-              variables: Data.variableChangeModel(res[2], gridFor(projectId), windowHours()) };
-            render();
-          })
-          .catch(e => {
-            if (IP.spaceId !== wantedSpace) return;
-            // A space without the feature-flag preview simply has no endpoint;
-            // that is a blank section, not an error worth shouting about.
-            const missing = e && (e.code === '404 Not Found' || String(e.code || '').indexOf('404') === 0);
-            IP.projectFlags[projectId] = missing
-              ? { status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false } }
-              : { status: 'error', error: e && e.auth ? 'Your session isn\'t authenticated.'
-                  : 'Feature flags could not be read for this project.' };
-            render();
-          });
-      };
-      IP.loadProjectHistory = function (projectId) {
-        IP.projectHistory = IP.projectHistory || {};
-        IP.progressionRaw = IP.progressionRaw || {};
-        if (IP.projectHistory[projectId]) return;
-        IP.projectHistory[projectId] = { status: 'loading' };
-        const wantedSpace = IP.spaceId;
-        Data.fetchProgression(wantedSpace, projectId)
-          .then(prog => {
-            if (IP.spaceId !== wantedSpace) return;
-            IP.progressionRaw[projectId] = prog;
-            IP.projectHistory[projectId] = { status: 'ready',
-              model: Data.progressionModel(prog, gridFor(projectId), windowHours()) };
-            render();
-          })
-          .catch(e => {
-            if (IP.spaceId !== wantedSpace) return;
-            IP.projectHistory[projectId] = { status: 'error',
-              error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The release history request failed.' };
-            render();
-          });
-      };
-      if (needed && Data.fetchDashboard) {
-        const wanted = IP.spaceId;
-        Data.fetchDashboard(wanted)
-          .then(d => {
-            if (IP.spaceId !== wanted) return;
-            IP.releases = { status: 'ready', spaceId: wanted, model: Data.releasesModel(d) };
-            render();
-          })
-          .catch(e => {
-            if (IP.spaceId !== wanted) return;
-            const msg = e && e.auth ? 'Your session isn\'t authenticated. Sign in to Octopus and reopen this dashboard.'
-              : (e && e.code) || 'The dashboard request failed.';
-            IP.releases = { status: 'error', spaceId: wanted, error: msg };
-            render();
-          });
-      }
     }
     else { el.innerHTML = '<div class="ip-state"><h3>' + view + '</h3><p>Coming in a later phase.</p></div>'; }
   }
+
+  // The project dashboard and everything that hangs off it — release history,
+  // flags, the window rebuild — are wanted by the projects list and by a single
+  // project's Status tab. They are installed once, here, so neither owns them.
+  function ensureReleases() {
+    // One request, made the first time someone needs it and re-made when they
+    // switch space. Keyed on spaceId so a switch can't leave the previous
+    // space's releases on screen.
+    const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
+    if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.flagEventsRaw = {}; IP.varEventsRaw = {}; IP.projectOpen = {}; }
+    // Expanding a project fetches its release history once and keeps it for
+    // the session. Re-render is driven from here so the view stays a pure
+    // string builder.
+    // Columns come from the group the project sits in, not the estate-wide
+    // set, or an expanded row would not line up with the grid it opened from.
+    const gridFor = projectId => {
+      const model = IP.releases && IP.releases.model;
+      const group = model && (model.groups || []).find(g => g.projects.some(p => p.id === projectId));
+      return group ? group.environments : (model ? model.environments : []);
+    };
+    const windowHours = () => {
+      const label = IP.historyWindow || (Data.HISTORY_WINDOWS[0] && Data.HISTORY_WINDOWS[0].label);
+      const w = Data.HISTORY_WINDOWS.find(x => x.label === label);
+      return w ? w.hours : null;
+    };
+    // The raw payload is kept so changing the window re-filters what we
+    // already have instead of asking the server again.
+    IP.rebuildHistories = function () {
+      IP.progressionRaw = IP.progressionRaw || {};
+      IP.projectHistory = IP.projectHistory || {};
+      Object.keys(IP.progressionRaw).forEach(pid => {
+        IP.projectHistory[pid] = { status: 'ready',
+          model: Data.progressionModel(IP.progressionRaw[pid], gridFor(pid), windowHours()) };
+      });
+      IP.flagEventsRaw = IP.flagEventsRaw || {};
+      Object.keys(IP.flagEventsRaw).forEach(pid => {
+        const cur = IP.projectFlags && IP.projectFlags[pid];
+        if (cur && cur.status === 'ready') {
+          cur.changes = Data.flagChangeModel(IP.flagEventsRaw[pid], gridFor(pid), windowHours());
+        }
+      });
+      IP.varEventsRaw = IP.varEventsRaw || {};
+      Object.keys(IP.varEventsRaw).forEach(pid => {
+        const cur = IP.projectFlags && IP.projectFlags[pid];
+        if (cur && cur.status === 'ready') {
+          cur.variables = Data.variableChangeModel(IP.varEventsRaw[pid], gridFor(pid), windowHours());
+        }
+      });
+    };
+    // Flags are a second, independent request on expand. It failing must not
+    // take the release history with it, so they are tracked separately.
+    IP.loadProjectFlags = function (projectId) {
+      IP.projectFlags = IP.projectFlags || {};
+      if (IP.projectFlags[projectId]) return;
+      IP.projectFlags[projectId] = { status: 'loading' };
+      const wantedSpace = IP.spaceId;
+      // Two requests: current state, and the audit trail that gives the
+      // changes timestamps. Events failing leaves the current state usable.
+      // Three requests: current flag state, plus the two audit trails that
+      // give flag and variable changes their timestamps. Either trail may
+      // fail on its own without taking the others down.
+      Promise.all([
+        Data.fetchFeatureToggles(wantedSpace, projectId),
+        Data.fetchFlagEvents(wantedSpace, projectId).catch(() => ({ Items: [] })),
+        Data.fetchVariableEvents(wantedSpace, projectId).catch(() => ({ Items: [] }))
+      ])
+        .then(res => {
+          if (IP.spaceId !== wantedSpace) return;
+          IP.flagEventsRaw = IP.flagEventsRaw || {};
+          IP.varEventsRaw = IP.varEventsRaw || {};
+          IP.flagEventsRaw[projectId] = res[1];
+          IP.varEventsRaw[projectId] = res[2];
+          IP.projectFlags[projectId] = { status: 'ready',
+            model: Data.featureFlagModel(res[0], gridFor(projectId)),
+            changes: Data.flagChangeModel(res[1], gridFor(projectId), windowHours()),
+            variables: Data.variableChangeModel(res[2], gridFor(projectId), windowHours()) };
+          render();
+        })
+        .catch(e => {
+          if (IP.spaceId !== wantedSpace) return;
+          // A space without the feature-flag preview simply has no endpoint;
+          // that is a blank section, not an error worth shouting about.
+          const missing = e && (e.code === '404 Not Found' || String(e.code || '').indexOf('404') === 0);
+          IP.projectFlags[projectId] = missing
+            ? { status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false } }
+            : { status: 'error', error: e && e.auth ? 'Your session isn\'t authenticated.'
+                : 'Feature flags could not be read for this project.' };
+          render();
+        });
+    };
+    IP.loadProjectHistory = function (projectId) {
+      IP.projectHistory = IP.projectHistory || {};
+      IP.progressionRaw = IP.progressionRaw || {};
+      if (IP.projectHistory[projectId]) return;
+      IP.projectHistory[projectId] = { status: 'loading' };
+      const wantedSpace = IP.spaceId;
+      Data.fetchProgression(wantedSpace, projectId)
+        .then(prog => {
+          if (IP.spaceId !== wantedSpace) return;
+          IP.progressionRaw[projectId] = prog;
+          IP.projectHistory[projectId] = { status: 'ready',
+            model: Data.progressionModel(prog, gridFor(projectId), windowHours()) };
+          render();
+        })
+        .catch(e => {
+          if (IP.spaceId !== wantedSpace) return;
+          IP.projectHistory[projectId] = { status: 'error',
+            error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The release history request failed.' };
+          render();
+        });
+    };
+    if (needed && Data.fetchDashboard) {
+      const wanted = IP.spaceId;
+      Data.fetchDashboard(wanted)
+        .then(d => {
+          if (IP.spaceId !== wanted) return;
+          IP.releases = { status: 'ready', spaceId: wanted, model: Data.releasesModel(d) };
+          // A history fetched before the dashboard landed was built against no
+          // columns at all. Rebuilding from the raw payload costs nothing and is
+          // the difference between an aligned row and an empty one.
+          IP.rebuildHistories();
+          render();
+        })
+        .catch(e => {
+          if (IP.spaceId !== wanted) return;
+          const msg = e && e.auth ? 'Your session isn\'t authenticated. Sign in to Octopus and reopen this dashboard.'
+            : (e && e.code) || 'The dashboard request failed.';
+          IP.releases = { status: 'error', spaceId: wanted, error: msg };
+          render();
+        });
+    }
+    return needed;
+  }
+
   function init() { window.addEventListener('hashchange', render); render(); }
   return { init, render };
 })();

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -52,6 +52,32 @@ const Router = (function () {
       }
       return;
     }
+    if (hash.indexOf('projects/') === 0) {
+      setActive('projects');
+      let rawP = hash.slice('projects/'.length);
+      let projectId; try { projectId = decodeURIComponent(rawP); } catch (e) { projectId = rawP; }
+      const staleP = !IP.projectMap || IP.projectMap.projectId !== projectId
+        || IP.projectMap.spaceId !== IP.spaceId;
+      if (staleP) IP.projectMap = { status: 'loading', projectId: projectId, spaceId: IP.spaceId };
+      el.innerHTML = Views.renderProjectMap(IP);
+      if (staleP) {
+        const wantedSpace = IP.spaceId;
+        Data.fetchProjectMap(wantedSpace, projectId)
+          .then(payload => {
+            if (IP.spaceId !== wantedSpace || !IP.projectMap || IP.projectMap.projectId !== projectId) return;
+            IP.projectMap = { status: 'ready', projectId: projectId, spaceId: wantedSpace,
+              model: Data.projectMapModel(payload) };
+            render();
+          })
+          .catch(e => {
+            if (IP.spaceId !== wantedSpace || !IP.projectMap || IP.projectMap.projectId !== projectId) return;
+            IP.projectMap = { status: 'error', projectId: projectId, spaceId: wantedSpace,
+              error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The project request failed.' };
+            render();
+          });
+      }
+      return;
+    }
     if (hash.indexOf('tenants/') === 0) {
       setActive('tenants');
       let raw = hash.slice('tenants/'.length);

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -67,7 +67,7 @@ const Router = (function () {
       // space. Keyed on spaceId so a switch can't leave the previous space's
       // releases on screen.
       const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
-      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.projectOpen = {}; }
+      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.flagEventsRaw = {}; IP.projectOpen = {}; }
       el.innerHTML = Views.renderProjects(IP);
       Views.bindProjects && Views.bindProjects(IP);
       // Expanding a project fetches its release history once and keeps it for
@@ -94,6 +94,13 @@ const Router = (function () {
           IP.projectHistory[pid] = { status: 'ready',
             model: Data.progressionModel(IP.progressionRaw[pid], gridFor(pid), windowHours()) };
         });
+        IP.flagEventsRaw = IP.flagEventsRaw || {};
+        Object.keys(IP.flagEventsRaw).forEach(pid => {
+          const cur = IP.projectFlags && IP.projectFlags[pid];
+          if (cur && cur.status === 'ready') {
+            cur.changes = Data.flagChangeModel(IP.flagEventsRaw[pid], gridFor(pid), windowHours());
+          }
+        });
       };
       // Flags are a second, independent request on expand. It failing must not
       // take the release history with it, so they are tracked separately.
@@ -102,11 +109,19 @@ const Router = (function () {
         if (IP.projectFlags[projectId]) return;
         IP.projectFlags[projectId] = { status: 'loading' };
         const wantedSpace = IP.spaceId;
-        Data.fetchFeatureToggles(wantedSpace, projectId)
-          .then(payload => {
+        // Two requests: current state, and the audit trail that gives the
+        // changes timestamps. Events failing leaves the current state usable.
+        Promise.all([
+          Data.fetchFeatureToggles(wantedSpace, projectId),
+          Data.fetchFlagEvents(wantedSpace, projectId).catch(() => ({ Items: [] }))
+        ])
+          .then(res => {
             if (IP.spaceId !== wantedSpace) return;
+            IP.flagEventsRaw = IP.flagEventsRaw || {};
+            IP.flagEventsRaw[projectId] = res[1];
             IP.projectFlags[projectId] = { status: 'ready',
-              model: Data.featureFlagModel(payload, gridFor(projectId)) };
+              model: Data.featureFlagModel(res[0], gridFor(projectId)),
+              changes: Data.flagChangeModel(res[1], gridFor(projectId), windowHours()) };
             render();
           })
           .catch(e => {

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -67,7 +67,7 @@ const Router = (function () {
       // space. Keyed on spaceId so a switch can't leave the previous space's
       // releases on screen.
       const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
-      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectOpen = {}; }
+      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.projectOpen = {}; }
       el.innerHTML = Views.renderProjects(IP);
       Views.bindProjects && Views.bindProjects(IP);
       // Expanding a project fetches its release history once and keeps it for
@@ -94,6 +94,32 @@ const Router = (function () {
           IP.projectHistory[pid] = { status: 'ready',
             model: Data.progressionModel(IP.progressionRaw[pid], gridFor(pid), windowHours()) };
         });
+      };
+      // Flags are a second, independent request on expand. It failing must not
+      // take the release history with it, so they are tracked separately.
+      IP.loadProjectFlags = function (projectId) {
+        IP.projectFlags = IP.projectFlags || {};
+        if (IP.projectFlags[projectId]) return;
+        IP.projectFlags[projectId] = { status: 'loading' };
+        const wantedSpace = IP.spaceId;
+        Data.fetchFeatureToggles(wantedSpace, projectId)
+          .then(payload => {
+            if (IP.spaceId !== wantedSpace) return;
+            IP.projectFlags[projectId] = { status: 'ready',
+              model: Data.featureFlagModel(payload, gridFor(projectId)) };
+            render();
+          })
+          .catch(e => {
+            if (IP.spaceId !== wantedSpace) return;
+            // A space without the feature-flag preview simply has no endpoint;
+            // that is a blank section, not an error worth shouting about.
+            const missing = e && (e.code === '404 Not Found' || String(e.code || '').indexOf('404') === 0);
+            IP.projectFlags[projectId] = missing
+              ? { status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false } }
+              : { status: 'error', error: e && e.auth ? 'Your session isn\'t authenticated.'
+                  : 'Feature flags could not be read for this project.' };
+            render();
+          });
       };
       IP.loadProjectHistory = function (projectId) {
         IP.projectHistory = IP.projectHistory || {};

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -52,6 +52,47 @@ const Router = (function () {
       }
       return;
     }
+    if (hash.indexOf('tenants/') === 0) {
+      setActive('tenants');
+      let raw = hash.slice('tenants/'.length);
+      let tenantId; try { tenantId = decodeURIComponent(raw); } catch (e) { tenantId = raw; }
+      const stale = !IP.tenantDetail || IP.tenantDetail.tenantId !== tenantId || IP.tenantDetail.spaceId !== IP.spaceId;
+      if (stale) IP.tenantDetail = { status: 'loading', tenantId: tenantId, spaceId: IP.spaceId };
+      el.innerHTML = Views.renderTenantDetail(IP);
+      if (stale) {
+        const wantedSpace = IP.spaceId;
+        const stillWanted = () => IP.spaceId === wantedSpace
+          && IP.tenantDetail && IP.tenantDetail.tenantId === tenantId;
+        // The tenant page reuses the dashboard the list already fetched when it
+        // is there, and asks for one when it is not. Variables and machines are
+        // separate: either can fail without costing the page.
+        const dashboard = (IP.tenants && IP.tenants.status === 'ready' && IP.tenants.raw)
+          ? Promise.resolve(IP.tenants.raw) : Data.fetchDashboard(wantedSpace);
+        Promise.all([
+          Data.fetchTenant(wantedSpace, tenantId),
+          dashboard,
+          Data.fetchTenantVariables(wantedSpace, tenantId).then(v => ({ v: v }))
+            .catch(() => ({ err: 'Tenant variables could not be read, so readiness is unknown.' })),
+          Data.fetchTenantMachines(wantedSpace).then(mach => ({ mach: mach }))
+            .catch(() => ({ err: 'Deployment targets cannot be read in this space, so the targets behind this tenant are unknown.' }))
+        ])
+          .then(res => {
+            if (!stillWanted()) return;
+            IP.tenantDetail = { status: 'ready', tenantId: tenantId, spaceId: wantedSpace,
+              model: Data.tenantDetailModel({ tenant: res[0], dashboard: res[1],
+                variables: res[2].v, variablesError: res[2].err,
+                machines: res[3].mach, machinesError: res[3].err }) };
+            render();
+          })
+          .catch(e => {
+            if (!stillWanted()) return;
+            IP.tenantDetail = { status: 'error', tenantId: tenantId, spaceId: wantedSpace,
+              error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The tenant request failed.' };
+            render();
+          });
+      }
+      return;
+    }
     const view = VIEWS.includes(hash) ? hash : 'overview';
     // Agents and machine policies are tabs inside the Deployment Targets section rather than
     // nav items of their own, so the sidebar highlights the section they live in. Their
@@ -82,7 +123,7 @@ const Router = (function () {
         ])
           .then(res => {
             if (IP.spaceId !== wanted) return;
-            IP.tenants = { status: 'ready', spaceId: wanted,
+            IP.tenants = { status: 'ready', spaceId: wanted, raw: res[1],
               model: Data.tenantsModel({ tenants: res[0], dashboard: res[1], tagSets: res[2] }) };
             render();
           })

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -59,6 +59,8 @@ const Router = (function () {
       const stale = !IP.tenantDetail || IP.tenantDetail.tenantId !== tenantId || IP.tenantDetail.spaceId !== IP.spaceId;
       if (stale) IP.tenantDetail = { status: 'loading', tenantId: tenantId, spaceId: IP.spaceId };
       el.innerHTML = Views.renderTenantDetail(IP);
+      Views.bindTenantDetail && Views.bindTenantDetail(IP);
+      if (stale) { IP.tenantTab = 'Overview'; }
       if (stale) {
         const wantedSpace = IP.spaceId;
         const stillWanted = () => IP.spaceId === wantedSpace

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -67,7 +67,7 @@ const Router = (function () {
       // space. Keyed on spaceId so a switch can't leave the previous space's
       // releases on screen.
       const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
-      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.flagEventsRaw = {}; IP.projectOpen = {}; }
+      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectFlags = {}; IP.flagEventsRaw = {}; IP.varEventsRaw = {}; IP.projectOpen = {}; }
       el.innerHTML = Views.renderProjects(IP);
       Views.bindProjects && Views.bindProjects(IP);
       // Expanding a project fetches its release history once and keeps it for
@@ -101,6 +101,13 @@ const Router = (function () {
             cur.changes = Data.flagChangeModel(IP.flagEventsRaw[pid], gridFor(pid), windowHours());
           }
         });
+        IP.varEventsRaw = IP.varEventsRaw || {};
+        Object.keys(IP.varEventsRaw).forEach(pid => {
+          const cur = IP.projectFlags && IP.projectFlags[pid];
+          if (cur && cur.status === 'ready') {
+            cur.variables = Data.variableChangeModel(IP.varEventsRaw[pid], gridFor(pid), windowHours());
+          }
+        });
       };
       // Flags are a second, independent request on expand. It failing must not
       // take the release history with it, so they are tracked separately.
@@ -111,17 +118,24 @@ const Router = (function () {
         const wantedSpace = IP.spaceId;
         // Two requests: current state, and the audit trail that gives the
         // changes timestamps. Events failing leaves the current state usable.
+        // Three requests: current flag state, plus the two audit trails that
+        // give flag and variable changes their timestamps. Either trail may
+        // fail on its own without taking the others down.
         Promise.all([
           Data.fetchFeatureToggles(wantedSpace, projectId),
-          Data.fetchFlagEvents(wantedSpace, projectId).catch(() => ({ Items: [] }))
+          Data.fetchFlagEvents(wantedSpace, projectId).catch(() => ({ Items: [] })),
+          Data.fetchVariableEvents(wantedSpace, projectId).catch(() => ({ Items: [] }))
         ])
           .then(res => {
             if (IP.spaceId !== wantedSpace) return;
             IP.flagEventsRaw = IP.flagEventsRaw || {};
+            IP.varEventsRaw = IP.varEventsRaw || {};
             IP.flagEventsRaw[projectId] = res[1];
+            IP.varEventsRaw[projectId] = res[2];
             IP.projectFlags[projectId] = { status: 'ready',
               model: Data.featureFlagModel(res[0], gridFor(projectId)),
-              changes: Data.flagChangeModel(res[1], gridFor(projectId), windowHours()) };
+              changes: Data.flagChangeModel(res[1], gridFor(projectId), windowHours()),
+              variables: Data.variableChangeModel(res[2], gridFor(projectId), windowHours()) };
             render();
           })
           .catch(e => {

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -67,8 +67,36 @@ const Router = (function () {
       // space. Keyed on spaceId so a switch can't leave the previous space's
       // releases on screen.
       const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
-      if (needed) IP.releases = { status: 'loading', spaceId: IP.spaceId };
+      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.projectOpen = {}; }
       el.innerHTML = Views.renderProjects(IP);
+      Views.bindProjects && Views.bindProjects(IP);
+      // Expanding a project fetches its release history once and keeps it for
+      // the session. Re-render is driven from here so the view stays a pure
+      // string builder.
+      IP.loadProjectHistory = function (projectId) {
+        IP.projectHistory = IP.projectHistory || {};
+        if (IP.projectHistory[projectId]) return;
+        IP.projectHistory[projectId] = { status: 'loading' };
+        const wantedSpace = IP.spaceId;
+        Data.fetchProgression(wantedSpace, projectId)
+          .then(prog => {
+            if (IP.spaceId !== wantedSpace) return;
+            // Align the history to the columns of the group this project sits
+            // in, not the estate-wide set, or an expanded row would not line up
+            // with the grid it opened from.
+            const model = IP.releases && IP.releases.model;
+            const group = model && (model.groups || []).find(g => g.projects.some(p => p.id === projectId));
+            const grid = group ? group.environments : (model ? model.environments : []);
+            IP.projectHistory[projectId] = { status: 'ready', model: Data.progressionModel(prog, grid) };
+            render();
+          })
+          .catch(e => {
+            if (IP.spaceId !== wantedSpace) return;
+            IP.projectHistory[projectId] = { status: 'error',
+              error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The release history request failed.' };
+            render();
+          });
+      };
       if (needed && Data.fetchDashboard) {
         const wanted = IP.spaceId;
         Data.fetchDashboard(wanted)

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -67,27 +67,46 @@ const Router = (function () {
       // space. Keyed on spaceId so a switch can't leave the previous space's
       // releases on screen.
       const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
-      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.projectOpen = {}; }
+      if (needed) { IP.releases = { status: 'loading', spaceId: IP.spaceId }; IP.projectHistory = {}; IP.progressionRaw = {}; IP.projectOpen = {}; }
       el.innerHTML = Views.renderProjects(IP);
       Views.bindProjects && Views.bindProjects(IP);
       // Expanding a project fetches its release history once and keeps it for
       // the session. Re-render is driven from here so the view stays a pure
       // string builder.
+      // Columns come from the group the project sits in, not the estate-wide
+      // set, or an expanded row would not line up with the grid it opened from.
+      const gridFor = projectId => {
+        const model = IP.releases && IP.releases.model;
+        const group = model && (model.groups || []).find(g => g.projects.some(p => p.id === projectId));
+        return group ? group.environments : (model ? model.environments : []);
+      };
+      const windowHours = () => {
+        const label = IP.historyWindow || (Data.HISTORY_WINDOWS[0] && Data.HISTORY_WINDOWS[0].label);
+        const w = Data.HISTORY_WINDOWS.find(x => x.label === label);
+        return w ? w.hours : null;
+      };
+      // The raw payload is kept so changing the window re-filters what we
+      // already have instead of asking the server again.
+      IP.rebuildHistories = function () {
+        IP.progressionRaw = IP.progressionRaw || {};
+        IP.projectHistory = IP.projectHistory || {};
+        Object.keys(IP.progressionRaw).forEach(pid => {
+          IP.projectHistory[pid] = { status: 'ready',
+            model: Data.progressionModel(IP.progressionRaw[pid], gridFor(pid), windowHours()) };
+        });
+      };
       IP.loadProjectHistory = function (projectId) {
         IP.projectHistory = IP.projectHistory || {};
+        IP.progressionRaw = IP.progressionRaw || {};
         if (IP.projectHistory[projectId]) return;
         IP.projectHistory[projectId] = { status: 'loading' };
         const wantedSpace = IP.spaceId;
         Data.fetchProgression(wantedSpace, projectId)
           .then(prog => {
             if (IP.spaceId !== wantedSpace) return;
-            // Align the history to the columns of the group this project sits
-            // in, not the estate-wide set, or an expanded row would not line up
-            // with the grid it opened from.
-            const model = IP.releases && IP.releases.model;
-            const group = model && (model.groups || []).find(g => g.projects.some(p => p.id === projectId));
-            const grid = group ? group.environments : (model ? model.environments : []);
-            IP.projectHistory[projectId] = { status: 'ready', model: Data.progressionModel(prog, grid) };
+            IP.progressionRaw[projectId] = prog;
+            IP.projectHistory[projectId] = { status: 'ready',
+              model: Data.progressionModel(prog, gridFor(projectId), windowHours()) };
             render();
           })
           .catch(e => {

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -1,6 +1,6 @@
 'use strict';
 const Router = (function () {
-  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd','releases'];
+  const VIEWS = ['overview','targets','environments','machinepolicies','workers','agents','argocd','projects'];
   // Views that render inside the Deployment Targets section shell.
   const IP_TARGET_SECTION_VIEWS = ['targets','agents','machinepolicies'];
   function setActive(view) {
@@ -61,14 +61,14 @@ const Router = (function () {
     else if (view === 'workers') { el.innerHTML = Views.renderWorkers(IP); Views.bindWorkers && Views.bindWorkers(IP); }
     else if (view === 'agents') { el.innerHTML = Views.renderAgents(IP); Views.bindAgents && Views.bindAgents(IP); }
     else if (view === 'argocd') { el.innerHTML = Views.renderArgo(IP); }
-    else if (view === 'releases') {
+    else if (view === 'projects') {
       // The project dashboard isn't in the boot payload — it's one request, made
       // the first time someone opens this section, and re-made when they switch
       // space. Keyed on spaceId so a switch can't leave the previous space's
       // releases on screen.
       const needed = !IP.releases || IP.releases.spaceId !== IP.spaceId;
       if (needed) IP.releases = { status: 'loading', spaceId: IP.spaceId };
-      el.innerHTML = Views.renderReleases(IP);
+      el.innerHTML = Views.renderProjects(IP);
       if (needed && Data.fetchDashboard) {
         const wanted = IP.spaceId;
         Data.fetchDashboard(wanted)

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -943,3 +943,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 /* Row hover has to sit on the card's own colour now, not a page-level grey. */
 .ip-rel-row:hover { background: rgba(127,127,127,.06); }
 .dark .ip-rel-row:hover { background: rgba(255,255,255,.04); }
+
+/* The divider between the project and the first environment ran the full height
+   of the cell, which on a row carrying several releases is a long line for a
+   separator. It is drawn as a short segment beside the text it divides instead.
+
+   The border stays in the box as transparent rather than being removed, so the
+   track keeps its exact width and the columns do not shift by the border. */
+.ip-rel-proj { position: relative; border-right-color: transparent; }
+.ip-rel-proj::after { content: ''; position: absolute; right: -1px; width: 1px;
+  top: 12px; height: 16px; background: var(--color-grey-200); }
+.ip-rel-head .ip-rel-proj::after { top: 50%; height: 14px; margin-top: -7px; }
+/* No text in the expanded gutter, so nothing to divide. */
+.ip-rel-history-gutter::after { display: none; }
+.dark .ip-rel-proj::after { background: var(--color-navy-700); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -576,3 +576,64 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
 .ip-rel-more { font-size: 10px; color: var(--color-grey-600); }
 .dark .ip-rel-more { color: var(--color-grey-400); }
+
+/* Project groups: each is its own grid, because each carries its own columns. */
+.ip-rel-group { margin: 0 0 22px; }
+.ip-rel-group-name { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px;
+  font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
+.ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
+.ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
+
+/* Expandable row */
+.ip-rel-row[data-project] { cursor: pointer; }
+.ip-rel-row[data-project]:hover { background: var(--color-grey-100); }
+.ip-rel-row[data-project]:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: -2px; }
+.ip-rel-proj { align-items: flex-start; }
+.ip-rel-caret { width: 0; height: 0; margin-top: 4px; flex: 0 0 auto;
+  border-left: 5px solid var(--color-grey-600); border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent; transition: transform .12s ease; }
+.ip-rel-row .ip-rel-proj { flex-direction: row; gap: 8px; align-items: center; }
+.ip-rel-proj-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.ip-rel-row.expanded .ip-rel-caret { transform: rotate(90deg); }
+
+/* History panel */
+.ip-rel-history { display: flex; align-items: stretch; background: var(--color-grey-100);
+  border-top: 1px solid var(--color-grey-200); }
+.ip-rel-history-side { display: flex; flex-direction: column; gap: 2px; padding-top: 14px; }
+.ip-rel-history-title { font-size: 11px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--color-grey-700); }
+.ip-rel-history-count { font-size: 11px; color: var(--color-grey-600); }
+.ip-rel-history-body { flex: 1 1 auto; padding: 10px 0 12px; min-width: 0; }
+.ip-rel-loading { display: flex; align-items: center; gap: 10px; padding: 8px 12px;
+  font-size: 12px; color: var(--color-grey-600); }
+.ip-rel-err { margin: 0; padding: 8px 12px; font-size: 12px; color: var(--color-red-700); }
+.ip-rel-hrow { display: flex; align-items: center; min-height: 30px; }
+.ip-rel-hrow.undeployed { opacity: .72; }
+.ip-rel-hmeta { width: 210px; flex: 0 0 210px; padding: 0 12px; display: flex;
+  flex-wrap: wrap; align-items: baseline; gap: 5px; }
+.ip-rel-hver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
+  color: var(--color-navy-900); word-break: break-all; }
+.ip-rel-hchan { font-size: 10px; padding: 0 4px; border-radius: 3px;
+  background: var(--color-grey-200); color: var(--color-grey-700); }
+.ip-rel-hage { font-size: 10px; color: var(--color-grey-600); }
+.ip-rel-hlag { font-size: 10px; color: var(--color-grey-600); }
+.ip-rel-hnever { font-size: 10px; color: var(--color-grey-500); font-style: italic; }
+.ip-rel-hcell { position: relative; display: flex; flex-direction: column; align-items: center;
+  gap: 1px; padding: 3px 4px; min-width: 0; }
+.ip-rel-hcell .ip-rel-seg { top: 9px; height: 2px; }
+.ip-rel-hnode { position: relative; z-index: 1; width: 11px; height: 11px; border-radius: 50%; display: block; }
+.ip-rel-hnote { margin: 8px 0 0; padding: 0 12px; }
+.ip-rel-hnote p { margin: 2px 0; font-size: 11px; color: var(--color-grey-600); }
+
+.dark .ip-rel-group-name { color: var(--color-grey-100); }
+.dark .ip-rel-group-count, .dark .ip-rel-hidden { color: var(--color-grey-400); }
+.dark .ip-rel-row[data-project]:hover { background: var(--color-navy-800); }
+.dark .ip-rel-caret { border-left-color: var(--color-grey-400); }
+.dark .ip-rel-history { background: var(--color-navy-800); border-top-color: var(--color-navy-700); }
+.dark .ip-rel-history-title { color: var(--color-grey-300); }
+.dark .ip-rel-history-count, .dark .ip-rel-hage, .dark .ip-rel-hlag,
+.dark .ip-rel-hnote p, .dark .ip-rel-loading { color: var(--color-grey-400); }
+.dark .ip-rel-hver { color: var(--color-grey-100); }
+.dark .ip-rel-hchan { background: rgba(255,255,255,.10); color: var(--color-grey-300); }
+.dark .ip-rel-hnever { color: var(--color-grey-500); }
+.dark .ip-rel-err { color: var(--color-red-200); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -953,3 +953,10 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 /* No text in the expanded gutter, so nothing to divide. */
 .ip-rel-history-gutter::after { display: none; }
 .dark .ip-rel-proj::after { background: var(--color-navy-700); }
+
+/* Collapsed, the divider is a short segment beside the name — a long rule for
+   one line of text reads as a table edge. Expanded, the history needs the
+   columns held apart, so the same divider runs from the name to the bottom of
+   the card, through the gutter, as one continuous line. */
+.ip-rel-card.is-open .ip-rel-proj::after { bottom: 0; height: auto; }
+.ip-rel-card.is-open .ip-rel-history-gutter::after { display: block; top: 0; bottom: 0; height: auto; }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -879,3 +879,5 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-pill-warning { background: rgba(196,83,23,.22); color: var(--color-orange-200);
   border-color: transparent; }
 .dark .ip-tn-tabcount { background: rgba(196,83,23,.22); color: var(--color-orange-200); }
+.ip-tn-flagstates { display: inline-flex; flex-wrap: wrap; gap: 10px; justify-content: flex-end; }
+.ip-tn-flagstate { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -1052,3 +1052,9 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-pm-fdot { box-shadow: inset 0 0 0 1.5px var(--color-navy-500); }
 .dark .ip-pm-fdot.is-on { background: var(--color-green-500); }
 .dark .ip-pm-fpct { color: var(--color-orange-300); }
+/* The project page's tab row carries Status's controls on its right, so they
+   sit against the tabs the way they sit against the heading on the list. */
+.ip-pm-tabbar { display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 16px; flex-wrap: wrap; margin-bottom: 20px; border-bottom: 1px solid var(--border); }
+.ip-pm-tabbar > .ip-tabs { margin-bottom: 0; border-bottom: 0; }
+.ip-pm-tabbar > .ip-rel-controls { padding-bottom: 8px; }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -565,16 +565,10 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   width: 10px; height: 10px; }
 .ip-rel-labels { display: flex; flex-direction: column; align-items: center; gap: 2px;
   min-width: 0; text-align: center; position: relative; z-index: 2; }
-.ip-rel-entry { display: flex; flex-direction: column; align-items: stretch; gap: 2px;
-  width: 100%; min-width: 0; }
-.ip-rel-entry-head { display: flex; flex-wrap: wrap; justify-content: center;
+.ip-rel-entry { display: flex; flex-wrap: wrap; justify-content: center;
   align-items: baseline; gap: 5px; min-width: 0; }
-/* A cell carrying a tenant split needs its full column width for the bars, so
-   its labels stop centring as a block and stretch instead. */
+/* A cell carrying a tenant split stretches so each row can measure its share. */
 .ip-rel-cell.has-split .ip-rel-labels { align-items: stretch; width: 100%; }
-.ip-rel-cell.has-split .ip-rel-entry-head { justify-content: space-between; }
-.ip-rel-cell.has-split .ip-rel-ver { overflow: hidden; text-overflow: ellipsis;
-  white-space: nowrap; word-break: normal; }
 .ip-rel-ver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
   color: var(--color-navy-900); word-break: break-all; }
 .ip-rel-age, .ip-rel-tenants { font-size: 11px; color: var(--color-grey-600); }
@@ -653,15 +647,25 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border-bottom: 1px solid var(--color-grey-200); }
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
 
-/* Tenant share bar: a slice of the environment's tenants, sitting with the
-   release it belongs to inside the environment's own column. */
-.ip-rel-tsbar { display: block; width: 100%; height: 5px; border-radius: 3px;
-  background: var(--color-grey-200); overflow: hidden; }
-.ip-rel-tsbar > span { display: block; height: 100%; background: var(--color-green-500); }
-.ip-rel-tscount { font-size: 10px; color: var(--color-grey-600);
-  font-variant-numeric: tabular-nums; }
-.ip-rel-tssum { font-size: 10px; font-weight: 600; color: var(--color-grey-700);
-  padding-bottom: 2px; }
-.dark .ip-rel-tsbar { background: var(--color-navy-700); }
-.dark .ip-rel-tscount { color: var(--color-grey-400); }
-.dark .ip-rel-tssum { color: var(--color-grey-300); }
+/* Tenant share: one line per release. The share is the row's own fill, so the
+   bar costs no extra height and a deep split stays compact — version on the
+   left, tenant count on the right, both reading over the fill. */
+.ip-rel-entry-share { display: flex; flex-wrap: nowrap; justify-content: space-between;
+  align-items: baseline; gap: 6px; width: 100%; min-width: 0;
+  padding: 1px 5px; border-radius: 3px;
+  background: linear-gradient(to right,
+    var(--ip-rel-share-fill) var(--ip-rel-share, 0%),
+    var(--color-grey-200) var(--ip-rel-share, 0%));
+}
+.ip-rel-groups { --ip-rel-share-fill: #B8E7D3; }
+.ip-rel-entry-share .ip-rel-ver { overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; word-break: normal; font-weight: 600; }
+.ip-rel-tscount { font-size: 10px; color: var(--color-navy-900);
+  font-variant-numeric: tabular-nums; flex: 0 0 auto; }
+.ip-rel-tssum { font-size: 10px; color: var(--color-grey-600); padding-bottom: 1px; }
+.dark .ip-rel-groups { --ip-rel-share-fill: #14603F; }
+.dark .ip-rel-entry-share { background: linear-gradient(to right,
+  var(--ip-rel-share-fill) var(--ip-rel-share, 0%),
+  var(--color-navy-700) var(--ip-rel-share, 0%)); }
+.dark .ip-rel-tscount { color: var(--color-grey-100); }
+.dark .ip-rel-tssum { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -986,81 +986,6 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
 .ip-pm-col > .ip-tn-panel { margin: 0; }
 
-/* Inputs and triggers stack in one grid cell: both answer "what feeds this
-   project", and both are short enough that a cell each left holes beside them. */
-.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
-.ip-pm-col > .ip-tn-panel { margin: 0; }
-
-/* Lifecycles run full width at the top: a phase order is the one thing on this
-   page that is genuinely a sequence, and it deserves to be read left to right
-   rather than folded into a column. */
-.ip-pm-lifecycles { display: flex; flex-direction: column; gap: 14px; }
-.ip-pm-lifecycle + .ip-pm-lifecycle { padding-top: 12px; border-top: 1px solid var(--color-grey-200); }
-.ip-pm-lchead { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 8px; }
-.ip-pm-flow { list-style: none; display: flex; flex-wrap: wrap; align-items: stretch;
-  gap: 8px; margin: 0; padding: 0; }
-.ip-pm-phasebox { position: relative; display: flex; flex-direction: column; gap: 5px;
-  padding: 8px 12px; min-width: 140px; border: 1px solid var(--color-grey-300);
-  border-radius: var(--radius-lg); background: var(--card); }
-/* The arrow is drawn between boxes rather than as a character, so it survives
-   the row wrapping. */
-.ip-pm-phasebox + .ip-pm-phasebox::before { content: ''; position: absolute; left: -8px; top: 50%;
-  width: 8px; height: 1px; background: var(--color-grey-400); }
-.ip-pm-phasename { font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
-.ip-pm-auto { margin-left: 5px; font-size: 9px; text-transform: uppercase; letter-spacing: .04em;
-  opacity: .75; }
-.dark .ip-pm-lifecycle + .ip-pm-lifecycle { border-top-color: var(--color-navy-700); }
-.dark .ip-pm-phasebox { border-color: var(--color-navy-600); }
-.dark .ip-pm-phasename { color: var(--color-grey-100); }
-.dark .ip-pm-phasebox + .ip-pm-phasebox::before { background: var(--color-navy-500); }
-
-/* Inputs and triggers stack in one grid cell: both answer "what feeds this
-   project", and both are short enough that a cell each left holes beside them. */
-.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
-.ip-pm-col > .ip-tn-panel { margin: 0; }
-
-/* Inputs and triggers stack in one grid cell: both answer "what feeds this
-   project", and both are short enough that a cell each left holes beside them. */
-.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
-.ip-pm-col > .ip-tn-panel { margin: 0; }
-
-/* Lifecycles run full width at the top: a phase order is the one thing on this
-   page that is genuinely a sequence, and it deserves to be read left to right
-   rather than folded into a column. */
-.ip-pm-lifecycles { display: flex; flex-direction: column; gap: 14px; }
-.ip-pm-lifecycle + .ip-pm-lifecycle { padding-top: 12px; border-top: 1px solid var(--color-grey-200); }
-.ip-pm-lchead { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 8px; }
-.ip-pm-flow { list-style: none; display: flex; flex-wrap: wrap; align-items: stretch;
-  gap: 8px; margin: 0; padding: 0; }
-.ip-pm-phasebox { position: relative; display: flex; flex-direction: column; gap: 5px;
-  padding: 8px 12px; min-width: 140px; border: 1px solid var(--color-grey-300);
-  border-radius: var(--radius-lg); background: var(--card); }
-/* The arrow is drawn between boxes rather than as a character, so it survives
-   the row wrapping. */
-.ip-pm-phasebox + .ip-pm-phasebox::before { content: ''; position: absolute; left: -8px; top: 50%;
-  width: 8px; height: 1px; background: var(--color-grey-400); }
-.ip-pm-phasename { font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
-.ip-pm-auto { margin-left: 5px; font-size: 9px; text-transform: uppercase; letter-spacing: .04em;
-  opacity: .75; }
-.dark .ip-pm-lifecycle + .ip-pm-lifecycle { border-top-color: var(--color-navy-700); }
-.dark .ip-pm-phasebox { border-color: var(--color-navy-600); }
-.dark .ip-pm-phasename { color: var(--color-grey-100); }
-.dark .ip-pm-phasebox + .ip-pm-phasebox::before { background: var(--color-navy-500); }
-
-/* Lifecycles: environments named once across the top, each lifecycle a row.
-   Repeating the environments per lifecycle made two routes to the same
-   production look like two different productions. */
-.ip-pm-lctable { width: 100%; }
-.ip-pm-lctable th, .ip-pm-lctable td { vertical-align: top; }
-.ip-pm-lcname { display: flex; flex-direction: column; gap: 2px; min-width: 150px; }
-.ip-pm-lccell.is-absent { background: repeating-linear-gradient(45deg, transparent, transparent 5px,
-  rgba(127,127,127,.06) 5px, rgba(127,127,127,.06) 10px); }
-.ip-pm-phasename { font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
-.ip-pm-auto { margin-left: 6px; font-size: 9px; text-transform: uppercase; letter-spacing: .04em;
-  padding: 0 4px; border-radius: 3px; background: var(--color-green-100); color: var(--color-green-700); }
-.dark .ip-pm-phasename { color: var(--color-grey-100); }
-.dark .ip-pm-auto { background: rgba(0,135,77,.24); color: var(--color-green-300); }
-
 /* Lifecycles, compact: environments once across the top, each lifecycle a line
    beneath them. The node carries its phase number, so environments in the same
    phase share a number and the grouping shows without repeating any names. */
@@ -1100,3 +1025,13 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pm-tstats { display: flex; flex-wrap: wrap; gap: 20px; margin: 0 0 8px; }
 .ip-pm-health { margin: 0 0 10px; }
 .dark .ip-pm-sel dt { color: var(--color-grey-400); }
+/* Extra lifecycles fold away: most projects have one route that matters, and a
+   project with six channel lifecycles should not open with six lines. */
+.ip-pm-lcmore > summary { cursor: pointer; font-size: 11px; padding: 5px 0 3px;
+  color: var(--color-grey-700); }
+.ip-pm-lcmore > summary:hover { color: var(--color-navy-900); }
+.ip-pm-lcmore > summary:focus-visible { outline: 2px solid var(--color-blue-500);
+  outline-offset: 2px; border-radius: 3px; }
+.ip-pm-lcmore > .ip-pm-lcrow + .ip-pm-lcrow { margin-top: 2px; }
+.dark .ip-pm-lcmore > summary { color: var(--color-grey-400); }
+.dark .ip-pm-lcmore > summary:hover { color: var(--color-grey-100); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -565,7 +565,16 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   width: 10px; height: 10px; }
 .ip-rel-labels { display: flex; flex-direction: column; align-items: center; gap: 2px;
   min-width: 0; text-align: center; position: relative; z-index: 2; }
-.ip-rel-entry { display: flex; flex-wrap: wrap; justify-content: center; align-items: baseline; gap: 5px; }
+.ip-rel-entry { display: flex; flex-direction: column; align-items: stretch; gap: 2px;
+  width: 100%; min-width: 0; }
+.ip-rel-entry-head { display: flex; flex-wrap: wrap; justify-content: center;
+  align-items: baseline; gap: 5px; min-width: 0; }
+/* A cell carrying a tenant split needs its full column width for the bars, so
+   its labels stop centring as a block and stretch instead. */
+.ip-rel-cell.has-split .ip-rel-labels { align-items: stretch; width: 100%; }
+.ip-rel-cell.has-split .ip-rel-entry-head { justify-content: space-between; }
+.ip-rel-cell.has-split .ip-rel-ver { overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; word-break: normal; }
 .ip-rel-ver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
   color: var(--color-navy-900); word-break: break-all; }
 .ip-rel-age, .ip-rel-tenants { font-size: 11px; color: var(--color-grey-600); }
@@ -644,29 +653,15 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border-bottom: 1px solid var(--color-grey-200); }
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
 
-/* Tenant spread: laid out in the environment columns, so each breakdown sits
-   under the environment it describes and against the row above it. The bar is a
-   share of that environment's tenants, so a long tail reads as a long tail
-   rather than as numbers to compare by eye. */
-.ip-rel-tsblock { margin: 2px 0 10px; }
-.ip-rel-tscaption { margin: 0 0 6px; font-size: 11px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-700); }
-.ip-rel-tscell { display: flex; flex-direction: column; gap: 5px; padding: 0 12px 0 0;
-  min-width: 0; align-items: stretch; }
-.ip-rel-tssum { font-size: 10px; color: var(--color-grey-600); }
-.ip-rel-tsall { font-size: 10px; color: var(--color-grey-500); font-style: italic; }
-.ip-rel-tsentry { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.ip-rel-tshead { display: flex; align-items: baseline; justify-content: space-between;
-  gap: 6px; min-width: 0; }
-.ip-rel-tshead .ip-rel-ver { font-size: 11px; overflow: hidden; text-overflow: ellipsis;
-  white-space: nowrap; word-break: normal; }
-.ip-rel-tscount { font-size: 10px; color: var(--color-grey-600);
-  font-variant-numeric: tabular-nums; flex: 0 0 auto; }
+/* Tenant share bar: a slice of the environment's tenants, sitting with the
+   release it belongs to inside the environment's own column. */
 .ip-rel-tsbar { display: block; width: 100%; height: 5px; border-radius: 3px;
   background: var(--color-grey-200); overflow: hidden; }
 .ip-rel-tsbar > span { display: block; height: 100%; background: var(--color-green-500); }
-.ip-rel-tsmore { font-size: 10px; color: var(--color-grey-500); }
-.dark .ip-rel-tscaption { color: var(--color-grey-300); }
-.dark .ip-rel-tssum, .dark .ip-rel-tscount { color: var(--color-grey-400); }
-.dark .ip-rel-tsall, .dark .ip-rel-tsmore { color: var(--color-grey-500); }
+.ip-rel-tscount { font-size: 10px; color: var(--color-grey-600);
+  font-variant-numeric: tabular-nums; }
+.ip-rel-tssum { font-size: 10px; font-weight: 600; color: var(--color-grey-700);
+  padding-bottom: 2px; }
 .dark .ip-rel-tsbar { background: var(--color-navy-700); }
+.dark .ip-rel-tscount { color: var(--color-grey-400); }
+.dark .ip-rel-tssum { color: var(--color-grey-300); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -647,25 +647,37 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border-bottom: 1px solid var(--color-grey-200); }
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
 
-/* Tenant share: one line per release. The share is the row's own fill, so the
-   bar costs no extra height and a deep split stays compact — version on the
-   left, tenant count on the right, both reading over the fill. */
-.ip-rel-entry-share { display: flex; flex-wrap: nowrap; justify-content: space-between;
-  align-items: baseline; gap: 6px; width: 100%; min-width: 0;
-  padding: 1px 5px; border-radius: 3px;
-  background: linear-gradient(to right,
-    var(--ip-rel-share-fill) var(--ip-rel-share, 0%),
-    var(--color-grey-200) var(--ip-rel-share, 0%));
-}
-.ip-rel-groups { --ip-rel-share-fill: #B8E7D3; }
+/* Tenant share: one line per release — version, a bar for its slice of the
+   environment's tenants, then the count. The bar is its own element again
+   rather than a fill behind the text, which read as a highlight instead of a
+   measure. */
+.ip-rel-entry-share { display: flex; flex-wrap: nowrap; align-items: center; gap: 6px;
+  width: 100%; min-width: 0; }
 .ip-rel-entry-share .ip-rel-ver { overflow: hidden; text-overflow: ellipsis;
-  white-space: nowrap; word-break: normal; font-weight: 600; }
-.ip-rel-tscount { font-size: 10px; color: var(--color-navy-900);
-  font-variant-numeric: tabular-nums; flex: 0 0 auto; }
+  white-space: nowrap; word-break: normal; flex: 0 1 auto; max-width: 45%; }
+.ip-rel-tsbar { flex: 1 1 auto; min-width: 24px; height: 5px; border-radius: 3px;
+  background: var(--color-grey-200); overflow: hidden; }
+.ip-rel-tsbar > span { display: block; height: 100%; background: var(--color-green-500); }
+.ip-rel-tscount { font-size: 10px; color: var(--color-grey-700); flex: 0 0 auto;
+  font-variant-numeric: tabular-nums; }
 .ip-rel-tssum { font-size: 10px; color: var(--color-grey-600); padding-bottom: 1px; }
-.dark .ip-rel-groups { --ip-rel-share-fill: #14603F; }
-.dark .ip-rel-entry-share { background: linear-gradient(to right,
-  var(--ip-rel-share-fill) var(--ip-rel-share, 0%),
-  var(--color-navy-700) var(--ip-rel-share, 0%)); }
-.dark .ip-rel-tscount { color: var(--color-grey-100); }
+.dark .ip-rel-tsbar { background: var(--color-navy-700); }
+.dark .ip-rel-tscount { color: var(--color-grey-300); }
 .dark .ip-rel-tssum { color: var(--color-grey-400); }
+
+/* Environment mute: a switch under each column heading, scoped to its group.
+   Muting affects the expanded history only — the collapsed row still reports
+   what every environment is running, because that is the question the grid
+   exists to answer. The column stays in place either way, so nothing shifts. */
+.ip-rel-envhead { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.ip-rel-envhead.is-off .ip-rel-envname { opacity: .45; text-decoration: line-through; }
+.ip-rel-envtoggle { border: 0; padding: 0; background: none; cursor: pointer; line-height: 0; }
+.ip-rel-envtoggle:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: 2px; border-radius: 8px; }
+.ip-rel-envtoggle-track { display: block; width: 22px; height: 12px; border-radius: 6px;
+  background: var(--color-green-500); position: relative; transition: background .12s ease; }
+.ip-rel-envtoggle-knob { position: absolute; top: 2px; left: 12px; width: 8px; height: 8px;
+  border-radius: 50%; background: #fff; transition: left .12s ease; }
+.ip-rel-envtoggle[aria-checked="false"] .ip-rel-envtoggle-track { background: var(--color-grey-400); }
+.ip-rel-envtoggle[aria-checked="false"] .ip-rel-envtoggle-knob { left: 2px; }
+.ip-rel-hcell.is-off { visibility: hidden; }
+.dark .ip-rel-envtoggle[aria-checked="false"] .ip-rel-envtoggle-track { background: var(--color-navy-600); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -924,11 +924,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   background: var(--ip-rel-surface); box-shadow: var(--shadow-xs); overflow: hidden;
   transition: border-color .12s ease, box-shadow .12s ease; }
 .ip-rel-card:hover { border-color: var(--color-grey-400); box-shadow: var(--shadow-sm, var(--shadow-xs)); }
-.ip-rel-card.is-open { border-color: var(--color-blue-400);
-  box-shadow: 0 1px 3px rgba(16,24,40,.06); }
 .ip-rel-card .ip-rel-history { border-bottom: 0; border-top: 1px solid var(--color-grey-200); }
 .dark .ip-rel-card:hover { border-color: var(--color-navy-500); }
-.dark .ip-rel-card.is-open { border-color: var(--color-blue-600); box-shadow: none; }
 .dark .ip-rel-card .ip-rel-history { border-top-color: var(--color-navy-700); }
 
 /* The environment header sticks while its own group is on screen. Each group

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -518,8 +518,10 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-key-pale { width: 22px; height: 2px; border-radius: 2px; background: var(--color-green-200); }
 
 .ip-rel-group { margin: 0 0 22px; }
-.ip-rel-group-name { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px;
-  font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
+.ip-rel-group + .ip-rel-group { margin-top: 40px; }
+.ip-rel-group-name { display: flex; align-items: baseline; gap: 10px; margin: 0 0 12px;
+  padding-bottom: 8px; border-bottom: 1px solid var(--color-grey-200);
+  font-size: 15px; font-weight: 600; color: var(--color-navy-900); }
 .ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
 .ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
 
@@ -628,7 +630,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
 
 .dark .ip-rel-proj-name, .dark .ip-rel-ver, .dark .ip-rel-hver { color: var(--color-grey-100); }
-.dark .ip-rel-group-name { color: var(--color-grey-100); }
+.dark .ip-rel-group-name { color: var(--color-grey-100); border-bottom-color: var(--color-navy-700); }
 .dark .ip-rel-caret { border-left-color: var(--color-grey-400); }
 .dark .ip-rel-node-empty { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
 .dark .ip-rel-age, .dark .ip-rel-tenants, .dark .ip-rel-hage, .dark .ip-rel-hlag,

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -484,16 +484,24 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-env-cell:focus-visible,.ip-heat:focus-visible{outline:none;box-shadow:var(--shadow-focus);position:relative;z-index:1}
 .ip-ev-who{color:var(--fg2);white-space:nowrap;text-align:right}
 
-/* ── Releases ───────────────────────────────────────────────────────────────
-   Environments are columns and each project is one line across them. The
-   segment between two columns carries the reading: solid where both hold the
-   same release, faded where they have drifted. Colour is backed by node shape
-   and a written state, because a green/red pair alone failed a deuteranopia
-   check earlier in this series. */
+/* ── Projects ────────────────────────────────────────────────────────────────
+   Environments are fixed-width columns, left-aligned, and identical on every
+   row of the page: collapsed rows, expanded history rows, and every project
+   group. Spare width goes to the right of the last column rather than
+   stretching them, so a node sits at the same x wherever it appears — which is
+   the whole point of a grid you read down.
+
+   Nodes sit at the START of their column, not the centre, so a version label
+   can ride the line to the right of the node it belongs to.
+
+   Colour is backed by node shape and a written state: a green/red pair alone
+   failed a deuteranopia check earlier in this series. */
+.ip-rel-grid { --ip-rel-label: 220px; --ip-rel-col: 176px; }
 .ip-rel-note { margin: 0 0 14px; padding: 10px 12px; border-left: 3px solid var(--color-blue-400);
   background: var(--color-blue-100); border-radius: 4px; }
 .ip-rel-note p { margin: 0; font-size: 12px; color: var(--color-navy-700); }
-.ip-rel-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0 0 12px;
+.ip-rel-window { display: flex; align-items: center; gap: 8px; }
+.ip-rel-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0 0 14px;
   font-size: 11px; color: var(--color-grey-700); }
 .ip-rel-legend span { display: inline-flex; align-items: center; gap: 6px; }
 .ip-rel-key { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
@@ -504,25 +512,41 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-key-strong { width: 22px; height: 2px; border-radius: 2px; background: var(--color-green-500); }
 .ip-rel-key-pale { width: 22px; height: 2px; border-radius: 2px; background: var(--color-green-200); }
 
+.ip-rel-group { margin: 0 0 22px; }
+.ip-rel-group-name { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px;
+  font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
+.ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
+.ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
+
 .ip-rel-grid { border: 1px solid var(--color-grey-300); border-radius: 6px; overflow: hidden; }
 .ip-rel-head, .ip-rel-row { display: flex; align-items: stretch; }
 .ip-rel-head { background: var(--color-grey-100); border-bottom: 1px solid var(--color-grey-300); }
-.ip-rel-row { border-bottom: 1px solid var(--color-grey-200); }
+.ip-rel-row { border-bottom: 1px solid var(--color-grey-200); cursor: pointer; }
 .ip-rel-row:last-child { border-bottom: 0; }
-.ip-rel-proj { width: 220px; flex: 0 0 220px; padding: 12px 14px; display: flex; flex-direction: column;
-  justify-content: center; gap: 2px; border-right: 1px solid var(--color-grey-200); }
+.ip-rel-row:hover { background: var(--color-grey-100); }
+.ip-rel-row:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: -2px; }
+.ip-rel-proj { width: var(--ip-rel-label, 220px); flex: 0 0 var(--ip-rel-label, 220px);
+  padding: 12px 14px; display: flex; align-items: center; gap: 8px;
+  border-right: 1px solid var(--color-grey-200); }
 .ip-rel-head .ip-rel-proj { font-size: 11px; font-weight: 600; text-transform: uppercase;
   letter-spacing: .06em; color: var(--color-grey-700); }
+.ip-rel-proj-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .ip-rel-proj-name { font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
-.ip-rel-proj-group { font-size: 11px; color: var(--color-grey-600); }
-.ip-rel-track { flex: 1 1 auto; display: grid; }
-.ip-rel-envhead { padding: 10px 8px; text-align: center; font-size: 11px; font-weight: 600;
+.ip-rel-caret { width: 0; height: 0; flex: 0 0 auto;
+  border-left: 5px solid var(--color-grey-600); border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent; transition: transform .12s ease; }
+.ip-rel-row.expanded .ip-rel-caret { transform: rotate(90deg); }
+/* justify-content:start is what stops the columns stretching to fill. */
+.ip-rel-track { flex: 1 1 auto; display: grid; justify-content: start; min-width: 0; }
+.ip-rel-envhead { padding: 10px 0 10px 2px; font-size: 11px; font-weight: 600;
   text-transform: uppercase; letter-spacing: .06em; color: var(--color-grey-700); }
 
-.ip-rel-cell { position: relative; padding: 12px 8px 12px; display: flex; flex-direction: column;
-  align-items: center; gap: 6px; min-width: 0; }
-/* Reaches back to the previous column's centre; equal columns make that one cell wide. */
-.ip-rel-seg { position: absolute; top: 20px; right: 50%; width: 100%; height: 2px; border-radius: 2px; }
+.ip-rel-cell { position: relative; padding: 12px 12px 12px 0; display: flex;
+  flex-direction: column; align-items: flex-start; gap: 6px; min-width: 0; }
+/* Reaches back to the previous column's node; nodes sit at column start, so a
+   segment is exactly one column wide. */
+.ip-rel-seg { position: absolute; top: 20px; right: 100%; width: var(--ip-rel-col); height: 2px;
+  border-radius: 2px; margin-left: 8px; }
 .ip-rel-seg-strong { background: var(--color-green-500); }
 .ip-rel-seg-pale { background: var(--color-green-200); }
 .ip-rel-node { position: relative; z-index: 1; width: 16px; height: 16px; border-radius: 50%;
@@ -531,109 +555,72 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-node-running { background: var(--color-blue-500); }
 .ip-rel-node-unhealthy { background: var(--color-red-500); }
 .ip-rel-node-disabled { background: var(--color-slate-300); }
-/* A tenant split leaves two releases live at once — drawn as a ring so the
-   difference reads without relying on the label underneath. */
 .ip-rel-node-split { background: transparent; box-shadow: inset 0 0 0 3px var(--color-green-500); }
 .ip-rel-node-empty { background: transparent; box-shadow: inset 0 0 0 2px var(--color-grey-300);
   width: 10px; height: 10px; }
-.ip-rel-labels { display: flex; flex-direction: column; align-items: center; gap: 2px; min-width: 0; }
-.ip-rel-entry { display: flex; flex-wrap: wrap; justify-content: center; align-items: baseline; gap: 5px; }
+.ip-rel-labels { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; min-width: 0; }
+.ip-rel-entry { display: flex; flex-wrap: wrap; align-items: baseline; gap: 5px; }
 .ip-rel-ver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
   color: var(--color-navy-900); word-break: break-all; }
-.ip-rel-age { font-size: 11px; color: var(--color-grey-600); }
-.ip-rel-none { font-size: 11px; color: var(--color-grey-500); }
-/* The tenant count is the least important number in the cell, and a filled chip
-   made it the brightest thing on the row — badly so against a dark background.
-   It reads as quiet text now, in the same weight as the age beside it. */
-.ip-rel-tenants { font-size: 11px; color: var(--color-grey-600); }
+.ip-rel-age, .ip-rel-tenants { font-size: 11px; color: var(--color-grey-600); }
+.ip-rel-none, .ip-rel-more { font-size: 10px; color: var(--color-grey-500); }
 .ip-rel-state { font-size: 10px; padding: 1px 5px; border-radius: 3px; }
 .ip-rel-state-failed, .ip-rel-state-timedout { background: var(--color-red-100); color: var(--color-red-700); }
 .ip-rel-state-running { background: var(--color-blue-100); color: var(--color-blue-700); }
 .ip-rel-state-cancelled, .ip-rel-state-unknown { background: var(--color-grey-200); color: var(--color-grey-700); }
+
+/* History: no header bar, no second table. It reads as the same grid continuing
+   underneath the row it belongs to, indented by the same label column. */
+.ip-rel-history { padding: 4px 0 10px var(--ip-rel-label, 220px); background: transparent;
+  border-bottom: 1px solid var(--color-grey-200); }
+.ip-rel-hrow { display: flex; align-items: center; min-height: 26px; }
+.ip-rel-hrow.undeployed { opacity: .7; }
+.ip-rel-hcell { position: relative; display: flex; align-items: center; gap: 6px;
+  padding: 0 12px 0 0; min-width: 0; }
+.ip-rel-hcell .ip-rel-seg { top: 50%; margin-top: -1px; }
+.ip-rel-hnode { position: relative; z-index: 1; width: 11px; height: 11px; border-radius: 50%;
+  display: block; flex: 0 0 auto; }
+.ip-rel-hlabel { display: inline-flex; align-items: baseline; gap: 6px; white-space: nowrap;
+  position: absolute; left: 18px; z-index: 2; }
+.ip-rel-hver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
+  color: var(--color-navy-900); }
+.ip-rel-hchan { font-size: 10px; padding: 0 4px; border-radius: 3px;
+  background: var(--color-grey-200); color: var(--color-grey-700); }
+.ip-rel-hage, .ip-rel-hlag, .ip-rel-hcellage { font-size: 10px; color: var(--color-grey-600); }
+.ip-rel-hnever { font-size: 10px; color: var(--color-grey-500); font-style: italic; }
+.ip-rel-hempty, .ip-rel-err { margin: 6px 0; font-size: 12px; color: var(--color-grey-600); }
+.ip-rel-err { color: var(--color-red-700); }
+.ip-rel-loading { display: flex; align-items: center; gap: 10px; padding: 6px 0;
+  font-size: 12px; color: var(--color-grey-600); }
+.ip-rel-hnote { margin: 8px 0 0; }
+.ip-rel-hnote p { margin: 2px 0; font-size: 11px; color: var(--color-grey-600); }
 
 .dark .ip-rel-note { background: rgba(26,119,202,.14); }
 .dark .ip-rel-note p { color: var(--color-grey-200); }
 .dark .ip-rel-grid { border-color: var(--color-navy-600); }
 .dark .ip-rel-head { background: var(--color-navy-800); border-bottom-color: var(--color-navy-600); }
 .dark .ip-rel-row { border-bottom-color: var(--color-navy-700); }
+.dark .ip-rel-row:hover { background: var(--color-navy-800); }
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
-.dark .ip-rel-proj-name, .dark .ip-rel-ver { color: var(--color-grey-100); }
+.dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
+.dark .ip-rel-proj-name, .dark .ip-rel-ver, .dark .ip-rel-hver { color: var(--color-grey-100); }
+.dark .ip-rel-group-name { color: var(--color-grey-100); }
+.dark .ip-rel-caret { border-left-color: var(--color-grey-400); }
 .dark .ip-rel-node-empty { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
-.dark .ip-rel-tenants, .dark .ip-rel-age, .dark .ip-rel-none { color: var(--color-grey-400); }
-/* Translucent fills sit on the row rather than punching a light block through it. */
+.dark .ip-rel-age, .dark .ip-rel-tenants, .dark .ip-rel-hage, .dark .ip-rel-hlag,
+.dark .ip-rel-hcellage, .dark .ip-rel-hnote p, .dark .ip-rel-loading, .dark .ip-rel-hempty,
+.dark .ip-rel-group-count, .dark .ip-rel-hidden, .dark .ip-rel-legend { color: var(--color-grey-400); }
+.dark .ip-rel-none, .dark .ip-rel-more, .dark .ip-rel-hnever { color: var(--color-grey-500); }
+.dark .ip-rel-envhead, .dark .ip-rel-head .ip-rel-proj { color: var(--color-grey-300); }
+.dark .ip-rel-hchan { background: rgba(255,255,255,.10); color: var(--color-grey-300); }
 .dark .ip-rel-state-failed, .dark .ip-rel-state-timedout {
   background: rgba(214,61,61,.22); color: var(--color-red-200); }
 .dark .ip-rel-state-running { background: rgba(26,119,202,.24); color: var(--color-blue-200); }
 .dark .ip-rel-state-cancelled, .dark .ip-rel-state-unknown {
   background: rgba(255,255,255,.10); color: var(--color-grey-300); }
-.dark .ip-rel-proj-group { color: var(--color-grey-400); }
-.dark .ip-rel-envhead, .dark .ip-rel-head .ip-rel-proj { color: var(--color-grey-300); }
-.dark .ip-rel-legend { color: var(--color-grey-400); }
+.dark .ip-rel-err { color: var(--color-red-200); }
 
 /* Projects sits in its own group above the Infrastructure heading. */
 .ip-nav-lead { margin-bottom: 10px; padding-bottom: 10px;
   border-bottom: 1px solid var(--color-grey-200); }
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
-.ip-rel-more { font-size: 10px; color: var(--color-grey-600); }
-.dark .ip-rel-more { color: var(--color-grey-400); }
-
-/* Project groups: each is its own grid, because each carries its own columns. */
-.ip-rel-group { margin: 0 0 22px; }
-.ip-rel-group-name { display: flex; align-items: baseline; gap: 8px; margin: 0 0 8px;
-  font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
-.ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
-.ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
-
-/* Expandable row */
-.ip-rel-row[data-project] { cursor: pointer; }
-.ip-rel-row[data-project]:hover { background: var(--color-grey-100); }
-.ip-rel-row[data-project]:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: -2px; }
-.ip-rel-proj { align-items: flex-start; }
-.ip-rel-caret { width: 0; height: 0; margin-top: 4px; flex: 0 0 auto;
-  border-left: 5px solid var(--color-grey-600); border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent; transition: transform .12s ease; }
-.ip-rel-row .ip-rel-proj { flex-direction: row; gap: 8px; align-items: center; }
-.ip-rel-proj-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.ip-rel-row.expanded .ip-rel-caret { transform: rotate(90deg); }
-
-/* History panel */
-.ip-rel-history { display: flex; align-items: stretch; background: var(--color-grey-100);
-  border-top: 1px solid var(--color-grey-200); }
-.ip-rel-history-side { display: flex; flex-direction: column; gap: 2px; padding-top: 14px; }
-.ip-rel-history-title { font-size: 11px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: .06em; color: var(--color-grey-700); }
-.ip-rel-history-count { font-size: 11px; color: var(--color-grey-600); }
-.ip-rel-history-body { flex: 1 1 auto; padding: 10px 0 12px; min-width: 0; }
-.ip-rel-loading { display: flex; align-items: center; gap: 10px; padding: 8px 12px;
-  font-size: 12px; color: var(--color-grey-600); }
-.ip-rel-err { margin: 0; padding: 8px 12px; font-size: 12px; color: var(--color-red-700); }
-.ip-rel-hrow { display: flex; align-items: center; min-height: 30px; }
-.ip-rel-hrow.undeployed { opacity: .72; }
-.ip-rel-hmeta { width: 210px; flex: 0 0 210px; padding: 0 12px; display: flex;
-  flex-wrap: wrap; align-items: baseline; gap: 5px; }
-.ip-rel-hver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
-  color: var(--color-navy-900); word-break: break-all; }
-.ip-rel-hchan { font-size: 10px; padding: 0 4px; border-radius: 3px;
-  background: var(--color-grey-200); color: var(--color-grey-700); }
-.ip-rel-hage { font-size: 10px; color: var(--color-grey-600); }
-.ip-rel-hlag { font-size: 10px; color: var(--color-grey-600); }
-.ip-rel-hnever { font-size: 10px; color: var(--color-grey-500); font-style: italic; }
-.ip-rel-hcell { position: relative; display: flex; flex-direction: column; align-items: center;
-  gap: 1px; padding: 3px 4px; min-width: 0; }
-.ip-rel-hcell .ip-rel-seg { top: 9px; height: 2px; }
-.ip-rel-hnode { position: relative; z-index: 1; width: 11px; height: 11px; border-radius: 50%; display: block; }
-.ip-rel-hnote { margin: 8px 0 0; padding: 0 12px; }
-.ip-rel-hnote p { margin: 2px 0; font-size: 11px; color: var(--color-grey-600); }
-
-.dark .ip-rel-group-name { color: var(--color-grey-100); }
-.dark .ip-rel-group-count, .dark .ip-rel-hidden { color: var(--color-grey-400); }
-.dark .ip-rel-row[data-project]:hover { background: var(--color-navy-800); }
-.dark .ip-rel-caret { border-left-color: var(--color-grey-400); }
-.dark .ip-rel-history { background: var(--color-navy-800); border-top-color: var(--color-navy-700); }
-.dark .ip-rel-history-title { color: var(--color-grey-300); }
-.dark .ip-rel-history-count, .dark .ip-rel-hage, .dark .ip-rel-hlag,
-.dark .ip-rel-hnote p, .dark .ip-rel-loading { color: var(--color-grey-400); }
-.dark .ip-rel-hver { color: var(--color-grey-100); }
-.dark .ip-rel-hchan { background: rgba(255,255,255,.10); color: var(--color-grey-300); }
-.dark .ip-rel-hnever { color: var(--color-grey-500); }
-.dark .ip-rel-err { color: var(--color-red-200); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -730,3 +730,24 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-flagdelta { color: var(--color-purple-200); }
 .dark .ip-rel-flagscope { background: rgba(255,255,255,.10); color: var(--color-grey-300); }
 .dark .ip-rel-fnode.is-change { box-shadow: 0 0 0 3px var(--ip-rel-surface), 0 0 0 4px var(--color-purple-800); }
+
+/* Flag rows carry a purple wash so they separate from the releases at a glance
+   when a project has a lot of history.
+
+   The wash is also assigned to --ip-rel-surface on the row, because the version
+   labels and cell ages mask the line behind them using that variable — without
+   this they would punch surface-coloured holes through the tint.
+
+   The tint is not the only signal: a flag row already has a square node, a
+   purple line and the flag's name, so it survives being read without colour. */
+.ip-rel-groups { --ip-rel-flagtint: var(--color-purple-100); }
+.ip-rel-frow {
+  --ip-rel-surface: var(--ip-rel-flagtint);
+  background: var(--ip-rel-flagtint);
+  /* Inset rather than a border: a real border would shift the track and undo
+     the column alignment. */
+  box-shadow: inset 3px 0 0 var(--color-purple-300);
+  border-radius: 0 3px 3px 0;
+}
+.dark .ip-rel-groups { --ip-rel-flagtint: #241C39; }
+.dark .ip-rel-frow { box-shadow: inset 3px 0 0 var(--color-purple-700); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -958,3 +958,9 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    the card, through the gutter, as one continuous line. */
 .ip-rel-card.is-open .ip-rel-proj::after { bottom: 0; height: auto; }
 .ip-rel-card.is-open .ip-rel-history-gutter::after { display: block; top: 0; bottom: 0; height: auto; }
+/* The description is metadata about the tenant, not a heading. One line, muted,
+   with the full text on hover — on Cloud it is the same licence link on every
+   tenant and must not compete with the name. */
+.ip-tn-desc { margin: 4px 0 0; font-size: 12px; color: var(--color-grey-600);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 640px; }
+.dark .ip-tn-desc { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -892,3 +892,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-tn-stat-healthy { color: var(--color-green-300); }
 .dark .ip-tn-stat-warning { color: var(--color-orange-200); }
 .dark .ip-tn-stat-disabled, .dark .ip-tn-statlabel { color: var(--color-grey-400); }
+/* The flag panel sits beside the matrix and stays narrow: it is a summary, and
+   the matrix is the thing being read. Below a comfortable width they stack. */
+.ip-tn-matrixrow { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-start; }
+.ip-tn-matrixpanel { flex: 1 1 420px; min-width: 0; }
+.ip-tn-flagpanel { flex: 0 1 300px; min-width: 240px; }
+.ip-tn-flagpanel .ip-tn-stats { gap: 16px; }
+.ip-tn-flagpanel .ip-tn-statnum { font-size: 18px; }
+/* In a narrow column the per-environment states stack under the flag name. */
+.ip-tn-flagpanel .ip-tn-target { flex-direction: column; align-items: flex-start; gap: 2px;
+  padding: 5px 0; border-bottom: 1px solid var(--color-grey-200); }
+.ip-tn-flagpanel .ip-tn-target:last-child { border-bottom: 0; }
+.ip-tn-flagpanel .ip-tn-tname { white-space: normal; }
+.ip-tn-flagpanel .ip-tn-flagstates { justify-content: flex-start; gap: 4px 10px; }
+.dark .ip-tn-flagpanel .ip-tn-target { border-bottom-color: var(--color-navy-700); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -495,7 +495,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 
    Colour is backed by node shape and a written state: a green/red pair alone
    failed a deuteranopia check earlier in this series. */
-.ip-rel-groups { --ip-rel-label: 220px; --ip-rel-endgutter: 180px; --ip-rel-surface: #fff; }
+.ip-rel-groups { --ip-rel-label: 220px; --ip-rel-endgutter: 180px; --ip-rel-surface: #fff;
+  --ip-rel-cardbg: var(--color-grey-100); }
 /* The stylesheet has no global box-sizing, so a declared width here would
    otherwise exclude padding and border — which is exactly how the expanded
    gutter ended up 28px narrower than the project cell it had to match. */
@@ -618,7 +619,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 
 .dark .ip-rel-note { background: rgba(26,119,202,.14); }
 .dark .ip-rel-note p { color: var(--color-grey-200); }
-.dark .ip-rel-groups { --ip-rel-surface: var(--color-navy-900); }
+.dark .ip-rel-groups { --ip-rel-surface: var(--color-navy-900);
+  --ip-rel-cardbg: var(--color-navy-800); }
 .dark .ip-rel-grid { background: transparent; }
 .dark .ip-rel-head { background: transparent; }
 .dark .ip-rel-row, .dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
@@ -669,7 +671,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    Muting affects the expanded history only — the collapsed row still reports
    what every environment is running, because that is the question the grid
    exists to answer. The column stays in place either way, so nothing shifts. */
-.ip-rel-envhead { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.ip-rel-envhead { display: flex; flex-direction: row; align-items: center;
+  justify-content: center; gap: 6px; }
 .ip-rel-envhead.is-off .ip-rel-envname { opacity: .45; text-decoration: line-through; }
 .ip-rel-envtoggle { border: 0; padding: 0; background: none; cursor: pointer; line-height: 0; }
 .ip-rel-envtoggle:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: 2px; border-radius: 8px; }
@@ -911,7 +914,13 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    with dividers reads as a table; discrete cards read as a list of projects,
    which is what this is. */
 .ip-rel-cards { display: flex; flex-direction: column; gap: 8px; }
-.ip-rel-card { border: 1px solid var(--color-grey-300); border-radius: 8px;
+.ip-rel-card {
+  --ip-rel-surface: var(--ip-rel-cardbg);
+  /* Its own stacking context, so the version labels inside — which sit high to
+     mask the lines behind them — cannot paint over the sticky header as the
+     card scrolls under it. */
+  position: relative; z-index: 1;
+  border: 1px solid var(--color-grey-300); border-radius: 8px;
   background: var(--ip-rel-surface); overflow: hidden;
   transition: border-color .12s ease, box-shadow .12s ease; }
 .ip-rel-card:hover { border-color: var(--color-grey-400); }
@@ -922,3 +931,15 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-card:hover { border-color: var(--color-navy-500); }
 .dark .ip-rel-card.is-open { border-color: var(--color-blue-600); box-shadow: none; }
 .dark .ip-rel-card .ip-rel-history { border-top-color: var(--color-navy-700); }
+
+/* The environment header sticks while its own group is on screen. Each group
+   has its own header inside its own section, so one group's columns never hang
+   over another's — the header is only true for the group it belongs to. */
+.ip-rel-head { position: sticky; top: 0; z-index: 6;
+  background: var(--background); padding-top: 6px; }
+.ip-rel-head::after { content: ''; position: absolute; left: 0; right: 0; bottom: 0;
+  height: 1px; background: var(--color-grey-200); }
+.dark .ip-rel-head::after { background: var(--color-navy-700); }
+/* Row hover has to sit on the card's own colour now, not a page-level grey. */
+.ip-rel-row:hover { background: rgba(127,127,127,.06); }
+.dark .ip-rel-row:hover { background: rgba(255,255,255,.04); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -981,3 +981,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pm-roles, .ip-pm-envs { display: inline-flex; flex-wrap: wrap; gap: 4px; }
 .dark .ip-pm-step, .dark .ip-pm-phase { border-bottom-color: var(--color-navy-700); }
 .dark .ip-pm-num { background: var(--color-navy-700); color: var(--color-grey-300); }
+/* Inputs and triggers stack in one grid cell: both answer "what feeds this
+   project", and both are short enough that a cell each left holes beside them. */
+.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.ip-pm-col > .ip-tn-panel { margin: 0; }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -496,7 +496,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    Colour is backed by node shape and a written state: a green/red pair alone
    failed a deuteranopia check earlier in this series. */
 .ip-rel-groups { --ip-rel-label: 220px; --ip-rel-endgutter: 180px; --ip-rel-surface: #fff;
-  --ip-rel-cardbg: var(--color-grey-100); }
+  --ip-rel-cardbg: var(--card); }
 /* The stylesheet has no global box-sizing, so a declared width here would
    otherwise exclude padding and border — which is exactly how the expanded
    gutter ended up 28px narrower than the project cell it had to match. */
@@ -620,7 +620,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-note { background: rgba(26,119,202,.14); }
 .dark .ip-rel-note p { color: var(--color-grey-200); }
 .dark .ip-rel-groups { --ip-rel-surface: var(--color-navy-900);
-  --ip-rel-cardbg: var(--color-navy-800); }
+ }
 .dark .ip-rel-grid { background: transparent; }
 .dark .ip-rel-head { background: transparent; }
 .dark .ip-rel-row, .dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
@@ -920,14 +920,13 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
      mask the lines behind them — cannot paint over the sticky header as the
      card scrolls under it. */
   position: relative; z-index: 1;
-  border: 1px solid var(--color-grey-300); border-radius: 8px;
-  background: var(--ip-rel-surface); overflow: hidden;
+  border: 1px solid var(--border); border-radius: var(--radius-lg);
+  background: var(--ip-rel-surface); box-shadow: var(--shadow-xs); overflow: hidden;
   transition: border-color .12s ease, box-shadow .12s ease; }
-.ip-rel-card:hover { border-color: var(--color-grey-400); }
+.ip-rel-card:hover { border-color: var(--color-grey-400); box-shadow: var(--shadow-sm, var(--shadow-xs)); }
 .ip-rel-card.is-open { border-color: var(--color-blue-400);
   box-shadow: 0 1px 3px rgba(16,24,40,.06); }
 .ip-rel-card .ip-rel-history { border-bottom: 0; border-top: 1px solid var(--color-grey-200); }
-.dark .ip-rel-card { border-color: var(--color-navy-600); }
 .dark .ip-rel-card:hover { border-color: var(--color-navy-500); }
 .dark .ip-rel-card.is-open { border-color: var(--color-blue-600); box-shadow: none; }
 .dark .ip-rel-card .ip-rel-history { border-top-color: var(--color-navy-700); }
@@ -937,9 +936,6 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    over another's — the header is only true for the group it belongs to. */
 .ip-rel-head { position: sticky; top: 0; z-index: 6;
   background: var(--background); padding-top: 6px; }
-.ip-rel-head::after { content: ''; position: absolute; left: 0; right: 0; bottom: 0;
-  height: 1px; background: var(--color-grey-200); }
-.dark .ip-rel-head::after { background: var(--color-navy-700); }
 /* Row hover has to sit on the card's own colour now, not a page-level grey. */
 .ip-rel-row:hover { background: rgba(127,127,127,.06); }
 .dark .ip-rel-row:hover { background: rgba(255,255,255,.04); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -964,3 +964,20 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-tn-desc { margin: 4px 0 0; font-size: 12px; color: var(--color-grey-600);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 640px; }
 .dark .ip-tn-desc { color: var(--color-grey-400); }
+
+/* Project map: panels, so the same facts read without asking anyone to trust a
+   layout before they trust the data. */
+.ip-pm-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+.ip-pm-git { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 0 0 8px; }
+.ip-pm-repo { font-family: var(--font-mono, monospace); font-size: 12px; word-break: break-all; }
+.ip-pm-steps, .ip-pm-phases { list-style: none; margin: 0; padding: 0; counter-reset: none; }
+.ip-pm-step, .ip-pm-phase { display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  padding: 5px 0; border-bottom: 1px solid var(--color-grey-200); font-size: 12px; }
+.ip-pm-step:last-child, .ip-pm-phase:last-child { border-bottom: 0; }
+.ip-pm-step.is-disabled { opacity: .55; }
+.ip-pm-num { flex: 0 0 auto; width: 18px; height: 18px; border-radius: 50%; display: grid;
+  place-items: center; font-size: 10px; background: var(--color-grey-200); color: var(--color-grey-700); }
+.ip-pm-stepmain { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1 1 auto; }
+.ip-pm-roles, .ip-pm-envs { display: inline-flex; flex-wrap: wrap; gap: 4px; }
+.dark .ip-pm-step, .dark .ip-pm-phase { border-bottom-color: var(--color-navy-700); }
+.dark .ip-pm-num { background: var(--color-navy-700); color: var(--color-grey-300); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -790,8 +790,9 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border: 1px solid var(--color-blue-400); background: var(--color-blue-100); color: var(--color-blue-700); }
 .ip-tn-chip.is-clear { border-color: var(--color-grey-400); background: transparent; color: var(--color-grey-700); }
 .ip-tn-body { display: flex; align-items: flex-start; gap: 16px; }
-.ip-tn-facets { width: 220px; flex: 0 0 220px; border: 1px solid var(--color-grey-300);
-  border-radius: 6px; padding: 10px 12px; max-height: 70vh; overflow-y: auto; }
+.ip-tn-facets { width: 220px; flex: 0 0 220px;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs); padding: 10px 12px; max-height: 70vh; overflow-y: auto; }
 .ip-tn-facethead { margin: 0 0 8px; font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
 .ip-tn-facetgroup { margin: 0 0 12px; }
 .ip-tn-facettitle { margin: 0 0 4px; font-size: 10px; font-weight: 600; text-transform: uppercase;
@@ -810,7 +811,6 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-tn-age { font-size: 11px; color: var(--color-grey-600); }
 .ip-tn-pager { display: flex; align-items: center; gap: 10px; padding: 10px 0; }
 .dark .ip-tn-sortsel { background: var(--color-navy-800); border-color: var(--color-navy-600); color: var(--color-grey-100); }
-.dark .ip-tn-facets { border-color: var(--color-navy-600); }
 .dark .ip-tn-facethead { color: var(--color-grey-100); }
 .dark .ip-tn-facettitle, .dark .ip-tn-facet-count, .dark .ip-tn-age, .dark .ip-tn-id { color: var(--color-grey-400); }
 .dark .ip-tn-muted { color: var(--color-grey-500); }
@@ -836,15 +836,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-tn-taggroup { display: inline-flex; align-items: center; gap: 6px; }
 .ip-tn-tagset { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-600); }
 .ip-tn-cards { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
-.ip-tn-card { flex: 1 1 240px; min-width: 0; border: 1px solid var(--color-grey-300);
-  border-radius: 6px; padding: 12px 14px; }
+.ip-tn-card { flex: 1 1 240px; min-width: 0;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs); padding: 12px 14px; }
 .ip-tn-cardtitle { margin: 0 0 6px; font-size: 10px; font-weight: 600; text-transform: uppercase;
   letter-spacing: .06em; color: var(--color-grey-600); }
 .ip-tn-cardhead { margin: 0; display: flex; align-items: center; gap: 7px;
   font-size: 15px; font-weight: 600; color: var(--color-navy-900); }
 .ip-tn-carddetail { margin: 4px 0 0; font-size: 12px; color: var(--color-grey-700); }
 .ip-tn-cardlink { margin: 6px 0 0; font-size: 12px; }
-.ip-tn-panel { border: 1px solid var(--color-grey-300); border-radius: 6px;
+.ip-tn-panel { background: var(--card); border: 1px solid var(--border);
+  border-radius: var(--radius-lg); box-shadow: var(--shadow-xs);
   padding: 12px 14px; margin: 0 0 14px; }
 .ip-tn-panel h3 { display: flex; align-items: baseline; gap: 10px; margin: 0 0 10px; font-size: 13px; }
 .ip-tn-split { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-start; }
@@ -866,7 +868,6 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-tn-activity { list-style: none; margin: 0; padding: 0; }
 .ip-tn-activity li { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; }
 .ip-tn-actmain { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.dark .ip-tn-card, .dark .ip-tn-panel { border-color: var(--color-navy-600); }
 .dark .ip-tn-cardhead { color: var(--color-grey-100); }
 .dark .ip-tn-cardtitle, .dark .ip-tn-carddetail, .dark .ip-tn-tagset,
 .dark .ip-tn-mmeta, .dark .ip-tn-legend, .dark .ip-tn-targethead { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -1035,3 +1035,20 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pm-lcmore > .ip-pm-lcrow + .ip-pm-lcrow { margin-top: 2px; }
 .dark .ip-pm-lcmore > summary { color: var(--color-grey-400); }
 .dark .ip-pm-lcmore > summary:hover { color: var(--color-grey-100); }
+/* Flags reuse the lifecycle track so environments are named once, at the top.
+   The label takes what is left, because a flag name is longer than a
+   lifecycle name and the states are only a dot wide. */
+.ip-pm-fg { margin-top: 4px; }
+.ip-pm-fg .ip-pm-lclabel { width: auto; flex: 1 1 auto; padding: 4px 10px 4px 0; }
+.ip-pm-fg .ip-pm-lctrack { flex: 0 0 calc(var(--ip-pm-cols) * 38px); }
+.ip-pm-fg .ip-pm-cell { min-height: 24px; }
+.ip-pm-fdot { width: 10px; height: 10px; border-radius: 50%; background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--color-grey-400); }
+.ip-pm-fdot.is-on { background: var(--color-green-500); box-shadow: none; }
+/* A state inherited from the default is real but not configured here, so it
+   reads lighter than one somebody set. */
+.ip-pm-fdot.is-default { opacity: .45; }
+.ip-pm-fpct { font-size: 10px; font-weight: 600; color: var(--color-orange-700); }
+.dark .ip-pm-fdot { box-shadow: inset 0 0 0 1.5px var(--color-navy-500); }
+.dark .ip-pm-fdot.is-on { background: var(--color-green-500); }
+.dark .ip-pm-fpct { color: var(--color-orange-300); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -716,3 +716,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-fbar { background: var(--color-navy-700); }
 .dark .ip-rel-fnode.is-off-state { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
 .dark .ip-rel-fnode.is-partial { box-shadow: 0 0 0 2px var(--color-purple-800); }
+
+/* Grouping control sits beside the history window. */
+.ip-rel-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; }
+/* A flag change is a point event — a square that landed, not a line that
+   travelled — so it reads differently from a rollout state. */
+.ip-rel-fnode.is-change { background: var(--color-purple-500);
+  box-shadow: 0 0 0 3px var(--ip-rel-surface), 0 0 0 4px var(--color-purple-200); }
+.ip-rel-flagdelta { font-size: 10px; color: var(--color-purple-700);
+  font-family: var(--font-mono, monospace); }
+.ip-rel-flagscope { font-size: 9px; text-transform: uppercase; letter-spacing: .05em;
+  padding: 0 4px; border-radius: 3px; background: var(--color-grey-200); color: var(--color-grey-700); }
+.dark .ip-rel-flagdelta { color: var(--color-purple-200); }
+.dark .ip-rel-flagscope { background: rgba(255,255,255,.10); color: var(--color-grey-300); }
+.dark .ip-rel-fnode.is-change { box-shadow: 0 0 0 3px var(--ip-rel-surface), 0 0 0 4px var(--color-purple-800); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -881,3 +881,14 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-tn-tabcount { background: rgba(196,83,23,.22); color: var(--color-orange-200); }
 .ip-tn-flagstates { display: inline-flex; flex-wrap: wrap; gap: 10px; justify-content: flex-end; }
 .ip-tn-flagstate { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; }
+/* Flag posture at a glance: two counts and the ones that need a name. */
+.ip-tn-stats { display: flex; flex-wrap: wrap; gap: 22px; margin: 0 0 10px; }
+.ip-tn-stat { display: flex; flex-direction: column; gap: 1px; }
+.ip-tn-statnum { font-size: 20px; font-weight: 600; line-height: 1.1; font-variant-numeric: tabular-nums; }
+.ip-tn-stat-healthy { color: var(--color-green-600); }
+.ip-tn-stat-warning { color: var(--color-orange-600); }
+.ip-tn-stat-disabled { color: var(--color-grey-600); }
+.ip-tn-statlabel { font-size: 11px; color: var(--color-grey-600); }
+.dark .ip-tn-stat-healthy { color: var(--color-green-300); }
+.dark .ip-tn-stat-warning { color: var(--color-orange-200); }
+.dark .ip-tn-stat-disabled, .dark .ip-tn-statlabel { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -813,3 +813,15 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-tn-muted { color: var(--color-grey-500); }
 .dark .ip-tn-chip { background: rgba(26,119,202,.18); color: var(--color-blue-200); }
 .dark .ip-tn-chip.is-clear { color: var(--color-grey-300); border-color: var(--color-navy-600); }
+/* Sortable headers. The arrow shows the direction on the active column and an
+   idle glyph elsewhere, so a column that can be sorted looks like one before
+   it is clicked. */
+.ip-tn-sortbtn { display: inline-flex; align-items: center; gap: 5px; width: 100%;
+  border: 0; padding: 0; background: none; cursor: pointer; font: inherit;
+  color: inherit; text-align: left; }
+.ip-tn-sortbtn:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: 2px; border-radius: 3px; }
+.ip-tn-arrow { font-size: 10px; opacity: .35; }
+.ip-tn-th.is-sorted .ip-tn-arrow { opacity: 1; color: var(--color-blue-600); }
+.ip-tn-th.is-sorted .ip-tn-sortbtn { font-weight: 700; }
+.ip-tn-sortbtn:hover .ip-tn-arrow { opacity: .8; }
+.dark .ip-tn-th.is-sorted .ip-tn-arrow { color: var(--color-blue-300); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -495,7 +495,12 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 
    Colour is backed by node shape and a written state: a green/red pair alone
    failed a deuteranopia check earlier in this series. */
-.ip-rel-groups { --ip-rel-label: 220px; }
+.ip-rel-groups { --ip-rel-label: 220px; --ip-rel-endgutter: 180px; --ip-rel-surface: #fff; }
+/* The stylesheet has no global box-sizing, so a declared width here would
+   otherwise exclude padding and border — which is exactly how the expanded
+   gutter ended up 28px narrower than the project cell it had to match. */
+.ip-rel-groups, .ip-rel-groups *, .ip-rel-groups *::before, .ip-rel-groups *::after {
+  box-sizing: border-box; }
 .ip-rel-note { margin: 0 0 14px; padding: 10px 12px; border-left: 3px solid var(--color-blue-400);
   background: var(--color-blue-100); border-radius: 4px; }
 .ip-rel-note p { margin: 0; font-size: 12px; color: var(--color-navy-700); }
@@ -518,7 +523,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
 
 .ip-rel-grid { border: 1px solid var(--color-grey-300); border-radius: 6px; overflow: hidden;
-  background: var(--color-white, #fff); }
+  background: var(--ip-rel-surface); }
 .ip-rel-head, .ip-rel-row, .ip-rel-history { display: flex; align-items: stretch; }
 .ip-rel-head { background: var(--color-grey-100); border-bottom: 1px solid var(--color-grey-300); }
 .ip-rel-row { border-bottom: 1px solid var(--color-grey-200); cursor: pointer; }
@@ -574,7 +579,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    gutter matches the project column exactly, border included, so the columns
    do not shift when a row opens. */
 .ip-rel-history { border-bottom: 1px solid var(--color-grey-200); }
-.ip-rel-history-gutter { padding: 0; }
+.ip-rel-history-gutter { padding: 0; flex: 0 0 var(--ip-rel-label, 220px);
+  width: var(--ip-rel-label, 220px); }
 .ip-rel-history-body { flex: 1 1 auto; padding: 4px 0 10px; min-width: 0; }
 .ip-rel-history-body > .ip-rel-hempty,
 .ip-rel-history-body > .ip-rel-err,
@@ -591,9 +597,9 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    through the words. */
 .ip-rel-hlabel { display: inline-flex; align-items: baseline; gap: 6px; white-space: nowrap;
   position: absolute; left: 50%; margin-left: 12px; z-index: 3;
-  padding: 0 4px; background: var(--color-white, #fff); }
-.ip-rel-hcellage { position: relative; z-index: 3; padding: 0 3px;
-  background: var(--color-white, #fff); }
+  padding: 0 4px; background: var(--ip-rel-surface); }
+.ip-rel-hcellage { position: absolute; left: 50%; margin-left: 12px; z-index: 3;
+  white-space: nowrap; padding: 0 4px; background: var(--ip-rel-surface); }
 .ip-rel-hver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
   color: var(--color-navy-900); }
 .ip-rel-hchan { font-size: 10px; padding: 0 4px; border-radius: 3px;
@@ -609,12 +615,13 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 
 .dark .ip-rel-note { background: rgba(26,119,202,.14); }
 .dark .ip-rel-note p { color: var(--color-grey-200); }
-.dark .ip-rel-grid { border-color: var(--color-navy-600); background: var(--color-navy-900); }
+.dark .ip-rel-groups { --ip-rel-surface: var(--color-navy-900); }
+.dark .ip-rel-grid { border-color: var(--color-navy-600); background: var(--ip-rel-surface); }
 .dark .ip-rel-head { background: var(--color-navy-800); border-bottom-color: var(--color-navy-600); }
 .dark .ip-rel-row, .dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
 .dark .ip-rel-row:hover { background: var(--color-navy-800); }
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
-.dark .ip-rel-hlabel, .dark .ip-rel-hcellage { background: var(--color-navy-900); }
+
 .dark .ip-rel-proj-name, .dark .ip-rel-ver, .dark .ip-rel-hver { color: var(--color-grey-100); }
 .dark .ip-rel-group-name { color: var(--color-grey-100); }
 .dark .ip-rel-caret { border-left-color: var(--color-grey-400); }
@@ -636,3 +643,22 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-nav-lead { margin-bottom: 10px; padding-bottom: 10px;
   border-bottom: 1px solid var(--color-grey-200); }
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
+
+/* Tenant spread: which release each slice of the estate is on. The bar is a
+   share of the environment's tenants, so a long tail is visible as a long tail
+   rather than as a list of numbers to compare by eye. */
+.ip-rel-tenants-block { margin: 2px 0 10px; padding: 0 6px; }
+.ip-rel-tsenv { margin: 0 0 10px; }
+.ip-rel-tstitle { margin: 0 0 4px; font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-700); }
+.ip-rel-tslist { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 2px; }
+.ip-rel-tsrow { display: flex; align-items: baseline; gap: 8px; font-size: 11px; }
+.ip-rel-tsbar { flex: 0 0 120px; height: 6px; border-radius: 3px; align-self: center;
+  background: var(--color-grey-200); overflow: hidden; }
+.ip-rel-tsbar > span { display: block; height: 100%; background: var(--color-green-500); }
+.ip-rel-tscount { color: var(--color-navy-900); font-variant-numeric: tabular-nums; }
+.ip-rel-tsmore { margin: 3px 0 0; font-size: 10px; color: var(--color-grey-500); }
+.dark .ip-rel-tstitle { color: var(--color-grey-300); }
+.dark .ip-rel-tsbar { background: var(--color-navy-700); }
+.dark .ip-rel-tscount { color: var(--color-grey-100); }
+.dark .ip-rel-tsmore { color: var(--color-grey-500); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -985,3 +985,26 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
    project", and both are short enough that a cell each left holes beside them. */
 .ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
 .ip-pm-col > .ip-tn-panel { margin: 0; }
+
+/* Lifecycles run full width at the top: a phase order is the one thing on this
+   page that is genuinely a sequence, and it deserves to be read left to right
+   rather than folded into a column. */
+.ip-pm-lifecycles { display: flex; flex-direction: column; gap: 14px; }
+.ip-pm-lifecycle + .ip-pm-lifecycle { padding-top: 12px; border-top: 1px solid var(--color-grey-200); }
+.ip-pm-lchead { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 8px; }
+.ip-pm-flow { list-style: none; display: flex; flex-wrap: wrap; align-items: stretch;
+  gap: 8px; margin: 0; padding: 0; }
+.ip-pm-phasebox { position: relative; display: flex; flex-direction: column; gap: 5px;
+  padding: 8px 12px; min-width: 140px; border: 1px solid var(--color-grey-300);
+  border-radius: var(--radius-lg); background: var(--card); }
+/* The arrow is drawn between boxes rather than as a character, so it survives
+   the row wrapping. */
+.ip-pm-phasebox + .ip-pm-phasebox::before { content: ''; position: absolute; left: -8px; top: 50%;
+  width: 8px; height: 1px; background: var(--color-grey-400); }
+.ip-pm-phasename { font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
+.ip-pm-auto { margin-left: 5px; font-size: 9px; text-transform: uppercase; letter-spacing: .04em;
+  opacity: .75; }
+.dark .ip-pm-lifecycle + .ip-pm-lifecycle { border-top-color: var(--color-navy-700); }
+.dark .ip-pm-phasebox { border-color: var(--color-navy-600); }
+.dark .ip-pm-phasename { color: var(--color-grey-100); }
+.dark .ip-pm-phasebox + .ip-pm-phasebox::before { background: var(--color-navy-500); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -518,8 +518,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-key-pale { width: 22px; height: 2px; border-radius: 2px; background: var(--color-green-200); }
 
 .ip-rel-group { margin: 0 0 22px; }
-.ip-rel-group + .ip-rel-group { margin-top: 40px; }
-.ip-rel-group-name { display: flex; align-items: baseline; gap: 10px; margin: 0 0 14px;
+.ip-rel-group + .ip-rel-group { margin-top: 56px; }
+.ip-rel-group-name { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px;
   font-size: 15px; font-weight: 600; color: var(--color-navy-900); }
 .ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
 .ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -868,3 +868,14 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-tn-cardtitle, .dark .ip-tn-carddetail, .dark .ip-tn-tagset,
 .dark .ip-tn-mmeta, .dark .ip-tn-legend, .dark .ip-tn-targethead { color: var(--color-grey-400); }
 .dark .ip-tn-warn { color: var(--color-red-200); }
+/* Amber, not red. An unset value the projects asked for is a question to
+   answer, not something broken — and live data showed tenants deploying
+   successfully with them unset. */
+.ip-rel-node-warning { background: var(--color-orange-500); }
+.ip-pill-warning { background: var(--color-orange-100); color: var(--color-orange-700);
+  border: 1px solid var(--color-orange-300); }
+.ip-tn-tabcount { display: inline-block; margin-left: 6px; padding: 0 5px; border-radius: 8px;
+  font-size: 10px; background: var(--color-orange-100); color: var(--color-orange-700); }
+.dark .ip-pill-warning { background: rgba(196,83,23,.22); color: var(--color-orange-200);
+  border-color: transparent; }
+.dark .ip-tn-tabcount { background: rgba(196,83,23,.22); color: var(--color-orange-200); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -773,3 +773,43 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-vrow { box-shadow: inset 3px 0 0 var(--color-orange-700); }
 .dark .ip-rel-varname { color: var(--color-grey-100); }
 .dark .ip-rel-vardelta { color: var(--color-orange-200); }
+
+/* ── Tenants ─────────────────────────────────────────────────────────────────
+   A tenant has no health status of its own, so the row reports four
+   independent facts side by side. Nothing here rolls them into a score. */
+.ip-tn-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin: 0 0 10px; }
+.ip-tn-search { flex: 1 1 260px; max-width: 380px; }
+.ip-tn-sort { display: flex; align-items: center; gap: 6px; }
+.ip-tn-sortsel { font-size: 12px; padding: 4px 6px; border-radius: 4px;
+  border: 1px solid var(--color-grey-300); background: #fff; color: var(--color-navy-900); }
+.ip-tn-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 10px; }
+.ip-tn-chip { font-size: 11px; padding: 2px 8px; border-radius: 12px; cursor: pointer;
+  border: 1px solid var(--color-blue-400); background: var(--color-blue-100); color: var(--color-blue-700); }
+.ip-tn-chip.is-clear { border-color: var(--color-grey-400); background: transparent; color: var(--color-grey-700); }
+.ip-tn-body { display: flex; align-items: flex-start; gap: 16px; }
+.ip-tn-facets { width: 220px; flex: 0 0 220px; border: 1px solid var(--color-grey-300);
+  border-radius: 6px; padding: 10px 12px; max-height: 70vh; overflow-y: auto; }
+.ip-tn-facethead { margin: 0 0 8px; font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
+.ip-tn-facetgroup { margin: 0 0 12px; }
+.ip-tn-facettitle { margin: 0 0 4px; font-size: 10px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: .05em; color: var(--color-grey-600); }
+.ip-tn-facet { display: flex; align-items: center; gap: 6px; padding: 2px 0; font-size: 12px; cursor: pointer; }
+.ip-tn-facet.is-on { font-weight: 600; }
+.ip-tn-facet-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ip-tn-facet-count { font-size: 11px; color: var(--color-grey-600); font-variant-numeric: tabular-nums; }
+.ip-tn-table-wrap { flex: 1 1 auto; min-width: 0; }
+.ip-tn-table { width: 100%; }
+.ip-tn-name { font-weight: 600; display: block; }
+.ip-tn-id { display: block; font-size: 10px; color: var(--color-grey-600); font-family: var(--font-mono, monospace); }
+.ip-tn-muted { color: var(--color-grey-500); font-size: 12px; }
+.ip-tn-outcome { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.ip-tn-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
+.ip-tn-age { font-size: 11px; color: var(--color-grey-600); }
+.ip-tn-pager { display: flex; align-items: center; gap: 10px; padding: 10px 0; }
+.dark .ip-tn-sortsel { background: var(--color-navy-800); border-color: var(--color-navy-600); color: var(--color-grey-100); }
+.dark .ip-tn-facets { border-color: var(--color-navy-600); }
+.dark .ip-tn-facethead { color: var(--color-grey-100); }
+.dark .ip-tn-facettitle, .dark .ip-tn-facet-count, .dark .ip-tn-age, .dark .ip-tn-id { color: var(--color-grey-400); }
+.dark .ip-tn-muted { color: var(--color-grey-500); }
+.dark .ip-tn-chip { background: rgba(26,119,202,.18); color: var(--color-blue-200); }
+.dark .ip-tn-chip.is-clear { color: var(--color-grey-300); border-color: var(--color-navy-600); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -644,21 +644,29 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   border-bottom: 1px solid var(--color-grey-200); }
 .dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
 
-/* Tenant spread: which release each slice of the estate is on. The bar is a
-   share of the environment's tenants, so a long tail is visible as a long tail
-   rather than as a list of numbers to compare by eye. */
-.ip-rel-tenants-block { margin: 2px 0 10px; padding: 0 6px; }
-.ip-rel-tsenv { margin: 0 0 10px; }
-.ip-rel-tstitle { margin: 0 0 4px; font-size: 11px; font-weight: 600;
+/* Tenant spread: laid out in the environment columns, so each breakdown sits
+   under the environment it describes and against the row above it. The bar is a
+   share of that environment's tenants, so a long tail reads as a long tail
+   rather than as numbers to compare by eye. */
+.ip-rel-tsblock { margin: 2px 0 10px; }
+.ip-rel-tscaption { margin: 0 0 6px; font-size: 11px; font-weight: 600;
   text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-700); }
-.ip-rel-tslist { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 2px; }
-.ip-rel-tsrow { display: flex; align-items: baseline; gap: 8px; font-size: 11px; }
-.ip-rel-tsbar { flex: 0 0 120px; height: 6px; border-radius: 3px; align-self: center;
+.ip-rel-tscell { display: flex; flex-direction: column; gap: 5px; padding: 0 12px 0 0;
+  min-width: 0; align-items: stretch; }
+.ip-rel-tssum { font-size: 10px; color: var(--color-grey-600); }
+.ip-rel-tsall { font-size: 10px; color: var(--color-grey-500); font-style: italic; }
+.ip-rel-tsentry { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.ip-rel-tshead { display: flex; align-items: baseline; justify-content: space-between;
+  gap: 6px; min-width: 0; }
+.ip-rel-tshead .ip-rel-ver { font-size: 11px; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; word-break: normal; }
+.ip-rel-tscount { font-size: 10px; color: var(--color-grey-600);
+  font-variant-numeric: tabular-nums; flex: 0 0 auto; }
+.ip-rel-tsbar { display: block; width: 100%; height: 5px; border-radius: 3px;
   background: var(--color-grey-200); overflow: hidden; }
 .ip-rel-tsbar > span { display: block; height: 100%; background: var(--color-green-500); }
-.ip-rel-tscount { color: var(--color-navy-900); font-variant-numeric: tabular-nums; }
-.ip-rel-tsmore { margin: 3px 0 0; font-size: 10px; color: var(--color-grey-500); }
-.dark .ip-rel-tstitle { color: var(--color-grey-300); }
+.ip-rel-tsmore { font-size: 10px; color: var(--color-grey-500); }
+.dark .ip-rel-tscaption { color: var(--color-grey-300); }
+.dark .ip-rel-tssum, .dark .ip-rel-tscount { color: var(--color-grey-400); }
+.dark .ip-rel-tsall, .dark .ip-rel-tsmore { color: var(--color-grey-500); }
 .dark .ip-rel-tsbar { background: var(--color-navy-700); }
-.dark .ip-rel-tscount { color: var(--color-grey-100); }
-.dark .ip-rel-tsmore { color: var(--color-grey-500); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -506,7 +506,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   background: var(--color-blue-100); border-radius: 4px; }
 .ip-rel-note p { margin: 0; font-size: 12px; color: var(--color-navy-700); }
 .ip-rel-window { display: flex; align-items: center; gap: 8px; }
-.ip-rel-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0 0 14px;
+.ip-rel-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0 0 34px;
   font-size: 11px; color: var(--color-grey-700); }
 .ip-rel-legend span { display: inline-flex; align-items: center; gap: 6px; }
 .ip-rel-key { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -485,18 +485,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-ev-who{color:var(--fg2);white-space:nowrap;text-align:right}
 
 /* ── Projects ────────────────────────────────────────────────────────────────
-   Environments are fixed-width columns, left-aligned, and identical on every
-   row of the page: collapsed rows, expanded history rows, and every project
-   group. Spare width goes to the right of the last column rather than
-   stretching them, so a node sits at the same x wherever it appears — which is
-   the whole point of a grid you read down.
+   Environment columns are one width for the whole page, taken from the group
+   with the most environments, so every group lines up in the same columns. The
+   width is a share of the available space rather than a fixed pixel count, so
+   the grid spreads in a wide window and tightens in a narrow one.
 
-   Nodes sit at the START of their column, not the centre, so a version label
-   can ride the line to the right of the node it belongs to.
+   Nodes are centred in their column, under the environment name, and a version
+   label sits to the right of the node it belongs to.
 
    Colour is backed by node shape and a written state: a green/red pair alone
    failed a deuteranopia check earlier in this series. */
-.ip-rel-grid { --ip-rel-label: 220px; --ip-rel-col: 176px; }
+.ip-rel-groups { --ip-rel-label: 220px; }
 .ip-rel-note { margin: 0 0 14px; padding: 10px 12px; border-left: 3px solid var(--color-blue-400);
   background: var(--color-blue-100); border-radius: 4px; }
 .ip-rel-note p { margin: 0; font-size: 12px; color: var(--color-navy-700); }
@@ -518,38 +517,39 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
 .ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
 
-.ip-rel-grid { border: 1px solid var(--color-grey-300); border-radius: 6px; overflow: hidden; }
-.ip-rel-head, .ip-rel-row { display: flex; align-items: stretch; }
+.ip-rel-grid { border: 1px solid var(--color-grey-300); border-radius: 6px; overflow: hidden;
+  background: var(--color-white, #fff); }
+.ip-rel-head, .ip-rel-row, .ip-rel-history { display: flex; align-items: stretch; }
 .ip-rel-head { background: var(--color-grey-100); border-bottom: 1px solid var(--color-grey-300); }
 .ip-rel-row { border-bottom: 1px solid var(--color-grey-200); cursor: pointer; }
 .ip-rel-row:last-child { border-bottom: 0; }
 .ip-rel-row:hover { background: var(--color-grey-100); }
 .ip-rel-row:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: -2px; }
+/* The project name sits at the top of the cell: rows grow tall when a cell
+   carries several releases, and a name floating in the middle of that reads as
+   unrelated to the line it labels. */
 .ip-rel-proj { width: var(--ip-rel-label, 220px); flex: 0 0 var(--ip-rel-label, 220px);
-  padding: 12px 14px; display: flex; align-items: center; gap: 8px;
+  padding: 12px 14px; display: flex; align-items: flex-start; gap: 8px;
   border-right: 1px solid var(--color-grey-200); }
 .ip-rel-head .ip-rel-proj { font-size: 11px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: .06em; color: var(--color-grey-700); }
-.ip-rel-proj-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.ip-rel-proj-name { font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
-.ip-rel-caret { width: 0; height: 0; flex: 0 0 auto;
+  letter-spacing: .06em; color: var(--color-grey-700); align-items: center; }
+.ip-rel-proj-name { font-size: 13px; font-weight: 600; color: var(--color-navy-900);
+  line-height: 16px; min-width: 0; word-break: break-word; }
+.ip-rel-caret { width: 0; height: 0; flex: 0 0 auto; margin-top: 5px;
   border-left: 5px solid var(--color-grey-600); border-top: 4px solid transparent;
   border-bottom: 4px solid transparent; transition: transform .12s ease; }
 .ip-rel-row.expanded .ip-rel-caret { transform: rotate(90deg); }
-/* justify-content:start is what stops the columns stretching to fill. */
 .ip-rel-track { flex: 1 1 auto; display: grid; justify-content: start; min-width: 0; }
-.ip-rel-envhead { padding: 10px 0 10px 2px; font-size: 11px; font-weight: 600;
+.ip-rel-envhead { padding: 10px 4px; font-size: 11px; font-weight: 600; text-align: center;
   text-transform: uppercase; letter-spacing: .06em; color: var(--color-grey-700); }
 
-.ip-rel-cell { position: relative; padding: 12px 12px 12px 0; display: flex;
-  flex-direction: column; align-items: flex-start; gap: 6px; min-width: 0; }
-/* Reaches back to the previous column's node; nodes sit at column start, so a
-   segment is exactly one column wide. */
-.ip-rel-seg { position: absolute; top: 20px; right: 100%; width: var(--ip-rel-col); height: 2px;
-  border-radius: 2px; margin-left: 8px; }
+.ip-rel-cell { position: relative; padding: 12px 6px; display: flex; flex-direction: column;
+  align-items: center; gap: 6px; min-width: 0; }
+/* Centre to centre: nodes sit mid-column, so a segment is exactly one column. */
+.ip-rel-seg { position: absolute; top: 20px; right: 50%; width: 100%; height: 2px; border-radius: 2px; }
 .ip-rel-seg-strong { background: var(--color-green-500); }
 .ip-rel-seg-pale { background: var(--color-green-200); }
-.ip-rel-node { position: relative; z-index: 1; width: 16px; height: 16px; border-radius: 50%;
+.ip-rel-node { position: relative; z-index: 2; width: 16px; height: 16px; border-radius: 50%;
   display: block; flex: 0 0 auto; }
 .ip-rel-node-healthy { background: var(--color-green-500); }
 .ip-rel-node-running { background: var(--color-blue-500); }
@@ -558,8 +558,9 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-node-split { background: transparent; box-shadow: inset 0 0 0 3px var(--color-green-500); }
 .ip-rel-node-empty { background: transparent; box-shadow: inset 0 0 0 2px var(--color-grey-300);
   width: 10px; height: 10px; }
-.ip-rel-labels { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; min-width: 0; }
-.ip-rel-entry { display: flex; flex-wrap: wrap; align-items: baseline; gap: 5px; }
+.ip-rel-labels { display: flex; flex-direction: column; align-items: center; gap: 2px;
+  min-width: 0; text-align: center; position: relative; z-index: 2; }
+.ip-rel-entry { display: flex; flex-wrap: wrap; justify-content: center; align-items: baseline; gap: 5px; }
 .ip-rel-ver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
   color: var(--color-navy-900); word-break: break-all; }
 .ip-rel-age, .ip-rel-tenants { font-size: 11px; color: var(--color-grey-600); }
@@ -569,19 +570,30 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-state-running { background: var(--color-blue-100); color: var(--color-blue-700); }
 .ip-rel-state-cancelled, .ip-rel-state-unknown { background: var(--color-grey-200); color: var(--color-grey-700); }
 
-/* History: no header bar, no second table. It reads as the same grid continuing
-   underneath the row it belongs to, indented by the same label column. */
-.ip-rel-history { padding: 4px 0 10px var(--ip-rel-label, 220px); background: transparent;
-  border-bottom: 1px solid var(--color-grey-200); }
+/* History reads as the same grid continuing under the row it belongs to. The
+   gutter matches the project column exactly, border included, so the columns
+   do not shift when a row opens. */
+.ip-rel-history { border-bottom: 1px solid var(--color-grey-200); }
+.ip-rel-history-gutter { padding: 0; }
+.ip-rel-history-body { flex: 1 1 auto; padding: 4px 0 10px; min-width: 0; }
+.ip-rel-history-body > .ip-rel-hempty,
+.ip-rel-history-body > .ip-rel-err,
+.ip-rel-history-body > .ip-rel-loading,
+.ip-rel-history-body > .ip-rel-hnote { padding-left: 6px; }
 .ip-rel-hrow { display: flex; align-items: center; min-height: 26px; }
 .ip-rel-hrow.undeployed { opacity: .7; }
-.ip-rel-hcell { position: relative; display: flex; align-items: center; gap: 6px;
-  padding: 0 12px 0 0; min-width: 0; }
+.ip-rel-hcell { position: relative; display: flex; align-items: center; justify-content: center;
+  padding: 0 6px; min-width: 0; }
 .ip-rel-hcell .ip-rel-seg { top: 50%; margin-top: -1px; }
-.ip-rel-hnode { position: relative; z-index: 1; width: 11px; height: 11px; border-radius: 50%;
+.ip-rel-hnode { position: relative; z-index: 2; width: 11px; height: 11px; border-radius: 50%;
   display: block; flex: 0 0 auto; }
+/* Text sits in front of the line and masks it, rather than the line cutting
+   through the words. */
 .ip-rel-hlabel { display: inline-flex; align-items: baseline; gap: 6px; white-space: nowrap;
-  position: absolute; left: 18px; z-index: 2; }
+  position: absolute; left: 50%; margin-left: 12px; z-index: 3;
+  padding: 0 4px; background: var(--color-white, #fff); }
+.ip-rel-hcellage { position: relative; z-index: 3; padding: 0 3px;
+  background: var(--color-white, #fff); }
 .ip-rel-hver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
   color: var(--color-navy-900); }
 .ip-rel-hchan { font-size: 10px; padding: 0 4px; border-radius: 3px;
@@ -597,12 +609,12 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 
 .dark .ip-rel-note { background: rgba(26,119,202,.14); }
 .dark .ip-rel-note p { color: var(--color-grey-200); }
-.dark .ip-rel-grid { border-color: var(--color-navy-600); }
+.dark .ip-rel-grid { border-color: var(--color-navy-600); background: var(--color-navy-900); }
 .dark .ip-rel-head { background: var(--color-navy-800); border-bottom-color: var(--color-navy-600); }
-.dark .ip-rel-row { border-bottom-color: var(--color-navy-700); }
+.dark .ip-rel-row, .dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
 .dark .ip-rel-row:hover { background: var(--color-navy-800); }
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
-.dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
+.dark .ip-rel-hlabel, .dark .ip-rel-hcellage { background: var(--color-navy-900); }
 .dark .ip-rel-proj-name, .dark .ip-rel-ver, .dark .ip-rel-hver { color: var(--color-grey-100); }
 .dark .ip-rel-group-name { color: var(--color-grey-100); }
 .dark .ip-rel-caret { border-left-color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -519,8 +519,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 
 .ip-rel-group { margin: 0 0 22px; }
 .ip-rel-group + .ip-rel-group { margin-top: 40px; }
-.ip-rel-group-name { display: flex; align-items: baseline; gap: 10px; margin: 0 0 12px;
-  padding-bottom: 8px; border-bottom: 1px solid var(--color-grey-200);
+.ip-rel-group-name { display: flex; align-items: baseline; gap: 10px; margin: 0 0 14px;
   font-size: 15px; font-weight: 600; color: var(--color-navy-900); }
 .ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
 .ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
@@ -630,7 +629,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
 
 .dark .ip-rel-proj-name, .dark .ip-rel-ver, .dark .ip-rel-hver { color: var(--color-grey-100); }
-.dark .ip-rel-group-name { color: var(--color-grey-100); border-bottom-color: var(--color-navy-700); }
+.dark .ip-rel-group-name { color: var(--color-grey-100); }
 .dark .ip-rel-caret { border-left-color: var(--color-grey-400); }
 .dark .ip-rel-node-empty { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
 .dark .ip-rel-age, .dark .ip-rel-tenants, .dark .ip-rel-hage, .dark .ip-rel-hlag,

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -986,6 +986,11 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
 .ip-pm-col > .ip-tn-panel { margin: 0; }
 
+/* Inputs and triggers stack in one grid cell: both answer "what feeds this
+   project", and both are short enough that a cell each left holes beside them. */
+.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.ip-pm-col > .ip-tn-panel { margin: 0; }
+
 /* Lifecycles run full width at the top: a phase order is the one thing on this
    page that is genuinely a sequence, and it deserves to be read left to right
    rather than folded into a column. */
@@ -1008,3 +1013,17 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-pm-phasebox { border-color: var(--color-navy-600); }
 .dark .ip-pm-phasename { color: var(--color-grey-100); }
 .dark .ip-pm-phasebox + .ip-pm-phasebox::before { background: var(--color-navy-500); }
+
+/* Lifecycles: environments named once across the top, each lifecycle a row.
+   Repeating the environments per lifecycle made two routes to the same
+   production look like two different productions. */
+.ip-pm-lctable { width: 100%; }
+.ip-pm-lctable th, .ip-pm-lctable td { vertical-align: top; }
+.ip-pm-lcname { display: flex; flex-direction: column; gap: 2px; min-width: 150px; }
+.ip-pm-lccell.is-absent { background: repeating-linear-gradient(45deg, transparent, transparent 5px,
+  rgba(127,127,127,.06) 5px, rgba(127,127,127,.06) 10px); }
+.ip-pm-phasename { font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
+.ip-pm-auto { margin-left: 6px; font-size: 9px; text-transform: uppercase; letter-spacing: .04em;
+  padding: 0 4px; border-radius: 3px; background: var(--color-green-100); color: var(--color-green-700); }
+.dark .ip-pm-phasename { color: var(--color-grey-100); }
+.dark .ip-pm-auto { background: rgba(0,135,77,.24); color: var(--color-green-300); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -1092,3 +1092,11 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-pm-seg { background: var(--color-navy-600); }
 .dark .ip-pm-node { color: var(--color-grey-100); box-shadow: inset 0 0 0 2px var(--color-navy-500); }
 .dark .ip-pm-node.is-auto { background: var(--color-green-500); color: #fff; box-shadow: none; }
+/* Destinations: how targets are chosen, then what that resolves to. */
+.ip-pm-sel { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 0 0 12px; font-size: 12px; }
+.ip-pm-sel dt { font-size: 10px; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--color-grey-600); padding-top: 3px; }
+.ip-pm-sel dd { margin: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
+.ip-pm-tstats { display: flex; flex-wrap: wrap; gap: 20px; margin: 0 0 8px; }
+.ip-pm-health { margin: 0 0 10px; }
+.dark .ip-pm-sel dt { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -681,3 +681,38 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-envtoggle[aria-checked="false"] .ip-rel-envtoggle-knob { left: 2px; }
 .ip-rel-hcell.is-off { visibility: hidden; }
 .dark .ip-rel-envtoggle[aria-checked="false"] .ip-rel-envtoggle-track { background: var(--color-navy-600); }
+
+/* Feature flags: the same line grammar as a release, in purple. A flag is not a
+   deployment and must not read as one — the colour, the square node and the
+   written percentage all say so independently. */
+.ip-rel-band { margin: 10px 0 0; padding-top: 8px; border-top: 1px dashed var(--color-grey-300); }
+.ip-rel-bandhead { display: flex; align-items: baseline; gap: 8px; margin: 0 0 4px;
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em;
+  color: var(--color-grey-700); }
+.ip-rel-bandcount { font-size: 10px; font-weight: 400; text-transform: none;
+  letter-spacing: 0; color: var(--color-grey-600); }
+.ip-rel-hnote-inline { margin: 4px 0 0; font-size: 10px; color: var(--color-grey-600); }
+.ip-rel-frow { min-height: 24px; }
+.ip-rel-fcell { flex-direction: row; gap: 5px; }
+.ip-rel-seg-flag { background: var(--color-purple-300); }
+.ip-rel-fnode { position: relative; z-index: 2; width: 10px; height: 10px; border-radius: 2px;
+  display: block; flex: 0 0 auto; }
+.ip-rel-fnode.is-on { background: var(--color-purple-500); }
+.ip-rel-fnode.is-partial { background: var(--color-purple-500);
+  box-shadow: 0 0 0 2px var(--color-purple-200); }
+.ip-rel-fnode.is-off-state { background: transparent;
+  box-shadow: inset 0 0 0 2px var(--color-grey-400); }
+.ip-rel-fbar { position: relative; z-index: 2; display: block; width: 34px; height: 4px;
+  border-radius: 2px; background: var(--color-grey-200); overflow: hidden; flex: 0 0 auto; }
+.ip-rel-fbar > span { display: block; height: 100%; background: var(--color-purple-500); }
+.ip-rel-flagname { font-size: 11px; font-weight: 600; color: var(--color-navy-900); }
+.ip-rel-flagpct { font-size: 10px; color: var(--color-purple-700);
+  font-variant-numeric: tabular-nums; }
+.dark .ip-rel-band { border-top-color: var(--color-navy-600); }
+.dark .ip-rel-bandhead { color: var(--color-grey-300); }
+.dark .ip-rel-bandcount, .dark .ip-rel-hnote-inline { color: var(--color-grey-400); }
+.dark .ip-rel-flagname { color: var(--color-grey-100); }
+.dark .ip-rel-flagpct { color: var(--color-purple-200); }
+.dark .ip-rel-fbar { background: var(--color-navy-700); }
+.dark .ip-rel-fnode.is-off-state { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
+.dark .ip-rel-fnode.is-partial { box-shadow: 0 0 0 2px var(--color-purple-800); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -483,3 +483,79 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-btn-secondary{background:transparent;color:var(--ring);border:1px solid var(--ring)}
 .ip-env-cell:focus-visible,.ip-heat:focus-visible{outline:none;box-shadow:var(--shadow-focus);position:relative;z-index:1}
 .ip-ev-who{color:var(--fg2);white-space:nowrap;text-align:right}
+
+/* ── Releases ───────────────────────────────────────────────────────────────
+   Environments are columns and each project is one line across them. The
+   segment between two columns carries the reading: solid where both hold the
+   same release, faded where they have drifted. Colour is backed by node shape
+   and a written state, because a green/red pair alone failed a deuteranopia
+   check earlier in this series. */
+.ip-rel-note { margin: 0 0 14px; padding: 10px 12px; border-left: 3px solid var(--color-blue-400);
+  background: var(--color-blue-100); border-radius: 4px; }
+.ip-rel-note p { margin: 0; font-size: 12px; color: var(--color-navy-700); }
+.ip-rel-legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 0 0 12px;
+  font-size: 11px; color: var(--color-grey-700); }
+.ip-rel-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.ip-rel-key { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+.ip-rel-key-healthy { background: var(--color-green-500); }
+.ip-rel-key-running { background: var(--color-blue-500); }
+.ip-rel-key-unhealthy { background: var(--color-red-500); }
+.ip-rel-key-split { background: transparent; border: 2px solid var(--color-green-500); }
+.ip-rel-key-strong { width: 22px; height: 2px; border-radius: 2px; background: var(--color-green-500); }
+.ip-rel-key-pale { width: 22px; height: 2px; border-radius: 2px; background: var(--color-green-200); }
+
+.ip-rel-grid { border: 1px solid var(--color-grey-300); border-radius: 6px; overflow: hidden; }
+.ip-rel-head, .ip-rel-row { display: flex; align-items: stretch; }
+.ip-rel-head { background: var(--color-grey-100); border-bottom: 1px solid var(--color-grey-300); }
+.ip-rel-row { border-bottom: 1px solid var(--color-grey-200); }
+.ip-rel-row:last-child { border-bottom: 0; }
+.ip-rel-proj { width: 220px; flex: 0 0 220px; padding: 12px 14px; display: flex; flex-direction: column;
+  justify-content: center; gap: 2px; border-right: 1px solid var(--color-grey-200); }
+.ip-rel-head .ip-rel-proj { font-size: 11px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--color-grey-700); }
+.ip-rel-proj-name { font-size: 13px; font-weight: 600; color: var(--color-navy-900); }
+.ip-rel-proj-group { font-size: 11px; color: var(--color-grey-600); }
+.ip-rel-track { flex: 1 1 auto; display: grid; }
+.ip-rel-envhead { padding: 10px 8px; text-align: center; font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .06em; color: var(--color-grey-700); }
+
+.ip-rel-cell { position: relative; padding: 12px 8px 12px; display: flex; flex-direction: column;
+  align-items: center; gap: 6px; min-width: 0; }
+/* Reaches back to the previous column's centre; equal columns make that one cell wide. */
+.ip-rel-seg { position: absolute; top: 20px; right: 50%; width: 100%; height: 2px; border-radius: 2px; }
+.ip-rel-seg-strong { background: var(--color-green-500); }
+.ip-rel-seg-pale { background: var(--color-green-200); }
+.ip-rel-node { position: relative; z-index: 1; width: 16px; height: 16px; border-radius: 50%;
+  display: block; flex: 0 0 auto; }
+.ip-rel-node-healthy { background: var(--color-green-500); }
+.ip-rel-node-running { background: var(--color-blue-500); }
+.ip-rel-node-unhealthy { background: var(--color-red-500); }
+.ip-rel-node-disabled { background: var(--color-slate-300); }
+/* A tenant split leaves two releases live at once — drawn as a ring so the
+   difference reads without relying on the label underneath. */
+.ip-rel-node-split { background: transparent; box-shadow: inset 0 0 0 3px var(--color-green-500); }
+.ip-rel-node-empty { background: transparent; box-shadow: inset 0 0 0 2px var(--color-grey-300);
+  width: 10px; height: 10px; }
+.ip-rel-labels { display: flex; flex-direction: column; align-items: center; gap: 2px; min-width: 0; }
+.ip-rel-entry { display: flex; flex-wrap: wrap; justify-content: center; align-items: baseline; gap: 5px; }
+.ip-rel-ver { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600;
+  color: var(--color-navy-900); word-break: break-all; }
+.ip-rel-age { font-size: 11px; color: var(--color-grey-600); }
+.ip-rel-none { font-size: 11px; color: var(--color-grey-500); }
+.ip-rel-tenants { font-size: 10px; padding: 1px 5px; border-radius: 3px;
+  background: var(--color-blue-100); color: var(--color-blue-700); }
+.ip-rel-state { font-size: 10px; padding: 1px 5px; border-radius: 3px; }
+.ip-rel-state-failed, .ip-rel-state-timedout { background: var(--color-red-100); color: var(--color-red-700); }
+.ip-rel-state-running { background: var(--color-blue-100); color: var(--color-blue-700); }
+.ip-rel-state-cancelled, .ip-rel-state-unknown { background: var(--color-grey-200); color: var(--color-grey-700); }
+
+.dark .ip-rel-note { background: rgba(26,119,202,.14); }
+.dark .ip-rel-note p { color: var(--color-grey-200); }
+.dark .ip-rel-grid { border-color: var(--color-navy-600); }
+.dark .ip-rel-head { background: var(--color-navy-800); border-bottom-color: var(--color-navy-600); }
+.dark .ip-rel-row { border-bottom-color: var(--color-navy-700); }
+.dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
+.dark .ip-rel-proj-name, .dark .ip-rel-ver { color: var(--color-grey-100); }
+.dark .ip-rel-node-empty { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
+.ip-rel-more { font-size: 10px; color: var(--color-grey-600); }
+.dark .ip-rel-more { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -825,3 +825,46 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-tn-th.is-sorted .ip-tn-sortbtn { font-weight: 700; }
 .ip-tn-sortbtn:hover .ip-tn-arrow { opacity: .8; }
 .dark .ip-tn-th.is-sorted .ip-tn-arrow { color: var(--color-blue-300); }
+
+/* Tenant detail: four independent facts across the top, then what is on it,
+   then what it deploys to. Nothing here merges the facts into a score. */
+.ip-tn-back { margin: 0 0 8px; font-size: 12px; }
+.ip-tn-taggroups { display: flex; flex-wrap: wrap; gap: 16px; margin: 8px 0 0; }
+.ip-tn-taggroup { display: inline-flex; align-items: center; gap: 6px; }
+.ip-tn-tagset { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-600); }
+.ip-tn-cards { display: flex; flex-wrap: wrap; gap: 12px; margin: 14px 0; }
+.ip-tn-card { flex: 1 1 240px; min-width: 0; border: 1px solid var(--color-grey-300);
+  border-radius: 6px; padding: 12px 14px; }
+.ip-tn-cardtitle { margin: 0 0 6px; font-size: 10px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--color-grey-600); }
+.ip-tn-cardhead { margin: 0; display: flex; align-items: center; gap: 7px;
+  font-size: 15px; font-weight: 600; color: var(--color-navy-900); }
+.ip-tn-carddetail { margin: 4px 0 0; font-size: 12px; color: var(--color-grey-700); }
+.ip-tn-cardlink { margin: 6px 0 0; font-size: 12px; }
+.ip-tn-panel { border: 1px solid var(--color-grey-300); border-radius: 6px;
+  padding: 12px 14px; margin: 0 0 14px; }
+.ip-tn-panel h3 { display: flex; align-items: baseline; gap: 10px; margin: 0 0 10px; font-size: 13px; }
+.ip-tn-split { display: flex; flex-wrap: wrap; gap: 14px; align-items: flex-start; }
+.ip-tn-split > .ip-tn-panel { flex: 1 1 320px; min-width: 0; }
+.ip-tn-matrix td, .ip-tn-matrix th { vertical-align: top; }
+.ip-tn-mproj { font-weight: 600; }
+.ip-tn-mcell.is-absent { background: repeating-linear-gradient(45deg, transparent, transparent 5px,
+  rgba(127,127,127,.06) 5px, rgba(127,127,127,.06) 10px); }
+.ip-tn-mver { display: block; font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600; }
+.ip-tn-mmeta { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--color-grey-700); }
+.ip-tn-legend { margin: 8px 0 0; font-size: 11px; color: var(--color-grey-600); }
+.ip-tn-warn { margin: 0; font-size: 12px; color: var(--color-red-700); }
+.ip-tn-targetgroup { margin: 0 0 12px; }
+.ip-tn-targethead { display: flex; align-items: baseline; gap: 8px; margin: 0 0 6px;
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-600); }
+.ip-tn-targets { list-style: none; margin: 0; padding: 0; }
+.ip-tn-target { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 12px; }
+.ip-tn-tname { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ip-tn-activity { list-style: none; margin: 0; padding: 0; }
+.ip-tn-activity li { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; }
+.ip-tn-actmain { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dark .ip-tn-card, .dark .ip-tn-panel { border-color: var(--color-navy-600); }
+.dark .ip-tn-cardhead { color: var(--color-grey-100); }
+.dark .ip-tn-cardtitle, .dark .ip-tn-carddetail, .dark .ip-tn-tagset,
+.dark .ip-tn-mmeta, .dark .ip-tn-legend, .dark .ip-tn-targethead { color: var(--color-grey-400); }
+.dark .ip-tn-warn { color: var(--color-red-200); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -1014,6 +1014,39 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-pm-phasename { color: var(--color-grey-100); }
 .dark .ip-pm-phasebox + .ip-pm-phasebox::before { background: var(--color-navy-500); }
 
+/* Inputs and triggers stack in one grid cell: both answer "what feeds this
+   project", and both are short enough that a cell each left holes beside them. */
+.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.ip-pm-col > .ip-tn-panel { margin: 0; }
+
+/* Inputs and triggers stack in one grid cell: both answer "what feeds this
+   project", and both are short enough that a cell each left holes beside them. */
+.ip-pm-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.ip-pm-col > .ip-tn-panel { margin: 0; }
+
+/* Lifecycles run full width at the top: a phase order is the one thing on this
+   page that is genuinely a sequence, and it deserves to be read left to right
+   rather than folded into a column. */
+.ip-pm-lifecycles { display: flex; flex-direction: column; gap: 14px; }
+.ip-pm-lifecycle + .ip-pm-lifecycle { padding-top: 12px; border-top: 1px solid var(--color-grey-200); }
+.ip-pm-lchead { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px; margin: 0 0 8px; }
+.ip-pm-flow { list-style: none; display: flex; flex-wrap: wrap; align-items: stretch;
+  gap: 8px; margin: 0; padding: 0; }
+.ip-pm-phasebox { position: relative; display: flex; flex-direction: column; gap: 5px;
+  padding: 8px 12px; min-width: 140px; border: 1px solid var(--color-grey-300);
+  border-radius: var(--radius-lg); background: var(--card); }
+/* The arrow is drawn between boxes rather than as a character, so it survives
+   the row wrapping. */
+.ip-pm-phasebox + .ip-pm-phasebox::before { content: ''; position: absolute; left: -8px; top: 50%;
+  width: 8px; height: 1px; background: var(--color-grey-400); }
+.ip-pm-phasename { font-size: 12px; font-weight: 600; color: var(--color-navy-900); }
+.ip-pm-auto { margin-left: 5px; font-size: 9px; text-transform: uppercase; letter-spacing: .04em;
+  opacity: .75; }
+.dark .ip-pm-lifecycle + .ip-pm-lifecycle { border-top-color: var(--color-navy-700); }
+.dark .ip-pm-phasebox { border-color: var(--color-navy-600); }
+.dark .ip-pm-phasename { color: var(--color-grey-100); }
+.dark .ip-pm-phasebox + .ip-pm-phasebox::before { background: var(--color-navy-500); }
+
 /* Lifecycles: environments named once across the top, each lifecycle a row.
    Repeating the environments per lifecycle made two routes to the same
    production look like two different productions. */
@@ -1027,3 +1060,35 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   padding: 0 4px; border-radius: 3px; background: var(--color-green-100); color: var(--color-green-700); }
 .dark .ip-pm-phasename { color: var(--color-grey-100); }
 .dark .ip-pm-auto { background: rgba(0,135,77,.24); color: var(--color-green-300); }
+
+/* Lifecycles, compact: environments once across the top, each lifecycle a line
+   beneath them. The node carries its phase number, so environments in the same
+   phase share a number and the grouping shows without repeating any names. */
+.ip-pm-lc { display: flex; flex-direction: column; gap: 2px; }
+.ip-pm-lcrow { display: flex; align-items: stretch; }
+.ip-pm-lcrow:not(.ip-pm-lchead):hover { background: rgba(127,127,127,.05); border-radius: 6px; }
+.ip-pm-lclabel { width: 190px; flex: 0 0 190px; display: flex; flex-direction: column;
+  justify-content: center; gap: 1px; padding: 6px 10px 6px 0; min-width: 0; }
+.ip-pm-lclabel .ip-tn-tname { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ip-pm-def { align-self: flex-start; font-size: 9px; text-transform: uppercase; letter-spacing: .05em;
+  padding: 0 4px; border-radius: 3px; background: var(--color-grey-200); color: var(--color-grey-700); }
+.ip-pm-lctrack { flex: 1 1 auto; display: grid; min-width: 0;
+  grid-template-columns: repeat(var(--ip-pm-cols), minmax(0, 1fr)); }
+.ip-pm-colhead { padding: 0 4px 6px; text-align: center; font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .05em; color: var(--color-grey-700);
+  overflow: hidden; text-overflow: ellipsis; }
+.ip-pm-cell { position: relative; display: flex; align-items: center; justify-content: center;
+  min-height: 30px; min-width: 0; }
+/* Centre to centre, so a lifecycle reads as one line across the environments. */
+.ip-pm-seg { position: absolute; right: 50%; top: 50%; width: 100%; height: 2px;
+  margin-top: -1px; background: var(--color-grey-300); border-radius: 2px; }
+.ip-pm-node { position: relative; z-index: 1; width: 20px; height: 20px; border-radius: 50%;
+  display: grid; place-items: center; font-size: 10px; font-weight: 600;
+  background: var(--card); color: var(--color-navy-900);
+  box-shadow: inset 0 0 0 2px var(--color-grey-400); }
+.ip-pm-node.is-auto { background: var(--color-green-500); color: #fff; box-shadow: none; }
+.dark .ip-pm-def { background: rgba(255,255,255,.10); color: var(--color-grey-300); }
+.dark .ip-pm-colhead { color: var(--color-grey-300); }
+.dark .ip-pm-seg { background: var(--color-navy-600); }
+.dark .ip-pm-node { color: var(--color-grey-100); box-shadow: inset 0 0 0 2px var(--color-navy-500); }
+.dark .ip-pm-node.is-auto { background: var(--color-green-500); color: #fff; box-shadow: none; }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -751,3 +751,25 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 }
 .dark .ip-rel-groups { --ip-rel-flagtint: #241C39; }
 .dark .ip-rel-frow { box-shadow: inset 3px 0 0 var(--color-purple-700); }
+
+/* Variable changes: amber, so they separate from flags (purple) and releases
+   (green) without any of the three borrowing another's meaning. Same wash
+   treatment as flags, including reassigning --ip-rel-surface so the labels mask
+   the line in the row's own colour rather than punching through it. */
+.ip-rel-groups { --ip-rel-vartint: var(--color-orange-100); }
+.ip-rel-vrow {
+  --ip-rel-surface: var(--ip-rel-vartint);
+  background: var(--ip-rel-vartint);
+  box-shadow: inset 3px 0 0 var(--color-orange-300);
+  border-radius: 0 3px 3px 0;
+}
+.ip-rel-vnode { position: relative; z-index: 2; width: 9px; height: 9px; flex: 0 0 auto;
+  background: var(--color-orange-500); transform: rotate(45deg); border-radius: 1px; }
+.ip-rel-varname { font-size: 11px; font-weight: 600; color: var(--color-navy-900); }
+.ip-rel-vardelta { font-size: 10px; color: var(--color-orange-700);
+  font-family: var(--font-mono, monospace); }
+.ip-rel-vardelta.is-secret { font-family: inherit; font-style: italic; }
+.dark .ip-rel-groups { --ip-rel-vartint: #33240F; }
+.dark .ip-rel-vrow { box-shadow: inset 3px 0 0 var(--color-orange-700); }
+.dark .ip-rel-varname { color: var(--color-grey-100); }
+.dark .ip-rel-vardelta { color: var(--color-orange-200); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -522,12 +522,12 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-rel-group-count { font-size: 11px; font-weight: 400; color: var(--color-grey-600); }
 .ip-rel-hidden { margin: 6px 0 0; font-size: 11px; color: var(--color-grey-600); }
 
-.ip-rel-grid { border: 1px solid var(--color-grey-300); border-radius: 6px; overflow: hidden;
-  background: var(--ip-rel-surface); }
+.ip-rel-grid { background: transparent; }
 .ip-rel-head, .ip-rel-row, .ip-rel-history { display: flex; align-items: stretch; }
-.ip-rel-head { background: var(--color-grey-100); border-bottom: 1px solid var(--color-grey-300); }
-.ip-rel-row { border-bottom: 1px solid var(--color-grey-200); cursor: pointer; }
-.ip-rel-row:last-child { border-bottom: 0; }
+/* The header stands free above the cards. It carries a transparent border so
+   its columns sit on exactly the same x as the bordered cards below. */
+.ip-rel-head { background: transparent; border: 1px solid transparent; padding-bottom: 2px; }
+.ip-rel-row { cursor: pointer; border-radius: 7px; }
 .ip-rel-row:hover { background: var(--color-grey-100); }
 .ip-rel-row:focus-visible { outline: 2px solid var(--color-blue-500); outline-offset: -2px; }
 /* The project name sits at the top of the cell: rows grow tall when a cell
@@ -619,8 +619,8 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-note { background: rgba(26,119,202,.14); }
 .dark .ip-rel-note p { color: var(--color-grey-200); }
 .dark .ip-rel-groups { --ip-rel-surface: var(--color-navy-900); }
-.dark .ip-rel-grid { border-color: var(--color-navy-600); background: var(--ip-rel-surface); }
-.dark .ip-rel-head { background: var(--color-navy-800); border-bottom-color: var(--color-navy-600); }
+.dark .ip-rel-grid { background: transparent; }
+.dark .ip-rel-head { background: transparent; }
 .dark .ip-rel-row, .dark .ip-rel-history { border-bottom-color: var(--color-navy-700); }
 .dark .ip-rel-row:hover { background: var(--color-navy-800); }
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
@@ -906,3 +906,19 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .ip-tn-flagpanel .ip-tn-tname { white-space: normal; }
 .ip-tn-flagpanel .ip-tn-flagstates { justify-content: flex-start; gap: 4px 10px; }
 .dark .ip-tn-flagpanel .ip-tn-target { border-bottom-color: var(--color-navy-700); }
+
+/* One card per project, rather than rows inside a single box. A shared border
+   with dividers reads as a table; discrete cards read as a list of projects,
+   which is what this is. */
+.ip-rel-cards { display: flex; flex-direction: column; gap: 8px; }
+.ip-rel-card { border: 1px solid var(--color-grey-300); border-radius: 8px;
+  background: var(--ip-rel-surface); overflow: hidden;
+  transition: border-color .12s ease, box-shadow .12s ease; }
+.ip-rel-card:hover { border-color: var(--color-grey-400); }
+.ip-rel-card.is-open { border-color: var(--color-blue-400);
+  box-shadow: 0 1px 3px rgba(16,24,40,.06); }
+.ip-rel-card .ip-rel-history { border-bottom: 0; border-top: 1px solid var(--color-grey-200); }
+.dark .ip-rel-card { border-color: var(--color-navy-600); }
+.dark .ip-rel-card:hover { border-color: var(--color-navy-500); }
+.dark .ip-rel-card.is-open { border-color: var(--color-blue-600); box-shadow: none; }
+.dark .ip-rel-card .ip-rel-history { border-top-color: var(--color-navy-700); }

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -542,8 +542,10 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   color: var(--color-navy-900); word-break: break-all; }
 .ip-rel-age { font-size: 11px; color: var(--color-grey-600); }
 .ip-rel-none { font-size: 11px; color: var(--color-grey-500); }
-.ip-rel-tenants { font-size: 10px; padding: 1px 5px; border-radius: 3px;
-  background: var(--color-blue-100); color: var(--color-blue-700); }
+/* The tenant count is the least important number in the cell, and a filled chip
+   made it the brightest thing on the row — badly so against a dark background.
+   It reads as quiet text now, in the same weight as the age beside it. */
+.ip-rel-tenants { font-size: 11px; color: var(--color-grey-600); }
 .ip-rel-state { font-size: 10px; padding: 1px 5px; border-radius: 3px; }
 .ip-rel-state-failed, .ip-rel-state-timedout { background: var(--color-red-100); color: var(--color-red-700); }
 .ip-rel-state-running { background: var(--color-blue-100); color: var(--color-blue-700); }
@@ -557,5 +559,20 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
 .dark .ip-rel-proj { border-right-color: var(--color-navy-700); }
 .dark .ip-rel-proj-name, .dark .ip-rel-ver { color: var(--color-grey-100); }
 .dark .ip-rel-node-empty { box-shadow: inset 0 0 0 2px var(--color-navy-500); }
+.dark .ip-rel-tenants, .dark .ip-rel-age, .dark .ip-rel-none { color: var(--color-grey-400); }
+/* Translucent fills sit on the row rather than punching a light block through it. */
+.dark .ip-rel-state-failed, .dark .ip-rel-state-timedout {
+  background: rgba(214,61,61,.22); color: var(--color-red-200); }
+.dark .ip-rel-state-running { background: rgba(26,119,202,.24); color: var(--color-blue-200); }
+.dark .ip-rel-state-cancelled, .dark .ip-rel-state-unknown {
+  background: rgba(255,255,255,.10); color: var(--color-grey-300); }
+.dark .ip-rel-proj-group { color: var(--color-grey-400); }
+.dark .ip-rel-envhead, .dark .ip-rel-head .ip-rel-proj { color: var(--color-grey-300); }
+.dark .ip-rel-legend { color: var(--color-grey-400); }
+
+/* Projects sits in its own group above the Infrastructure heading. */
+.ip-nav-lead { margin-bottom: 10px; padding-bottom: 10px;
+  border-bottom: 1px solid var(--color-grey-200); }
+.dark .ip-nav-lead { border-bottom-color: var(--color-navy-700); }
 .ip-rel-more { font-size: 10px; color: var(--color-grey-600); }
 .dark .ip-rel-more { color: var(--color-grey-400); }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1104,7 +1104,8 @@ const Views = (function () {
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
       + '<div class="ip-rel-proj">'
       +   '<span class="ip-rel-caret" aria-hidden="true"></span>'
-      +   '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
+      +   '<a class="ip-rel-proj-name" href="#projects/' + escHtml(proj.id) + '" data-projectlink="1">'
+      +     escHtml(proj.name) + '</a>'
       + '</div>'
       + _relTrack(cells, cols)
       + '</div>';
@@ -1477,6 +1478,9 @@ const Views = (function () {
         if (IP.loadProjectFlags) IP.loadProjectFlags(id);
       }
     };
+    root.querySelectorAll('[data-projectlink]').forEach(a => {
+      a.addEventListener('click', ev => ev.stopPropagation());
+    });
     root.querySelectorAll('.ip-rel-row[data-project]').forEach(el => {
       el.addEventListener('click', () => toggle(el));
       el.addEventListener('keydown', ev => {
@@ -2041,6 +2045,114 @@ const Views = (function () {
       +   'it needs a request per connected project.</p>';
   }
 
+  // ─── Project map ───────────────────────────────────────────────────────────
+  // What goes in, what starts it, what it does, where it lands. Panels rather
+  // than a flow diagram: the same facts, without asking anyone to trust a
+  // layout before they trust the data.
+  function renderProjectMap(IP) {
+    const st = IP.projectMap || { status: 'loading' };
+    const back = '<p class="ip-tn-back"><a href="#projects">← All projects</a></p>';
+    if (st.status === 'loading' || !st.status) {
+      return back + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading project…</p></div>';
+    }
+    if (st.status === 'error') {
+      return back + '<div class="ip-state"><h3>Couldn\'t load this project</h3><p>'
+        + escHtml(st.error || 'Unknown error') + '</p></div>';
+    }
+    const m = st.model;
+    const panel = (title, meta, body) => '<section class="ip-tn-panel"><h3>' + escHtml(title)
+      + (meta ? '<span class="ip-tn-age">' + escHtml(meta) + '</span>' : '') + '</h3>' + body + '</section>';
+    const none = text => '<p class="ip-tn-muted">' + escHtml(text) + '</p>';
+
+    // Inputs: what the process consumes.
+    const inputs = (m.git
+        ? '<div class="ip-pm-git"><span class="ip-tn-tagset">Repository</span>'
+          + '<span class="ip-pm-repo">' + escHtml(m.git.url || 'version controlled') + '</span>'
+          + (m.git.branch ? '<span class="ip-chipx ip-chipx-tag">' + escHtml(m.git.branch) + '</span>' : '')
+          + (m.git.basePath ? '<span class="ip-tn-age">' + escHtml(m.git.basePath) + '</span>' : '')
+          + '</div>' : '')
+      + (m.inputs.length
+          ? '<ul class="ip-tn-targets">' + m.inputs.map(f =>
+              '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(f.feed) + '</span>'
+              + (f.feedType ? '<span class="ip-chipx ip-chipx-tag">' + escHtml(f.feedType) + '</span>' : '')
+              + '<span class="ip-tn-age">' + escHtml(f.packages.join(', ')) + '</span></li>').join('') + '</ul>'
+          : (m.git ? '' : none('No packages are consumed by this process.')));
+
+    // Triggers: what starts a deployment. Anything driven from outside Octopus
+    // is invisible here, and saying so is better than implying nothing does.
+    const triggers = (m.triggers.length
+        ? '<ul class="ip-tn-targets">' + m.triggers.map(t =>
+            '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(t.name) + '</span>'
+            + '<span class="ip-chipx ip-chipx-tag">' + escHtml(t.kind) + '</span>'
+            + '<span class="ip-tn-age">' + escHtml(t.detail) + '</span>'
+            + (t.disabled ? '<span class="ip-pill ip-pill-disabled">disabled</span>' : '') + '</li>').join('') + '</ul>'
+        : none('No triggers are configured.'))
+      + (m.autoCreateRelease ? '<p class="ip-tn-legend">A release is created automatically when a new package arrives.</p>' : '')
+      + '<p class="ip-tn-legend">Deployments started from CI or the API do not appear here — only what Octopus itself triggers.</p>';
+
+    // Process: what it does, in order. Names, types and packages — the detail
+    // lives in Octopus and this is a map, not a second editor.
+    const process = m.processError ? none(m.processError)
+      : (m.process.length
+          ? '<ol class="ip-pm-steps">' + m.process.map(stp =>
+              '<li class="ip-pm-step' + (stp.disabled ? ' is-disabled' : '') + '">'
+              + '<span class="ip-pm-num">' + stp.number + '</span>'
+              + '<span class="ip-pm-stepmain">'
+              +   '<span class="ip-tn-tname">' + escHtml(stp.name) + '</span>'
+              +   '<span class="ip-tn-age">' + escHtml(stp.type) + '</span>'
+              + '</span>'
+              + (stp.roles.length ? '<span class="ip-pm-roles">' + stp.roles.map(r =>
+                  '<span class="ip-chipx ip-chipx-tag">' + escHtml(r) + '</span>').join('') + '</span>' : '')
+              + (stp.packages.length ? '<span class="ip-tn-age">'
+                  + escHtml(stp.packages.map(pk => pk.packageId).join(', ')) + '</span>' : '')
+              + (stp.disabled ? '<span class="ip-pill ip-pill-disabled">disabled</span>' : '')
+              + '</li>').join('') + '</ol>'
+          : none('This project has no deployment steps.'));
+
+    // Destinations: where it lands, in lifecycle order.
+    const destinations = (m.phases.length
+        ? '<ol class="ip-pm-phases">' + m.phases.map(ph =>
+            '<li class="ip-pm-phase"><span class="ip-tn-tname">' + escHtml(ph.name) + '</span>'
+            + '<span class="ip-pm-envs">'
+            +   ph.automatic.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
+            +   ph.optional.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
+            + '</span>'
+            + (ph.automatic.length ? '<span class="ip-tn-age">automatic</span>' : '')
+            + '</li>').join('') + '</ol>'
+        : none('This project has no lifecycle phases.'))
+      + (m.roles.length
+          ? '<p class="ip-tn-legend">Targets are selected by role: '
+            + m.roles.map(r => escHtml(r)).join(', ') + '.</p>' : '')
+      + (m.tenantedMode === 'Untenanted'
+          ? '<p class="ip-tn-legend">Untenanted — it deploys to environments directly.</p>'
+          : '<p class="ip-tn-legend">' + escHtml(m.tenantedMode) + ' — '
+            + m.tenantCount.toLocaleString() + (m.tenantCount === 1 ? ' tenant is' : ' tenants are')
+            + ' connected to this project.</p>');
+
+    const channels = m.channels.length
+      ? '<ul class="ip-tn-targets">' + m.channels.map(c =>
+          '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(c.name) + '</span>'
+          + (c.isDefault ? '<span class="ip-chipx ip-chipx-tag">default</span>' : '')
+          + '<span class="ip-tn-age">' + (c.rules ? c.rules + (c.rules === 1 ? ' version rule' : ' version rules')
+              : 'no version rules') + '</span></li>').join('') + '</ul>'
+      : none('This project has one implicit channel.');
+
+    return back
+      + '<header class="ip-head"><h2>' + escHtml(m.name)
+      +   (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
+      +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
+      +   _tnDescription(m.description)
+      + '</header>'
+      + '<div class="ip-pm-grid">'
+      +   panel('Inputs', m.git ? 'version controlled' : '', inputs)
+      +   panel('Triggers', m.triggers.length ? m.triggers.length + ' configured' : '', triggers)
+      +   panel('Process', m.process.length ? m.process.length + (m.process.length === 1 ? ' step' : ' steps') : '', process)
+      +   panel('Destinations', m.lifecycle, destinations)
+      +   panel('Channels', '', channels)
+      + '</div>'
+      + '<p class="ip-rel-hnote-inline">The activity timeline and the project\'s variables are not on this page yet.</p>';
+  }
+
   function renderThemeToggle(IP) {
     const dark = IP.theme === 'dark';
     const icon = dark ? _sunSvg : _moonSvg;
@@ -2091,7 +2203,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderProjectMap, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2032,6 +2032,41 @@ const Views = (function () {
         + '</section>'
       : '';
 
+    // Feature flags, on the same terms as the tenant page: on and off are
+    // counts, and the ones in between are named, because "4 in between" is not
+    // something anyone can act on without knowing which four.
+    const flagPanel = (function () {
+      if (m.flagsError) return none(m.flagsError);
+      const fm = m.flags;
+      if (!fm) return '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading flags…</span></div>';
+      if (!fm.total) return none('This project has no feature flags.');
+      if (!fm.scoped) return none(fm.total + ' flags, but no lifecycle environments to place them in.');
+      const stat = (n, lbl, tone) => '<span class="ip-tn-stat">'
+        + '<span class="ip-tn-statnum ip-tn-stat-' + escHtml(tone) + '">' + n + '</span>'
+        + '<span class="ip-tn-statlabel">' + escHtml(lbl) + '</span></span>';
+      const tone = k => k === 'on' ? 'healthy' : (k === 'partial' ? 'warning' : 'disabled');
+      const text = c => c.key === 'partial' ? c.percent + '%'
+        : c.key === 'on' ? (c.tenantCount ? 'on · ' + c.tenantCount + ' targeted' : 'on')
+        : 'off';
+      const rows = fm.between.map(f =>
+        '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(f.name) + '</span>'
+        + '<span class="ip-tn-flagstates">' + f.cells.map(c =>
+            '<span class="ip-tn-flagstate"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone(c.key)) + '"></span>'
+            + escHtml(c.envName) + ' <span class="ip-tn-age">' + escHtml(text(c)) + '</span></span>').join('')
+        + '</span></li>').join('');
+      const notes = [];
+      notes.push('A flag with no setting for an environment falls back to its default, and is counted that way.');
+      if (fm.truncated) notes.push('Only the first ' + fm.flags.length + ' of ' + fm.total + ' flags were read.');
+      return '<div class="ip-tn-stats">'
+        +   stat(fm.fullyOn, 'on', 'healthy')
+        +   stat(fm.fullyOff, 'off', 'disabled')
+        +   stat(fm.betweenCount, 'rolling out', fm.betweenCount ? 'warning' : 'disabled')
+        + '</div>'
+        + (rows ? '<ul class="ip-tn-targets">' + rows + '</ul>'
+                : '<p class="ip-tn-muted">Every flag is on or off across all of these environments.</p>')
+        + '<p class="ip-tn-legend">' + notes.map(escHtml).join(' ') + '</p>';
+    })();
+
     return back
       + '<header class="ip-head"><h2>' + escHtml(m.name) + (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
       +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
@@ -2129,21 +2164,34 @@ const Views = (function () {
       }).join('');
     };
 
-    const lifecycles = (m.lifecycles && m.lifecycles.length && cols.length)
+    const lcRow = lc => '<div class="ip-pm-lcrow">'
+      + '<div class="ip-pm-lclabel">'
+      +   '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
+      +   (lc.isDefault ? '<span class="ip-pm-def">default</span>' : '')
+      +   '<span class="ip-tn-age">' + escHtml(lc.channels.length
+            ? lc.channels.join(', ') : 'unused') + '</span>'
+      + '</div>'
+      + '<div class="ip-pm-lctrack">' + lcTrack(lc) + '</div>'
+      + '</div>';
+    // Most projects have one route that matters. The others are shown on ask,
+    // so a project with six channel lifecycles does not open with six lines.
+    const lcAll = m.lifecycles || [];
+    const lcMain = lcAll.filter(lc => lc.isDefault);
+    const lcRest = lcAll.filter(lc => !lc.isDefault);
+    const lcLead = lcMain.length ? lcMain : lcAll.slice(0, 1);
+    const lcMore = lcMain.length ? lcRest : lcAll.slice(1);
+
+    const lifecycles = (lcAll.length && cols.length)
       ? '<div class="ip-pm-lc" style="--ip-pm-cols:' + cols.length + '">'
         + '<div class="ip-pm-lcrow ip-pm-lchead"><div class="ip-pm-lclabel"></div>'
         +   '<div class="ip-pm-lctrack">' + cols.map(e =>
               '<div class="ip-pm-colhead">' + escHtml(e) + '</div>').join('') + '</div></div>'
-        + m.lifecycles.map(lc =>
-            '<div class="ip-pm-lcrow">'
-            + '<div class="ip-pm-lclabel">'
-            +   '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
-            +   (lc.isDefault ? '<span class="ip-pm-def">default</span>' : '')
-            +   '<span class="ip-tn-age">' + escHtml(lc.channels.length
-                  ? lc.channels.join(', ') : 'unused') + '</span>'
-            + '</div>'
-            + '<div class="ip-pm-lctrack">' + lcTrack(lc) + '</div>'
-            + '</div>').join('')
+        + lcLead.map(lcRow).join('')
+        + (lcMore.length
+            ? '<details class="ip-pm-lcmore"><summary>' + lcMore.length
+              + (lcMore.length === 1 ? ' other lifecycle' : ' other lifecycles')
+              + '</summary>' + lcMore.map(lcRow).join('') + '</details>'
+            : '')
         + '</div>'
         + '<p class="ip-tn-legend">Numbers are lifecycle phases — environments sharing a number are in the '
         + 'same phase. A filled node deploys automatically. No node means that lifecycle never reaches '
@@ -2222,6 +2270,41 @@ const Views = (function () {
               : 'no version rules') + '</span></li>').join('') + '</ul>'
       : none('This project has one implicit channel.');
 
+    // Feature flags, on the same terms as the tenant page: on and off are
+    // counts, and the ones in between are named, because "4 in between" is not
+    // something anyone can act on without knowing which four.
+    const flagPanel = (function () {
+      if (m.flagsError) return none(m.flagsError);
+      const fm = m.flags;
+      if (!fm) return '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading flags…</span></div>';
+      if (!fm.total) return none('This project has no feature flags.');
+      if (!fm.scoped) return none(fm.total + ' flags, but no lifecycle environments to place them in.');
+      const stat = (n, lbl, tone) => '<span class="ip-tn-stat">'
+        + '<span class="ip-tn-statnum ip-tn-stat-' + escHtml(tone) + '">' + n + '</span>'
+        + '<span class="ip-tn-statlabel">' + escHtml(lbl) + '</span></span>';
+      const tone = k => k === 'on' ? 'healthy' : (k === 'partial' ? 'warning' : 'disabled');
+      const text = c => c.key === 'partial' ? c.percent + '%'
+        : c.key === 'on' ? (c.tenantCount ? 'on · ' + c.tenantCount + ' targeted' : 'on')
+        : 'off';
+      const rows = fm.between.map(f =>
+        '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(f.name) + '</span>'
+        + '<span class="ip-tn-flagstates">' + f.cells.map(c =>
+            '<span class="ip-tn-flagstate"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone(c.key)) + '"></span>'
+            + escHtml(c.envName) + ' <span class="ip-tn-age">' + escHtml(text(c)) + '</span></span>').join('')
+        + '</span></li>').join('');
+      const notes = [];
+      notes.push('A flag with no setting for an environment falls back to its default, and is counted that way.');
+      if (fm.truncated) notes.push('Only the first ' + fm.flags.length + ' of ' + fm.total + ' flags were read.');
+      return '<div class="ip-tn-stats">'
+        +   stat(fm.fullyOn, 'on', 'healthy')
+        +   stat(fm.fullyOff, 'off', 'disabled')
+        +   stat(fm.betweenCount, 'rolling out', fm.betweenCount ? 'warning' : 'disabled')
+        + '</div>'
+        + (rows ? '<ul class="ip-tn-targets">' + rows + '</ul>'
+                : '<p class="ip-tn-muted">Every flag is on or off across all of these environments.</p>')
+        + '<p class="ip-tn-legend">' + notes.map(escHtml).join(' ') + '</p>';
+    })();
+
     return back
       + '<header class="ip-head"><h2>' + escHtml(m.name)
       +   (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
@@ -2234,12 +2317,15 @@ const Views = (function () {
       // What feeds the project, what starts it, and what it ships through are
       // the same question asked three ways, so they share a column.
       +   '<div class="ip-pm-col">'
+      +     panel('Channels', m.channels.length ? String(m.channels.length) : '', channels)
       +     panel('Inputs', m.git ? 'version controlled' : '', inputs)
       +     panel('Triggers', m.triggers.length ? m.triggers.length + ' configured' : '', triggers)
-      +     panel('Channels', m.channels.length ? String(m.channels.length) : '', channels)
       +   '</div>'
       +   panel('Process', m.process.length ? m.process.length + (m.process.length === 1 ? ' step' : ' steps') : '', process)
-      +   panel('Destinations', '', destinations)
+      +   '<div class="ip-pm-col">'
+      +     panel('Destinations', '', destinations)
+      +     panel('Feature flags', m.flags && m.flags.total ? String(m.flags.total) : '', flagPanel)
+      +   '</div>'
       + '</div>'
       + '<p class="ip-rel-hnote-inline">The activity timeline and the project\'s variables are not on this page yet.</p>';
   }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1041,15 +1041,100 @@ const Views = (function () {
     return '<div class="ip-rel-cell">' + seg + node + '<div class="ip-rel-labels">' + labels + more + '</div></div>';
   }
 
-  function _relRow(proj, envCount) {
+  function _relRow(proj, envCount, expanded, history) {
     const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i])).join('');
-    return '<div class="ip-rel-row">'
+    const row = '<div class="ip-rel-row' + (expanded ? ' expanded' : '') + '" role="button" tabindex="0"'
+      + ' aria-expanded="' + (expanded ? 'true' : 'false') + '"'
+      + ' data-project="' + escHtml(proj.id) + '">'
       + '<div class="ip-rel-proj">'
-      +   '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
-      +   (proj.groupName ? '<span class="ip-rel-proj-group">' + escHtml(proj.groupName) + '</span>' : '')
+      +   '<span class="ip-rel-caret" aria-hidden="true"></span>'
+      +   '<span class="ip-rel-proj-text">'
+      +     '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
+      +     (proj.groupName ? '<span class="ip-rel-proj-group">' + escHtml(proj.groupName) + '</span>' : '')
+      +   '</span>'
       + '</div>'
       + '<div class="ip-rel-track" style="grid-template-columns:repeat(' + envCount + ',minmax(0,1fr))">' + cells + '</div>'
       + '</div>';
+    return row + (expanded ? _relHistory(proj, envCount, history) : '');
+  }
+
+  // ─── Expanded history ──────────────────────────────────────────────────────
+  // Same columns as the row above, one line per release, so a release's journey
+  // reads across and the environment it stopped at is where the line stops.
+  function _relHistory(proj, envCount, history) {
+    const st = history || { status: 'loading' };
+    const wrap = inner => '<div class="ip-rel-history"><div class="ip-rel-proj ip-rel-history-side">' + inner.side
+      + '</div><div class="ip-rel-history-body">' + inner.body + '</div></div>';
+
+    if (st.status === 'loading' || !st.status) {
+      return wrap({ side: '<span class="ip-rel-history-title">History</span>',
+        body: '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>' });
+    }
+    if (st.status === 'error') {
+      return wrap({ side: '<span class="ip-rel-history-title">History</span>',
+        body: '<p class="ip-rel-err">' + escHtml(st.error || 'Could not load this project\'s releases.') + '</p>' });
+    }
+    const m = st.model;
+    if (!m.releases.length) {
+      return wrap({ side: '<span class="ip-rel-history-title">History</span>',
+        body: '<p class="ip-rel-none">No releases have been created for this project.</p>' });
+    }
+
+    const multiChannel = m.channels.length > 1;
+    const rows = m.releases.map(r => {
+      const cells = r.cells.map((c, i) => {
+        const seg = (i > 0 && i <= r.frontier)
+          ? '<span class="ip-rel-seg ip-rel-seg-' + (i === r.frontier ? 'strong' : 'pale') + '"></span>' : '';
+        if (!c.deployed) return '<div class="ip-rel-hcell">' + seg + '</div>';
+        const tone = REL_STATE_TONE[c.stateKey] || 'disabled';
+        return '<div class="ip-rel-hcell">' + seg
+          + '<span class="ip-rel-hnode ip-rel-node-' + escHtml(tone) + '" title="'
+          + escHtml(c.stateLabel + ' in ' + c.envName) + '"></span>'
+          + '<span class="ip-rel-hage">' + escHtml(_relWhen(c.when)) + '</span></div>';
+      }).join('');
+      const meta = '<span class="ip-rel-hver">' + escHtml(r.version) + '</span>'
+        + (multiChannel && r.channelName ? '<span class="ip-rel-hchan">' + escHtml(r.channelName) + '</span>' : '')
+        + '<span class="ip-rel-hage">' + escHtml(_relWhen(r.assembled)) + '</span>'
+        + (r.lag > 0 ? '<span class="ip-rel-hlag">' + r.lag + ' behind'
+            + (multiChannel ? ' in ' + escHtml(r.channelName) : '') + '</span>' : '')
+        + (!r.everDeployed ? '<span class="ip-rel-hnever">created, never deployed</span>' : '');
+      return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">'
+        + '<div class="ip-rel-hmeta">' + meta + '</div>'
+        + '<div class="ip-rel-track" style="grid-template-columns:repeat(' + envCount + ',minmax(0,1fr))">' + cells + '</div>'
+        + '</div>';
+    }).join('');
+
+    const notes = [];
+    if (m.windowed) notes.push('The most recent ' + m.historyCount + ' releases per channel. Older releases are not shown.');
+    if (m.neverDeployedCount) notes.push(m.neverDeployedCount + ' of these were created and never deployed anywhere.');
+
+    return wrap({
+      side: '<span class="ip-rel-history-title">History</span>'
+        + '<span class="ip-rel-history-count">' + m.releases.length
+        + (m.releases.length === 1 ? ' release' : ' releases') + '</span>'
+        + (multiChannel ? '<span class="ip-rel-history-count">' + m.channels.length + ' channels</span>' : ''),
+      body: rows + (notes.length ? '<div class="ip-rel-hnote">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '')
+    });
+  }
+
+  function bindProjects(IP) {
+    const root = document.getElementById('main-content');
+    if (!root) return;
+    const toggle = el => {
+      const id = el.getAttribute('data-project');
+      if (!id) return;
+      IP.projectOpen = IP.projectOpen || {};
+      if (IP.projectOpen[id]) delete IP.projectOpen[id]; else IP.projectOpen[id] = true;
+      root.innerHTML = renderProjects(IP);
+      bindProjects(IP);
+      if (IP.projectOpen[id] && IP.loadProjectHistory) IP.loadProjectHistory(id);
+    };
+    root.querySelectorAll('.ip-rel-row[data-project]').forEach(el => {
+      el.addEventListener('click', () => toggle(el));
+      el.addEventListener('keydown', ev => {
+        if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); toggle(el); }
+      });
+    });
   }
 
   function renderProjects(IP) {
@@ -1079,15 +1164,40 @@ const Views = (function () {
     const notes = [];
     if (m.truncated.capped) notes.push('Showing ' + m.truncated.shown + ' projects — the server caps the dashboard at ' + m.truncated.projectLimit + '. Projects beyond the cap are missing from this view.');
     if (m.truncated.isFiltered) notes.push('The dashboard is filtered on this instance, so this is a subset of its projects.');
-    const hidden = m.hiddenEnvironments || [];
-    if (hidden.length) notes.push('Not shown, because nothing has been deployed to them: '
-      + hidden.map(e => e.name).join(', ') + '.');
     const note = notes.length
       ? '<div class="ip-rel-note">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '';
 
-    const cols = m.environments.length;
-    const heads = m.environments.map(e => '<div class="ip-rel-envhead">' + escHtml(e.name) + '</div>').join('');
-    const rows = m.projects.map(p => _relRow(p, cols)).join('');
+    const open = IP.projectOpen || {};
+    const hist = IP.projectHistory || {};
+
+    // One grid per project group. Each carries its own columns, because an
+    // environment is hidden where the group never deploys to it — a group that
+    // has nothing to do with Preprod shouldn't hold a column open for it.
+    const blocks = (m.groups || []).map(g => {
+      const cols = g.environments.length;
+      if (!cols) {
+        return '<section class="ip-rel-group">'
+          + '<h3 class="ip-rel-group-name">' + escHtml(g.name) + '</h3>'
+          + '<p class="ip-rel-none">Nothing in this group has been deployed yet.</p></section>';
+      }
+      const heads = g.environments.map(e => '<div class="ip-rel-envhead">' + escHtml(e.name) + '</div>').join('');
+      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id])).join('');
+      const hiddenNote = g.hiddenEnvironments.length
+        ? '<p class="ip-rel-hidden">Not shown, because this group has never deployed to them: '
+          + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>'
+        : '';
+      return '<section class="ip-rel-group">'
+        + '<h3 class="ip-rel-group-name">' + escHtml(g.name)
+        +   '<span class="ip-rel-group-count">' + g.projects.length
+        +   (g.projects.length === 1 ? ' project' : ' projects') + '</span></h3>'
+        + '<div class="ip-rel-grid">'
+        +   '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>'
+        +     '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols + ',minmax(0,1fr))">' + heads + '</div></div>'
+        +   rows
+        + '</div>'
+        + hiddenNote
+        + '</section>';
+    }).join('');
 
     return head + note
       + '<div class="ip-rel-legend">'
@@ -1098,13 +1208,8 @@ const Views = (function () {
       +   '<span><i class="ip-rel-key ip-rel-key-strong"></i>Same release both sides</span>'
       +   '<span><i class="ip-rel-key ip-rel-key-pale"></i>Drifted</span>'
       + '</div>'
-      + '<div class="ip-rel-grid">'
-      +   '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>'
-      +     '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols + ',minmax(0,1fr))">' + heads + '</div></div>'
-      +   rows
-      + '</div>';
+      + blocks;
   }
-
   function renderThemeToggle(IP) {
     const dark = IP.theme === 'dark';
     const icon = dark ? _sunSvg : _moonSvg;
@@ -1155,7 +1260,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderProjects, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, bindProjects, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2109,29 +2109,45 @@ const Views = (function () {
               + '</li>').join('') + '</ol>'
           : none('This project has no deployment steps.'));
 
-    // Environments are named once, across the top, and each lifecycle is a row
-    // across them — the same grammar the rest of the dashboard uses. Repeating
-    // the environments per lifecycle made two routes to production look like
-    // two different productions.
+    // Environments once across the top; each lifecycle is a line beneath them
+    // with a numbered node in every environment it reaches. The number is the
+    // phase, so two environments in one phase carry the same number and the
+    // grouping is visible without repeating any names.
     const cols = m.lifecycleEnvironments || [];
+    const lcTrack = lc => {
+      const reached = lc.cells.map((c, i) => c.reached ? i : -1).filter(i => i >= 0);
+      const first = reached.length ? reached[0] : -1;
+      const last = reached.length ? reached[reached.length - 1] : -1;
+      return lc.cells.map((c, i) => {
+        const within = first >= 0 && i > first && i <= last;
+        const seg = within ? '<span class="ip-pm-seg"></span>' : '';
+        if (!c.reached) return '<div class="ip-pm-cell">' + seg + '</div>';
+        return '<div class="ip-pm-cell">' + seg
+          + '<span class="ip-pm-node' + (c.automatic ? ' is-auto' : '') + '" title="'
+          + escHtml('Phase ' + (c.phaseIndex + 1) + ': ' + c.phase + (c.automatic ? ' — deploys automatically' : ''))
+          + '">' + (c.phaseIndex + 1) + '</span></div>';
+      }).join('');
+    };
+
     const lifecycles = (m.lifecycles && m.lifecycles.length && cols.length)
-      ? '<table class="ip-table ip-pm-lctable"><thead><tr><th>Lifecycle</th>'
-        + cols.map(e => '<th>' + escHtml(e) + '</th>').join('') + '</tr></thead><tbody>'
+      ? '<div class="ip-pm-lc" style="--ip-pm-cols:' + cols.length + '">'
+        + '<div class="ip-pm-lcrow ip-pm-lchead"><div class="ip-pm-lclabel"></div>'
+        +   '<div class="ip-pm-lctrack">' + cols.map(e =>
+              '<div class="ip-pm-colhead">' + escHtml(e) + '</div>').join('') + '</div></div>'
         + m.lifecycles.map(lc =>
-            '<tr><td class="ip-pm-lcname">'
-            + '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
-            + (lc.isDefault ? '<span class="ip-chipx ip-chipx-tag">default</span>' : '')
-            + '<span class="ip-tn-age">' + escHtml(lc.channels.length
-                ? lc.channels.join(', ') : 'no channel uses this') + '</span>'
-            + '</td>'
-            + lc.cells.map(c => c.reached
-                ? '<td class="ip-pm-lccell"><span class="ip-pm-phasename">' + escHtml(c.phase) + '</span>'
-                  + (c.automatic ? '<span class="ip-pm-auto">auto</span>' : '') + '</td>'
-                : '<td class="ip-pm-lccell is-absent"></td>').join('')
-            + '</tr>').join('')
-        + '</tbody></table>'
-        + '<p class="ip-tn-legend">A blank cell means that lifecycle never reaches that environment. '
-        + '<em>auto</em> marks a phase that deploys without being asked.</p>'
+            '<div class="ip-pm-lcrow">'
+            + '<div class="ip-pm-lclabel">'
+            +   '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
+            +   (lc.isDefault ? '<span class="ip-pm-def">default</span>' : '')
+            +   '<span class="ip-tn-age">' + escHtml(lc.channels.length
+                  ? lc.channels.join(', ') : 'unused') + '</span>'
+            + '</div>'
+            + '<div class="ip-pm-lctrack">' + lcTrack(lc) + '</div>'
+            + '</div>').join('')
+        + '</div>'
+        + '<p class="ip-tn-legend">Numbers are lifecycle phases — environments sharing a number are in the '
+        + 'same phase. A filled node deploys automatically. No node means that lifecycle never reaches '
+        + 'that environment.</p>'
       : none('This project has no lifecycle phases.');
 
     // Destinations keeps what the lifecycle panel does not say: how targets are

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1864,9 +1864,12 @@ const Views = (function () {
     // thing to go and look at, not part of the answer to "what is on this
     // tenant right now".
     const unsetCount = m.readiness ? m.readiness.count : 0;
-    const tab = (unsetCount && IP.tenantTab === 'Variables') ? 'Variables' : 'Overview';
+    const flagCount = (IP.flags && IP.flags.status === 'ready') ? IP.flags.model.liveCount : null;
     const tabDefs = [{ key: 'Overview', label: 'Overview' }];
     if (unsetCount) tabDefs.push({ key: 'Variables', label: 'Unset variables', count: unsetCount });
+    if (IP.flags) tabDefs.push({ key: 'Flags', label: 'Feature flags', count: flagCount || 0 });
+    const wanted = IP.tenantTab || 'Overview';
+    const tab = tabDefs.some(d => d.key === wanted) ? wanted : 'Overview';
     const tabs = tabDefs.length > 1
       ? '<nav class="ip-tabs ip-section-tabs" aria-label="Tenant sections">'
         + tabDefs.map(d => '<button type="button" class="ip-tab ip-section-tab'
@@ -1884,6 +1887,47 @@ const Views = (function () {
       +     '</h3>' + infra + '</section>'
       +   '<section class="ip-tn-panel"><h3>Activity</h3>' + activity + '</section>'
       + '</div>';
+
+    const fl = IP.flags;
+    const flagsTab = (function () {
+      if (!fl) return '';
+      if (fl.status === 'loading') {
+        return '<section class="ip-tn-panel"><h3>Feature flags</h3>'
+          + '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading flags…</span></div></section>';
+      }
+      if (fl.status === 'error') {
+        return '<section class="ip-tn-panel"><h3>Feature flags</h3>'
+          + '<p class="ip-tn-muted">' + escHtml(fl.error) + '</p></section>';
+      }
+      const fm = fl.model;
+      if (!fm.flags.length) {
+        return '<section class="ip-tn-panel"><h3>Feature flags</h3>'
+          + '<p class="ip-tn-muted">None of the ' + fm.total + ' flags on this tenant\'s projects is on for it.</p></section>';
+      }
+      const tone = k => k === 'on' ? 'healthy' : (k === 'partial' || k === 'segment' ? 'warning' : 'disabled');
+      const label = c => c.key === 'on' ? (c.via === 'targeted' ? 'on · targeted' : 'on')
+        : c.key === 'partial' ? c.percent + '% rollout'
+        : c.key === 'segment' ? 'segment rule'
+        : c.key === 'excluded' ? 'excluded'
+        : c.key === 'off' ? (c.via === 'targeted-elsewhere' ? 'other tenants' : 'off') : '—';
+      const rows = fm.flags.map(f =>
+        '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(f.name) + '</span>'
+        + '<span class="ip-tn-age">' + escHtml(f.projectName) + '</span>'
+        + '<span class="ip-tn-flagstates">' + f.cells.map(c =>
+            '<span class="ip-tn-flagstate"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone(c.key)) + '"></span>'
+            + escHtml(c.envName) + ' <span class="ip-tn-age">' + escHtml(label(c)) + '</span></span>').join('')
+        + '</span></li>').join('');
+      const notes = [];
+      if (fm.undecidedCount) notes.push(fm.undecidedCount + ' of these depend on a percentage rollout or a segment rule, '
+        + 'which are decided when the flag is evaluated rather than in its configuration — this cannot say yes or no for a tenant.');
+      if (fm.unreadableProjects) notes.push(fm.unreadableProjects + ' of this tenant\'s projects could not be read for flags.');
+      if (fm.truncated) notes.push('Only the first ' + fm.projectsRead + ' projects were read.');
+      return '<section class="ip-tn-panel"><h3>Feature flags'
+        + '<span class="ip-tn-age">' + fm.liveCount + ' on for this tenant, of ' + fm.total + ' across its projects</span></h3>'
+        + '<ul class="ip-tn-targets">' + rows + '</ul>'
+        + (notes.length ? '<p class="ip-tn-legend">' + notes.map(escHtml).join(' ') + '</p>' : '')
+        + '</section>';
+    })();
 
     const variablesTab = m.readiness && m.readiness.missing.length
       ? '<section class="ip-tn-panel"><h3>Unset variables'
@@ -1908,9 +1952,9 @@ const Views = (function () {
       + '</header>'
       + '<div class="ip-tn-cards">' + connCard + readyCard + outcomeCard + '</div>'
       + tabs
-      + (tab === 'Variables' ? variablesTab : overviewTab)
-      + '<p class="ip-rel-hnote-inline">Currency against each project\'s latest release, and feature flags scoped to this '
-      +   'tenant, are not shown yet — both need a request per connected project.</p>';
+      + (tab === 'Variables' ? variablesTab : (tab === 'Flags' ? flagsTab : overviewTab))
+      + '<p class="ip-rel-hnote-inline">Currency against each project\'s latest release is not shown yet — '
+      +   'it needs a request per connected project.</p>';
   }
 
   function renderThemeToggle(IP) {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -988,6 +988,120 @@ const Views = (function () {
   const _moonSvg = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" '
     + 'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
     + '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>';
+
+  // ─── Releases ──────────────────────────────────────────────────────────────
+  // One line per project across the environments: what each is running now.
+  // A segment is drawn strong where two environments hold a release in common
+  // and pale where they have drifted, so the eye finds the break rather than
+  // reading four version strings and comparing them.
+  const REL_STATE_TONE = { success:'healthy', failed:'unhealthy', timedout:'unhealthy', cancelled:'disabled', running:'running', unknown:'disabled' };
+
+  function _relWhen(iso) {
+    if (!iso) return '';
+    const then = Date.parse(iso);
+    if (isNaN(then)) return '';
+    const mins = Math.round((Date.now() - then) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + 'm ago';
+    const hours = Math.round(mins / 60);
+    if (hours < 48) return hours + 'h ago';
+    return Math.round(hours / 24) + 'd ago';
+  }
+
+  function _relCell(cell, link) {
+    const seg = link && link !== 'none'
+      ? '<span class="ip-rel-seg ip-rel-seg-' + escHtml(link) + '"></span>' : '';
+    if (!cell.entries.length) {
+      return '<div class="ip-rel-cell">' + seg
+        + '<span class="ip-rel-node ip-rel-node-empty" title="Never deployed"></span>'
+        + '<div class="ip-rel-labels"><span class="ip-rel-none">Never deployed</span></div></div>';
+    }
+    const head = cell.entries[0];
+    const split = cell.entries.length > 1;
+    const node = '<span class="ip-rel-node ip-rel-node-' + escHtml(REL_STATE_TONE[head.stateKey] || 'disabled')
+      + (split ? ' ip-rel-node-split' : '') + '" title="' + escHtml(head.stateLabel + ' in ' + cell.envName) + '"></span>';
+    // Cap the stack. Beyond a few, the useful facts are the newest release and
+    // how far the estate is spread, not forty version strings.
+    const REL_MAX_ENTRIES = 3;
+    const shown = cell.entries.slice(0, REL_MAX_ENTRIES);
+    const hidden = cell.entries.length - shown.length;
+    const labels = shown.map(e =>
+      '<span class="ip-rel-entry">'
+      + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
+      + '<span class="ip-rel-age">' + escHtml(_relWhen(e.when)) + '</span>'
+      + (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml(e.tenantCount + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : '')
+      + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '')
+      + '</span>').join('');
+    const more = hidden > 0
+      ? '<span class="ip-rel-more">+' + hidden + ' more '
+        + (hidden === 1 ? 'release' : 'releases')
+        + (cell.tenantTotal ? ' across ' + cell.tenantTotal + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') : '')
+        + '</span>'
+      : '';
+    return '<div class="ip-rel-cell">' + seg + node + '<div class="ip-rel-labels">' + labels + more + '</div></div>';
+  }
+
+  function _relRow(proj, envCount) {
+    const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i])).join('');
+    return '<div class="ip-rel-row">'
+      + '<div class="ip-rel-proj">'
+      +   '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
+      +   (proj.groupName ? '<span class="ip-rel-proj-group">' + escHtml(proj.groupName) + '</span>' : '')
+      + '</div>'
+      + '<div class="ip-rel-track" style="grid-template-columns:repeat(' + envCount + ',minmax(0,1fr))">' + cells + '</div>'
+      + '</div>';
+  }
+
+  function renderReleases(IP) {
+    const st = IP.releases || { status: 'idle' };
+    const head = '<header class="ip-head"><h2>Releases</h2>'
+      + '<p class="ip-sub">What each project is running in each environment, and where a release has stopped moving.</p></header>';
+
+    if (st.status === 'loading' || st.status === 'idle') {
+      return head + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading the project dashboard…</p></div>';
+    }
+    if (st.status === 'error') {
+      return head + '<div class="ip-state"><h3>Couldn\'t load the project dashboard</h3>'
+        + '<p>' + escHtml(st.error || 'Unknown error') + '</p></div>';
+    }
+    const m = st.model;
+    if (!m.projects.length) {
+      return head + '<div class="ip-empty"><h3>No projects in this space</h3>'
+        + '<p>Releases move through environments once a space has a project to deploy.</p></div>';
+    }
+    if (!m.environments.length) {
+      return head + '<div class="ip-empty"><h3>No environments in this space</h3>'
+        + '<p>There is nothing for a release to progress through yet.</p></div>';
+    }
+
+    // The dashboard endpoint caps and filters. A capped list is
+    // indistinguishable from a small instance unless we say so.
+    const notes = [];
+    if (m.truncated.capped) notes.push('Showing ' + m.truncated.shown + ' projects — the server caps the dashboard at ' + m.truncated.projectLimit + '. Projects beyond the cap are missing from this view.');
+    if (m.truncated.isFiltered) notes.push('The dashboard is filtered on this instance, so this is a subset of its projects.');
+    const note = notes.length
+      ? '<div class="ip-rel-note">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '';
+
+    const cols = m.environments.length;
+    const heads = m.environments.map(e => '<div class="ip-rel-envhead">' + escHtml(e.name) + '</div>').join('');
+    const rows = m.projects.map(p => _relRow(p, cols)).join('');
+
+    return head + note
+      + '<div class="ip-rel-legend">'
+      +   '<span><i class="ip-rel-key ip-rel-key-healthy"></i>Deployed</span>'
+      +   '<span><i class="ip-rel-key ip-rel-key-running"></i>In progress</span>'
+      +   '<span><i class="ip-rel-key ip-rel-key-unhealthy"></i>Failed or timed out</span>'
+      +   '<span><i class="ip-rel-key ip-rel-key-split"></i>Split across tenants</span>'
+      +   '<span><i class="ip-rel-key ip-rel-key-strong"></i>Same release both sides</span>'
+      +   '<span><i class="ip-rel-key ip-rel-key-pale"></i>Drifted</span>'
+      + '</div>'
+      + '<div class="ip-rel-grid">'
+      +   '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>'
+      +     '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols + ',minmax(0,1fr))">' + heads + '</div></div>'
+      +   rows
+      + '</div>';
+  }
+
   function renderThemeToggle(IP) {
     const dark = IP.theme === 'dark';
     const icon = dark ? _sunSvg : _moonSvg;
@@ -1038,7 +1152,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderReleases, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1080,7 +1080,7 @@ const Views = (function () {
       + '<div class="ip-rel-labels">' + summary + labels + more + '</div></div>';
   }
 
-  function _relRow(proj, cols, expanded, history, windowLabel, envOff) {
+  function _relRow(proj, cols, expanded, history, windowLabel, envOff, flags) {
     const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i], expanded)).join('');
     const row = '<div class="ip-rel-row' + (expanded ? ' expanded' : '') + '" role="button" tabindex="0"'
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
@@ -1090,7 +1090,7 @@ const Views = (function () {
       + '</div>'
       + _relTrack(cells, cols)
       + '</div>';
-    return row + (expanded ? _relHistory(proj, cols, history, windowLabel, envOff || {}) : '');
+    return row + (expanded ? _relHistory(proj, cols, history, windowLabel, envOff || {}, flags) : '');
   }
 
   // The version rides the line at the furthest environment the release reached.
@@ -1132,13 +1132,86 @@ const Views = (function () {
     return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">' + _relTrack(cells, cols) + '</div>';
   }
 
-  function _relHistory(proj, cols, history, windowLabel, envOff) {
+  // ─── Feature flags ─────────────────────────────────────────────────────────
+  // Flags travel across environments the way a release does, so they get the
+  // same line in the same columns — in purple, because a flag is not a
+  // deployment and must not borrow the deployment palette. Only flags mid-
+  // journey get a row; a flag on everywhere is not news, and there are 146 of
+  // those on Octopus Server alone.
+  function _relFlagRow(flag, cols, envOff) {
+    const off = envOff || {};
+    let frontier = -1;
+    flag.cells.forEach((c, i) => { if ((c.state === 'on' || c.state === 'partial') && !off[c.envId]) frontier = i; });
+    const first = flag.cells.reduce((f, c, i) =>
+      (f === -1 && (c.state === 'on' || c.state === 'partial') && !off[c.envId] ? i : f), -1);
+
+    const label = '<span class="ip-rel-hlabel">'
+      + '<span class="ip-rel-flagname">' + escHtml(flag.name) + '</span>'
+      + (frontier >= 0 && flag.cells[frontier].state === 'partial'
+          ? '<span class="ip-rel-flagpct">' + flag.cells[frontier].percent + '%</span>' : '')
+      + '</span>';
+
+    const cells = flag.cells.map((c, i) => {
+      if (off[c.envId]) return '<div class="ip-rel-hcell is-off"></div>';
+      const within = first >= 0 && i > first && i <= frontier;
+      const seg = within ? '<span class="ip-rel-seg ip-rel-seg-flag"></span>' : '';
+      let node = '';
+      if (c.state === 'on') node = '<span class="ip-rel-fnode is-on" title="' + escHtml('On in ' + c.envName) + '"></span>';
+      else if (c.state === 'partial') node = '<span class="ip-rel-fnode is-partial" title="'
+        + escHtml(c.percent + '% in ' + c.envName) + '"></span>';
+      else if (c.state === 'off') node = '<span class="ip-rel-fnode is-off-state" title="' + escHtml('Off in ' + c.envName) + '"></span>';
+      // A percentage gets a bar, the same instrument the tenant split uses.
+      const bar = c.state === 'partial'
+        ? '<span class="ip-rel-fbar" title="' + escHtml(c.percent + '% in ' + c.envName)
+          + '"><span style="width:' + c.percent + '%"></span></span>' : '';
+      return '<div class="ip-rel-hcell ip-rel-fcell">' + seg + node + bar + (i === frontier ? label : '') + '</div>';
+    }).join('');
+
+    return '<div class="ip-rel-hrow ip-rel-frow">' + _relTrack(cells, cols) + '</div>';
+  }
+
+  function _relFlags(proj, cols, flags, envOff) {
+    const st = flags || { status: 'loading' };
+    if (st.status === 'loading' || !st.status) {
+      return '<div class="ip-rel-band"><p class="ip-rel-bandhead">Feature flags</p>'
+        + '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading flags…</span></div></div>';
+    }
+    if (st.status === 'error') {
+      return '<div class="ip-rel-band"><p class="ip-rel-bandhead">Feature flags</p>'
+        + '<p class="ip-rel-hempty">' + escHtml(st.error) + '</p></div>';
+    }
+    const m = st.model;
+    if (!m.total) return '';
+    const settled = m.settled || {};
+    const quiet = [];
+    if (settled.onEverywhere) quiet.push(settled.onEverywhere + ' on everywhere');
+    if (settled.offEverywhere) quiet.push(settled.offEverywhere + ' off everywhere');
+    if (settled.noOverrides) quiet.push(settled.noOverrides + ' on their default');
+    const note = quiet.length
+      ? '<p class="ip-rel-hnote-inline">Not shown: ' + escHtml(quiet.join(', ')) + '.</p>' : '';
+    const truncated = m.truncated
+      ? '<p class="ip-rel-hnote-inline">More than ' + m.total + ' flags — this reads the first few pages only.</p>' : '';
+
+    if (!m.flags.length) {
+      return '<div class="ip-rel-band"><p class="ip-rel-bandhead">Feature flags</p>'
+        + '<p class="ip-rel-hempty">All ' + m.total + ' flags are settled — none is part-way through a rollout.</p>'
+        + note + '</div>';
+    }
+    return '<div class="ip-rel-band">'
+      + '<p class="ip-rel-bandhead">Feature flags in flight'
+      +   '<span class="ip-rel-bandcount">' + m.flags.length + ' of ' + m.total + '</span></p>'
+      + m.flags.map(f => _relFlagRow(f, cols, envOff)).join('')
+      + note + truncated
+      + '</div>';
+  }
+
+  function _relHistory(proj, cols, history, windowLabel, envOff, flags) {
     const st = history || { status: 'loading' };
     // Mirrors the row structure — a label-width gutter, then the track — so an
     // expanded row starts on exactly the same x as the row it opened from.
     const wrap = body => '<div class="ip-rel-history">'
       + '<div class="ip-rel-proj ip-rel-history-gutter" aria-hidden="true"></div>'
-      + '<div class="ip-rel-history-body">' + body + '</div></div>';
+      + '<div class="ip-rel-history-body">' + body + _relFlags(proj, cols, flags, envOff) + '</div></div>';
 
     if (st.status === 'loading' || !st.status) {
       return wrap('<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>');
@@ -1231,7 +1304,8 @@ const Views = (function () {
           +   '<span class="ip-rel-envtoggle-track"><span class="ip-rel-envtoggle-knob"></span></span>'
           + '</button></div>';
       }).join('');
-      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active, off)).join('');
+      const flg = IP.projectFlags || {};
+      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active, off, flg[p.id])).join('');
       const hiddenNote = g.hiddenEnvironments.length
         ? '<p class="ip-rel-hidden">Not shown, because this group has never deployed to them: '
           + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
@@ -1266,7 +1340,10 @@ const Views = (function () {
       IP.projectOpen = IP.projectOpen || {};
       if (IP.projectOpen[id]) delete IP.projectOpen[id]; else IP.projectOpen[id] = true;
       redraw();
-      if (IP.projectOpen[id] && IP.loadProjectHistory) IP.loadProjectHistory(id);
+      if (IP.projectOpen[id]) {
+        if (IP.loadProjectHistory) IP.loadProjectHistory(id);
+        if (IP.loadProjectFlags) IP.loadProjectFlags(id);
+      }
     };
     root.querySelectorAll('.ip-rel-row[data-project]').forEach(el => {
       el.addEventListener('click', () => toggle(el));

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -989,12 +989,17 @@ const Views = (function () {
     + 'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
     + '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>';
 
-  // ─── Releases ──────────────────────────────────────────────────────────────
-  // One line per project across the environments: what each is running now.
-  // A segment is drawn strong where two environments hold a release in common
-  // and pale where they have drifted, so the eye finds the break rather than
-  // reading four version strings and comparing them.
+  // ─── Projects ──────────────────────────────────────────────────────────────
+  // Environments are fixed-width columns, left-aligned, identical on every row
+  // of the page — collapsed rows, history rows, and every project group. Any
+  // spare width goes to the right of the last column rather than stretching the
+  // columns, so a node sits at the same x wherever it appears.
   const REL_STATE_TONE = { success:'healthy', failed:'unhealthy', timedout:'unhealthy', cancelled:'disabled', running:'running', unknown:'disabled' };
+
+  function _relTrack(inner, cols) {
+    return '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols + ',var(--ip-rel-col))">'
+      + inner + '</div>';
+  }
 
   function _relWhen(iso) {
     if (!iso) return '';
@@ -1009,8 +1014,7 @@ const Views = (function () {
   }
 
   function _relCell(cell, link) {
-    const seg = link && link !== 'none'
-      ? '<span class="ip-rel-seg ip-rel-seg-' + escHtml(link) + '"></span>' : '';
+    const seg = link && link !== 'none' ? '<span class="ip-rel-seg ip-rel-seg-' + escHtml(link) + '"></span>' : '';
     if (!cell.entries.length) {
       return '<div class="ip-rel-cell">' + seg
         + '<span class="ip-rel-node ip-rel-node-empty" title="Never deployed"></span>'
@@ -1020,10 +1024,8 @@ const Views = (function () {
     const split = cell.entries.length > 1;
     const node = '<span class="ip-rel-node ip-rel-node-' + escHtml(REL_STATE_TONE[head.stateKey] || 'disabled')
       + (split ? ' ip-rel-node-split' : '') + '" title="' + escHtml(head.stateLabel + ' in ' + cell.envName) + '"></span>';
-    // Cap the stack. Beyond a few, the useful facts are the newest release and
-    // how far the estate is spread, not forty version strings.
-    const REL_MAX_ENTRIES = 3;
-    const shown = cell.entries.slice(0, REL_MAX_ENTRIES);
+    const MAX = 3;
+    const shown = cell.entries.slice(0, MAX);
     const hidden = cell.entries.length - shown.length;
     const labels = shown.map(e =>
       '<span class="ip-rel-entry">'
@@ -1033,121 +1035,102 @@ const Views = (function () {
       + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '')
       + '</span>').join('');
     const more = hidden > 0
-      ? '<span class="ip-rel-more">+' + hidden + ' more '
-        + (hidden === 1 ? 'release' : 'releases')
-        + (cell.tenantTotal ? ' across ' + cell.tenantTotal + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') : '')
-        + '</span>'
+      ? '<span class="ip-rel-more">+' + hidden + ' more ' + (hidden === 1 ? 'release' : 'releases')
+        + (cell.tenantTotal ? ' across ' + cell.tenantTotal + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') : '') + '</span>'
       : '';
     return '<div class="ip-rel-cell">' + seg + node + '<div class="ip-rel-labels">' + labels + more + '</div></div>';
   }
 
-  function _relRow(proj, envCount, expanded, history) {
+  function _relRow(proj, cols, expanded, history, windowLabel) {
     const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i])).join('');
     const row = '<div class="ip-rel-row' + (expanded ? ' expanded' : '') + '" role="button" tabindex="0"'
-      + ' aria-expanded="' + (expanded ? 'true' : 'false') + '"'
-      + ' data-project="' + escHtml(proj.id) + '">'
+      + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
       + '<div class="ip-rel-proj">'
       +   '<span class="ip-rel-caret" aria-hidden="true"></span>'
       +   '<span class="ip-rel-proj-text">'
       +     '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
-      +     (proj.groupName ? '<span class="ip-rel-proj-group">' + escHtml(proj.groupName) + '</span>' : '')
       +   '</span>'
       + '</div>'
-      + '<div class="ip-rel-track" style="grid-template-columns:repeat(' + envCount + ',minmax(0,1fr))">' + cells + '</div>'
+      + _relTrack(cells, cols)
       + '</div>';
-    return row + (expanded ? _relHistory(proj, envCount, history) : '');
+    return row + (expanded ? _relHistory(proj, cols, history, windowLabel) : '');
   }
 
-  // ─── Expanded history ──────────────────────────────────────────────────────
-  // Same columns as the row above, one line per release, so a release's journey
-  // reads across and the environment it stopped at is where the line stops.
-  function _relHistory(proj, envCount, history) {
+  // The version rides the line at the furthest environment the release reached,
+  // rather than sitting in a column on the left. Where a release stops is then
+  // the same thing as where its name is.
+  function _relHistoryRow(r, cols, multiChannel) {
+    const meta = '<span class="ip-rel-hlabel">'
+      + '<span class="ip-rel-hver">' + escHtml(r.version) + '</span>'
+      + (multiChannel && r.channelName ? '<span class="ip-rel-hchan">' + escHtml(r.channelName) + '</span>' : '')
+      + '<span class="ip-rel-hage">' + escHtml(_relWhen(r.assembled)) + '</span>'
+      + (r.lag > 0 ? '<span class="ip-rel-hlag">' + r.lag + ' behind'
+          + (multiChannel ? ' in ' + escHtml(r.channelName) : '') + '</span>' : '')
+      + (!r.everDeployed ? '<span class="ip-rel-hnever">created, never deployed</span>' : '')
+      + '</span>';
+
+    const cells = r.cells.map((c, i) => {
+      const seg = (i > 0 && i <= r.frontier)
+        ? '<span class="ip-rel-seg ip-rel-seg-' + (i === r.frontier ? 'strong' : 'pale') + '"></span>' : '';
+      const atHead = (r.frontier === -1 && i === 0) || i === r.frontier;
+      const node = c.deployed
+        ? '<span class="ip-rel-hnode ip-rel-node-' + escHtml(REL_STATE_TONE[c.stateKey] || 'disabled')
+          + '" title="' + escHtml(c.stateLabel + ' in ' + c.envName) + '"></span>'
+        : (r.frontier === -1 && i === 0 ? '<span class="ip-rel-hnode ip-rel-node-empty"></span>' : '');
+      const age = c.deployed && i !== r.frontier
+        ? '<span class="ip-rel-hcellage">' + escHtml(_relWhen(c.when)) + '</span>' : '';
+      return '<div class="ip-rel-hcell">' + seg + node + age + (atHead ? meta : '') + '</div>';
+    }).join('');
+
+    return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">' + _relTrack(cells, cols) + '</div>';
+  }
+
+  function _relHistory(proj, cols, history, windowLabel) {
     const st = history || { status: 'loading' };
-    const wrap = inner => '<div class="ip-rel-history"><div class="ip-rel-proj ip-rel-history-side">' + inner.side
-      + '</div><div class="ip-rel-history-body">' + inner.body + '</div></div>';
+    const wrap = body => '<div class="ip-rel-history">' + body + '</div>';
 
     if (st.status === 'loading' || !st.status) {
-      return wrap({ side: '<span class="ip-rel-history-title">History</span>',
-        body: '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>' });
+      return wrap('<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>');
     }
     if (st.status === 'error') {
-      return wrap({ side: '<span class="ip-rel-history-title">History</span>',
-        body: '<p class="ip-rel-err">' + escHtml(st.error || 'Could not load this project\'s releases.') + '</p>' });
+      return wrap('<p class="ip-rel-err">' + escHtml(st.error || 'Could not load this project\'s releases.') + '</p>');
     }
     const m = st.model;
+    if (!m.totalReleases) {
+      return wrap('<p class="ip-rel-hempty">No releases have been created for this project.</p>');
+    }
     if (!m.releases.length) {
-      return wrap({ side: '<span class="ip-rel-history-title">History</span>',
-        body: '<p class="ip-rel-none">No releases have been created for this project.</p>' });
+      return wrap('<p class="ip-rel-hempty">Nothing moved in the last ' + escHtml(String(windowLabel).toLowerCase())
+        + '. ' + m.totalReleases + ' older ' + (m.totalReleases === 1 ? 'release' : 'releases')
+        + ' — widen the window to see ' + (m.totalReleases === 1 ? 'it' : 'them') + '.</p>');
     }
 
     const multiChannel = m.channels.length > 1;
-    const rows = m.releases.map(r => {
-      const cells = r.cells.map((c, i) => {
-        const seg = (i > 0 && i <= r.frontier)
-          ? '<span class="ip-rel-seg ip-rel-seg-' + (i === r.frontier ? 'strong' : 'pale') + '"></span>' : '';
-        if (!c.deployed) return '<div class="ip-rel-hcell">' + seg + '</div>';
-        const tone = REL_STATE_TONE[c.stateKey] || 'disabled';
-        return '<div class="ip-rel-hcell">' + seg
-          + '<span class="ip-rel-hnode ip-rel-node-' + escHtml(tone) + '" title="'
-          + escHtml(c.stateLabel + ' in ' + c.envName) + '"></span>'
-          + '<span class="ip-rel-hage">' + escHtml(_relWhen(c.when)) + '</span></div>';
-      }).join('');
-      const meta = '<span class="ip-rel-hver">' + escHtml(r.version) + '</span>'
-        + (multiChannel && r.channelName ? '<span class="ip-rel-hchan">' + escHtml(r.channelName) + '</span>' : '')
-        + '<span class="ip-rel-hage">' + escHtml(_relWhen(r.assembled)) + '</span>'
-        + (r.lag > 0 ? '<span class="ip-rel-hlag">' + r.lag + ' behind'
-            + (multiChannel ? ' in ' + escHtml(r.channelName) : '') + '</span>' : '')
-        + (!r.everDeployed ? '<span class="ip-rel-hnever">created, never deployed</span>' : '');
-      return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">'
-        + '<div class="ip-rel-hmeta">' + meta + '</div>'
-        + '<div class="ip-rel-track" style="grid-template-columns:repeat(' + envCount + ',minmax(0,1fr))">' + cells + '</div>'
-        + '</div>';
-    }).join('');
-
+    const rows = m.releases.map(r => _relHistoryRow(r, cols, multiChannel)).join('');
     const notes = [];
-    if (m.windowed) notes.push('The most recent ' + m.historyCount + ' releases per channel. Older releases are not shown.');
+    if (m.hiddenByWindow) notes.push(m.hiddenByWindow + ' older ' + (m.hiddenByWindow === 1 ? 'release is' : 'releases are') + ' outside this window.');
+    if (m.windowed) notes.push('History reaches back ' + m.historyCount + ' releases per channel.');
     if (m.neverDeployedCount) notes.push(m.neverDeployedCount + ' of these were created and never deployed anywhere.');
 
-    return wrap({
-      side: '<span class="ip-rel-history-title">History</span>'
-        + '<span class="ip-rel-history-count">' + m.releases.length
-        + (m.releases.length === 1 ? ' release' : ' releases') + '</span>'
-        + (multiChannel ? '<span class="ip-rel-history-count">' + m.channels.length + ' channels</span>' : ''),
-      body: rows + (notes.length ? '<div class="ip-rel-hnote">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '')
-    });
-  }
-
-  function bindProjects(IP) {
-    const root = document.getElementById('main-content');
-    if (!root) return;
-    const toggle = el => {
-      const id = el.getAttribute('data-project');
-      if (!id) return;
-      IP.projectOpen = IP.projectOpen || {};
-      if (IP.projectOpen[id]) delete IP.projectOpen[id]; else IP.projectOpen[id] = true;
-      root.innerHTML = renderProjects(IP);
-      bindProjects(IP);
-      if (IP.projectOpen[id] && IP.loadProjectHistory) IP.loadProjectHistory(id);
-    };
-    root.querySelectorAll('.ip-rel-row[data-project]').forEach(el => {
-      el.addEventListener('click', () => toggle(el));
-      el.addEventListener('keydown', ev => {
-        if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); toggle(el); }
-      });
-    });
+    return wrap(rows + (notes.length
+      ? '<div class="ip-rel-hnote">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : ''));
   }
 
   function renderProjects(IP) {
     const st = IP.releases || { status: 'idle' };
-    const head = '<header class="ip-head"><h2>Projects</h2>'
-      + '<p class="ip-sub">What each project is running in each environment, and where a release has stopped moving.</p></header>';
+    const windows = (typeof Data !== 'undefined' && Data.HISTORY_WINDOWS) || [{ label: '24 hours' }, { label: '7 days' }, { label: 'All' }];
+    const active = IP.historyWindow || windows[0].label;
+    const segs = windows.map(w => '<button class="ip-seg' + (w.label === active ? ' active' : '')
+      + '" data-window="' + escHtml(w.label) + '">' + escHtml(w.label) + '</button>').join('');
+    const head = '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Projects</h2>'
+      + '<p class="ip-sub">What each project is running in each environment, and where a release has stopped moving.</p></div>'
+      + '<div class="ip-rel-window"><span class="ip-caption">History</span><div class="ip-segs">' + segs + '</div></div></header>';
 
     if (st.status === 'loading' || st.status === 'idle') {
       return head + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading the project dashboard…</p></div>';
     }
     if (st.status === 'error') {
-      return head + '<div class="ip-state"><h3>Couldn\'t load the project dashboard</h3>'
-        + '<p>' + escHtml(st.error || 'Unknown error') + '</p></div>';
+      return head + '<div class="ip-state"><h3>Couldn\'t load the project dashboard</h3><p>' + escHtml(st.error || 'Unknown error') + '</p></div>';
     }
     const m = st.model;
     if (!m.projects.length) {
@@ -1155,48 +1138,36 @@ const Views = (function () {
         + '<p>Releases move through environments once a space has a project to deploy.</p></div>';
     }
     if (!m.environments.length) {
-      return head + '<div class="ip-empty"><h3>No environments in this space</h3>'
-        + '<p>There is nothing for a release to progress through yet.</p></div>';
+      return head + '<div class="ip-empty"><h3>Nothing has been deployed in this space</h3>'
+        + '<p>Projects exist, but no release has reached an environment yet.</p></div>';
     }
 
-    // The dashboard endpoint caps and filters. A capped list is
-    // indistinguishable from a small instance unless we say so.
     const notes = [];
     if (m.truncated.capped) notes.push('Showing ' + m.truncated.shown + ' projects — the server caps the dashboard at ' + m.truncated.projectLimit + '. Projects beyond the cap are missing from this view.');
     if (m.truncated.isFiltered) notes.push('The dashboard is filtered on this instance, so this is a subset of its projects.');
-    const note = notes.length
-      ? '<div class="ip-rel-note">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '';
+    const note = notes.length ? '<div class="ip-rel-note">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '';
 
     const open = IP.projectOpen || {};
     const hist = IP.projectHistory || {};
 
-    // One grid per project group. Each carries its own columns, because an
-    // environment is hidden where the group never deploys to it — a group that
-    // has nothing to do with Preprod shouldn't hold a column open for it.
     const blocks = (m.groups || []).map(g => {
       const cols = g.environments.length;
       if (!cols) {
-        return '<section class="ip-rel-group">'
-          + '<h3 class="ip-rel-group-name">' + escHtml(g.name) + '</h3>'
-          + '<p class="ip-rel-none">Nothing in this group has been deployed yet.</p></section>';
+        return '<section class="ip-rel-group"><h3 class="ip-rel-group-name">' + escHtml(g.name) + '</h3>'
+          + '<p class="ip-rel-hempty">Nothing in this group has been deployed yet.</p></section>';
       }
       const heads = g.environments.map(e => '<div class="ip-rel-envhead">' + escHtml(e.name) + '</div>').join('');
-      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id])).join('');
+      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active)).join('');
       const hiddenNote = g.hiddenEnvironments.length
         ? '<p class="ip-rel-hidden">Not shown, because this group has never deployed to them: '
-          + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>'
-        : '';
+          + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
       return '<section class="ip-rel-group">'
         + '<h3 class="ip-rel-group-name">' + escHtml(g.name)
-        +   '<span class="ip-rel-group-count">' + g.projects.length
-        +   (g.projects.length === 1 ? ' project' : ' projects') + '</span></h3>'
+        +   '<span class="ip-rel-group-count">' + g.projects.length + (g.projects.length === 1 ? ' project' : ' projects') + '</span></h3>'
         + '<div class="ip-rel-grid">'
-        +   '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>'
-        +     '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols + ',minmax(0,1fr))">' + heads + '</div></div>'
+        +   '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>' + _relTrack(heads, cols) + '</div>'
         +   rows
-        + '</div>'
-        + hiddenNote
-        + '</section>';
+        + '</div>' + hiddenNote + '</section>';
     }).join('');
 
     return head + note
@@ -1207,9 +1178,39 @@ const Views = (function () {
       +   '<span><i class="ip-rel-key ip-rel-key-split"></i>Split across tenants</span>'
       +   '<span><i class="ip-rel-key ip-rel-key-strong"></i>Same release both sides</span>'
       +   '<span><i class="ip-rel-key ip-rel-key-pale"></i>Drifted</span>'
-      + '</div>'
-      + blocks;
+      + '</div>' + blocks;
   }
+
+  function bindProjects(IP) {
+    const root = document.getElementById('main-content');
+    if (!root) return;
+    const redraw = () => { root.innerHTML = renderProjects(IP); bindProjects(IP); };
+    const toggle = el => {
+      const id = el.getAttribute('data-project');
+      if (!id) return;
+      IP.projectOpen = IP.projectOpen || {};
+      if (IP.projectOpen[id]) delete IP.projectOpen[id]; else IP.projectOpen[id] = true;
+      redraw();
+      if (IP.projectOpen[id] && IP.loadProjectHistory) IP.loadProjectHistory(id);
+    };
+    root.querySelectorAll('.ip-rel-row[data-project]').forEach(el => {
+      el.addEventListener('click', () => toggle(el));
+      el.addEventListener('keydown', ev => {
+        if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); toggle(el); }
+      });
+    });
+    // The window filters what was already fetched, so switching it never
+    // re-requests — the 30-per-channel payload is the ceiling either way.
+    root.querySelectorAll('.ip-rel-window [data-window]').forEach(btn => {
+      btn.addEventListener('click', ev => {
+        ev.stopPropagation();
+        IP.historyWindow = btn.getAttribute('data-window');
+        if (IP.rebuildHistories) IP.rebuildHistories();
+        redraw();
+      });
+    });
+  }
+
   function renderThemeToggle(IP) {
     const dark = IP.theme === 'dark';
     const icon = dark ? _sunSvg : _moonSvg;

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1705,7 +1705,13 @@ const Views = (function () {
             + '</div>' : '')
       +   '</div>'
       + '</div>'
-      + (m.truncated ? '<p class="ip-rel-hnote-inline">More than ' + m.total + ' tenants — this reads the first pages only.</p>' : '');
+      + (m.truncated ? '<p class="ip-rel-hnote-inline">More than ' + m.total + ' tenants — this reads the first pages only.</p>' : '')
+      + ((m.dashboardCap && m.dashboardCap.capped)
+          ? '<p class="ip-rel-hnote-inline">' + escHtml(m.dashboardCap.isFiltered
+              ? 'The project dashboard is filtered on this instance. Last outcome and Environments come from it, so a tenant deploying only to projects it leaves out reads as never deployed.'
+              : 'The project dashboard returns at most ' + m.dashboardCap.projectLimit
+                + ' projects. Last outcome and Environments come from it, so a tenant deploying only to projects beyond that reads as never deployed.')
+            + '</p>' : '');
   }
 
   function bindTenants(IP) {
@@ -1923,9 +1929,19 @@ const Views = (function () {
       infra = '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading targets…</span></div>';
     } else if (m.infrastructure.orphaned) {
       infra = '<p class="ip-tn-warn">No deployment target matches this tenant. Its deployments resolve to nothing.</p>';
+    } else if (!m.infrastructure.total && m.infrastructure.truncated) {
+      infra = '<p class="ip-tn-muted">Nothing among the first '
+        + m.infrastructure.estateRead.toLocaleString() + ' of '
+        + m.infrastructure.estateTotal.toLocaleString()
+        + ' deployment targets in this space matches this tenant. The rest were not read, '
+        + 'so whether it has targets is unknown.</p>';
     } else {
       infra = _tnTargets(m.infrastructure.dedicated, 'Dedicated', 'targets that name this tenant directly')
-        + _tnTargets(m.infrastructure.shared, 'Shared', 'matched by tag');
+        + _tnTargets(m.infrastructure.shared, 'Shared', 'matched by tag')
+        + (m.infrastructure.truncated ? '<p class="ip-tn-legend">Matched against the first '
+            + m.infrastructure.estateRead.toLocaleString() + ' of '
+            + m.infrastructure.estateTotal.toLocaleString()
+            + ' deployment targets in this space. There may be more.</p>' : '');
     }
 
     const activity = m.activity.length
@@ -1997,7 +2013,13 @@ const Views = (function () {
         + '</section>';
     })();
 
-    const overviewTab = '<div class="ip-tn-matrixrow">'
+    const capNote = (m.dashboardCap && m.dashboardCap.capped)
+      ? '<div class="ip-rel-note"><p>' + escHtml(m.dashboardCap.isFiltered
+          ? 'The project dashboard is filtered on this instance, so any project it leaves out reads here as never deployed.'
+          : 'The project dashboard returns at most ' + m.dashboardCap.projectLimit
+            + ' projects. Any of this tenant\'s projects beyond that reads here as never deployed.')
+        + '</p></div>' : '';
+    const overviewTab = capNote + '<div class="ip-tn-matrixrow">'
       +   '<section class="ip-tn-panel ip-tn-matrixpanel"><h3>Deployment matrix</h3>' + matrix + '</section>'
       +   flagSummary
       + '</div>'
@@ -2182,15 +2204,15 @@ const Views = (function () {
 
     // Triggers: what starts a deployment. Anything driven from outside Octopus
     // is invisible here, and saying so is better than implying nothing does.
-    const triggers = (m.triggers.length
+    const triggers = m.triggersError ? none(m.triggersError) : (m.triggers.length
         ? '<ul class="ip-tn-targets">' + m.triggers.map(t =>
             '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(t.name) + '</span>'
             + '<span class="ip-chipx ip-chipx-tag">' + escHtml(t.kind) + '</span>'
             + '<span class="ip-tn-age">' + escHtml(t.detail) + '</span>'
             + (t.disabled ? '<span class="ip-pill ip-pill-disabled">disabled</span>' : '') + '</li>').join('') + '</ul>'
         : none('No triggers are configured.'))
-      + (m.autoCreateRelease ? '<p class="ip-tn-legend">A release is created automatically when a new package arrives.</p>' : '')
-      + '<p class="ip-tn-legend">Deployments started from CI or the API do not appear here — only what Octopus itself triggers.</p>';
+      + (m.triggersError ? '' : (m.autoCreateRelease ? '<p class="ip-tn-legend">A release is created automatically when a new package arrives.</p>' : '')
+      + '<p class="ip-tn-legend">Deployments started from CI or the API do not appear here — only what Octopus itself triggers.</p>');
 
     // Process: what it does, in order. Names, types and packages — the detail
     // lives in Octopus and this is a map, not a second editor.
@@ -2263,7 +2285,7 @@ const Views = (function () {
         + '<p class="ip-tn-legend">Numbers are lifecycle phases — environments sharing a number are in the '
         + 'same phase. A filled node deploys automatically. No node means that lifecycle never reaches '
         + 'that environment.</p>'
-      : none('This project has no lifecycle phases.');
+      : (m.lifecycleError ? none(m.lifecycleError) : none('This project has no lifecycle phases.'));
 
     // Destinations: how targets are chosen, what that resolves to, and what
     // shape it is in. The lifecycle panel says where releases may go; this says
@@ -2278,8 +2300,10 @@ const Views = (function () {
           : '<span class="ip-tn-muted">no environments</span>') + '</dd>'
       + '<dt>Tenants</dt><dd>' + (m.tenantedMode === 'Untenanted'
           ? '<span class="ip-tn-muted">Untenanted — deploys to environments directly</span>'
-          : escHtml(m.tenantedMode) + ' · ' + m.tenantCount.toLocaleString()
-            + (m.tenantCount === 1 ? ' tenant connected' : ' tenants connected')) + '</dd>'
+          : (m.tenantsError
+              ? escHtml(m.tenantedMode) + ' · <span class="ip-tn-muted">' + escHtml(m.tenantsError) + '</span>'
+              : escHtml(m.tenantedMode) + ' · ' + m.tenantCount.toLocaleString()
+                + (m.tenantCount === 1 ? ' tenant connected' : ' tenants connected'))) + '</dd>'
       + '</dl>';
 
     let targets;
@@ -2287,11 +2311,25 @@ const Views = (function () {
       targets = '<p class="ip-tn-muted">' + escHtml(m.targetsError) + '</p>';
     } else if (!tg) {
       targets = '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading targets…</span></div>';
+    } else if (tg.scopeUnknown) {
+      // No environments to scope to. Counting across the whole estate instead
+      // reported targets in environments this project cannot reach.
+      targets = '<p class="ip-tn-muted">Which environments this project reaches is not known'
+        + (m.lifecycleError ? ' — its lifecycles could not be read' : '')
+        + ', so its targets cannot be counted. It selects by '
+        + escHtml(m.roles.join(', ')) + '.</p>';
     } else if (!tg.selectsByRole) {
       // No roles is a fact about the project, not an empty estate. Showing
       // "0 targets" here would read as something missing.
       targets = '<p class="ip-tn-muted">No step selects targets by role, so this project has no deployment '
         + 'targets to report. Its steps run on the server or on workers.</p>';
+    } else if (!tg.total && tg.truncated) {
+      // Nothing matched, but the estate was only partly read. "Nowhere to run"
+      // would be an assertion this read cannot support.
+      targets = '<p class="ip-tn-muted">Nothing among the first '
+        + tg.estateRead.toLocaleString() + ' of ' + tg.estateTotal.toLocaleString()
+        + ' deployment targets matches ' + escHtml(m.roles.join(', '))
+        + ' in these environments. The rest were not read.</p>';
     } else if (!tg.total) {
       targets = '<p class="ip-tn-warn">Nothing matches ' + escHtml(m.roles.join(', '))
         + ' in these environments. Deployments would have nowhere to run.</p>';
@@ -2316,6 +2354,9 @@ const Views = (function () {
             '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(r.role) + '</span>'
             + '<span class="ip-tn-age">' + r.count + (r.count === 1 ? ' target' : ' targets') + '</span></li>').join('')
           + '</ul>' : '')
+        + (tg.truncated ? '<p class="ip-tn-legend">Counted over the first '
+            + tg.estateRead.toLocaleString() + ' of ' + tg.estateTotal.toLocaleString()
+            + ' deployment targets in this space. There may be more.</p>' : '')
         + (tg.byEnvironment.length ? '<p class="ip-tn-legend">By environment: '
             + tg.byEnvironment.map(e => escHtml(e.environment) + ' ' + e.count).join(' · ') + '.</p>' : '')
         + (tg.tenanted
@@ -2335,7 +2376,7 @@ const Views = (function () {
           + (c.isDefault ? '<span class="ip-chipx ip-chipx-tag">default</span>' : '')
           + '<span class="ip-tn-age">' + (c.rules ? c.rules + (c.rules === 1 ? ' version rule' : ' version rules')
               : 'no version rules') + '</span></li>').join('') + '</ul>'
-      : none('This project has one implicit channel.');
+      : (m.channelsError ? none(m.channelsError) : none('This project has one implicit channel.'));
 
     // Feature flags, on the same terms as the tenant page: on and off are
     // counts, and the ones in between are named, because "4 in between" is not

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2144,8 +2144,12 @@ const Views = (function () {
       +   _tnDescription(m.description)
       + '</header>'
       + '<div class="ip-pm-grid">'
-      +   panel('Inputs', m.git ? 'version controlled' : '', inputs)
-      +   panel('Triggers', m.triggers.length ? m.triggers.length + ' configured' : '', triggers)
+      // What feeds the project and what starts it are the same question asked
+      // twice, so they share a column and read together.
+      +   '<div class="ip-pm-col">'
+      +     panel('Inputs', m.git ? 'version controlled' : '', inputs)
+      +     panel('Triggers', m.triggers.length ? m.triggers.length + ' configured' : '', triggers)
+      +   '</div>'
       +   panel('Process', m.process.length ? m.process.length + (m.process.length === 1 ? ' step' : ' steps') : '', process)
       +   panel('Destinations', m.lifecycle, destinations)
       +   panel('Channels', '', channels)

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2150,17 +2150,69 @@ const Views = (function () {
         + 'that environment.</p>'
       : none('This project has no lifecycle phases.');
 
-    // Destinations keeps what the lifecycle panel does not say: how targets are
-    // chosen, and whether tenants are involved.
-    const destinations = ''
-      + (m.roles.length
-          ? '<p class="ip-tn-legend">Targets are selected by role: '
-            + m.roles.map(r => escHtml(r)).join(', ') + '.</p>' : '')
-      + (m.tenantedMode === 'Untenanted'
-          ? '<p class="ip-tn-legend">Untenanted — it deploys to environments directly.</p>'
-          : '<p class="ip-tn-legend">' + escHtml(m.tenantedMode) + ' — '
-            + m.tenantCount.toLocaleString() + (m.tenantCount === 1 ? ' tenant is' : ' tenants are')
-            + ' connected to this project.</p>');
+    // Destinations: how targets are chosen, what that resolves to, and what
+    // shape it is in. The lifecycle panel says where releases may go; this says
+    // what is actually there to receive them.
+    const tg = m.targets;
+    const selection = '<dl class="ip-pm-sel">'
+      + '<dt>Selected by</dt><dd>' + (m.roles.length
+          ? m.roles.map(r => '<span class="ip-chipx ip-chipx-tag">' + escHtml(r) + '</span>').join('')
+          : '<span class="ip-tn-muted">No target roles — this project runs without deployment targets</span>') + '</dd>'
+      + '<dt>Within</dt><dd>' + (m.lifecycleEnvironments.length
+          ? m.lifecycleEnvironments.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
+          : '<span class="ip-tn-muted">no environments</span>') + '</dd>'
+      + '<dt>Tenants</dt><dd>' + (m.tenantedMode === 'Untenanted'
+          ? '<span class="ip-tn-muted">Untenanted — deploys to environments directly</span>'
+          : escHtml(m.tenantedMode) + ' · ' + m.tenantCount.toLocaleString()
+            + (m.tenantCount === 1 ? ' tenant connected' : ' tenants connected')) + '</dd>'
+      + '</dl>';
+
+    let targets;
+    if (m.targetsError) {
+      targets = '<p class="ip-tn-muted">' + escHtml(m.targetsError) + '</p>';
+    } else if (!tg) {
+      targets = '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading targets…</span></div>';
+    } else if (!tg.selectsByRole) {
+      // No roles is a fact about the project, not an empty estate. Showing
+      // "0 targets" here would read as something missing.
+      targets = '<p class="ip-tn-muted">No step selects targets by role, so this project has no deployment '
+        + 'targets to report. Its steps run on the server or on workers.</p>';
+    } else if (!tg.total) {
+      targets = '<p class="ip-tn-warn">Nothing matches ' + escHtml(m.roles.join(', '))
+        + ' in these environments. Deployments would have nowhere to run.</p>';
+    } else {
+      const pct = n => tg.total ? Math.round(n / tg.total * 100) : 0;
+      targets = '<div class="ip-pm-tstats">'
+        + '<span class="ip-tn-stat"><span class="ip-tn-statnum">' + tg.total + '</span>'
+        +   '<span class="ip-tn-statlabel">' + (tg.total === 1 ? 'target' : 'targets') + '</span></span>'
+        + '<span class="ip-tn-stat"><span class="ip-tn-statnum ip-tn-stat-healthy">' + tg.healthy + '</span>'
+        +   '<span class="ip-tn-statlabel">healthy</span></span>'
+        + (tg.unhealthy ? '<span class="ip-tn-stat"><span class="ip-tn-statnum ip-tn-stat-warning">'
+            + tg.unhealthy + '</span><span class="ip-tn-statlabel">unhealthy</span></span>' : '')
+        + (tg.disabled ? '<span class="ip-tn-stat"><span class="ip-tn-statnum ip-tn-stat-disabled">'
+            + tg.disabled + '</span><span class="ip-tn-statlabel">disabled</span></span>' : '')
+        + '</div>'
+        + '<div class="ip-bar ip-pm-health">'
+        +   '<span style="width:' + pct(tg.healthy) + '%;background:var(--color-green-500)"></span>'
+        +   '<span style="width:' + pct(tg.unhealthy) + '%;background:var(--color-red-500)"></span>'
+        +   '<span style="width:' + pct(tg.disabled) + '%;background:var(--color-slate-300)"></span>'
+        + '</div>'
+        + (tg.byRole.length ? '<ul class="ip-tn-targets">' + tg.byRole.map(r =>
+            '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(r.role) + '</span>'
+            + '<span class="ip-tn-age">' + r.count + (r.count === 1 ? ' target' : ' targets') + '</span></li>').join('')
+          + '</ul>' : '')
+        + (tg.byEnvironment.length ? '<p class="ip-tn-legend">By environment: '
+            + tg.byEnvironment.map(e => escHtml(e.environment) + ' ' + e.count).join(' · ') + '.</p>' : '')
+        + (tg.tenanted
+            ? '<p class="ip-tn-legend">'
+              + (tg.tenanted.dedicated ? tg.tenanted.dedicated + ' name a tenant directly. ' : '')
+              + (tg.tenanted.byTag ? tg.tenanted.byTag + ' are matched by tenant tag. ' : '')
+              + Object.keys(tg.tenanted.participation).map(k =>
+                  tg.tenanted.participation[k] + ' ' + escHtml(k)).join(', ')
+              + '.</p>'
+            : '');
+    }
+    const destinations = selection + targets;
 
     const channels = m.channels.length
       ? '<ul class="ip-tn-targets">' + m.channels.map(c =>

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1022,22 +1022,26 @@ const Views = (function () {
   // the detail lives with the environment it describes rather than in a
   // separate panel that repeats the column headings.
   function _relEntry(e, cell, withBar) {
+    const age = _relWhen(e.when);
+    const state = e.stateKey !== 'success'
+      ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '';
+    if (!withBar) {
+      return '<span class="ip-rel-entry">'
+        + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
+        + '<span class="ip-rel-age">' + escHtml(age) + '</span>'
+        + (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml('· ' + e.tenantCount
+            + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : '')
+        + state + '</span>';
+    }
+    // One line per release: the share is the row's own fill rather than a
+    // separate bar, so a twelve-way split stays readable in a column.
     const share = cell.tenantTotal ? (e.tenantCount / cell.tenantTotal * 100) : 0;
-    return '<span class="ip-rel-entry">'
-      + '<span class="ip-rel-entry-head">'
-      +   '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
-      +   '<span class="ip-rel-age">' + escHtml(_relWhen(e.when)) + '</span>'
-      + '</span>'
-      + (withBar
-          ? '<span class="ip-rel-tsbar" title="' + escHtml(e.tenantCount.toLocaleString() + ' of '
-              + cell.tenantTotal.toLocaleString() + ' tenants')
-            + '"><span style="width:' + share.toFixed(1) + '%"></span></span>'
-            + '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString()
-            + (e.tenantCount === 1 ? ' tenant' : ' tenants') + '</span>'
-          : (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml('· ' + e.tenantCount
-              + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : ''))
-      + (e.stateKey !== 'success'
-          ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '')
+    return '<span class="ip-rel-entry ip-rel-entry-share" style="--ip-rel-share:' + share.toFixed(1) + '%"'
+      + ' title="' + escHtml(e.version + ' — ' + e.tenantCount.toLocaleString() + ' of '
+          + cell.tenantTotal.toLocaleString() + ' tenants' + (age ? ', ' + age : '')) + '">'
+      + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
+      + state
+      + '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString() + '</span>'
       + '</span>';
   }
 
@@ -1062,7 +1066,7 @@ const Views = (function () {
     const hiddenTenants = cell.entries.slice(CAP).reduce((n, e) => n + e.tenantCount, 0);
 
     const labels = shown.map(e => _relEntry(e, cell, withBar)).join('');
-    const summary = withBar && expanded
+    const summary = withBar
       ? '<span class="ip-rel-tssum">' + cell.versionCount + ' releases · '
         + cell.tenantTotal.toLocaleString() + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') + '</span>'
       : '';

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1794,10 +1794,17 @@ const Views = (function () {
     } else if (!m.readiness) {
       readyCard = _tnCard('Readiness', 'disabled', 'Loading…', '', '');
     } else {
-      readyCard = _tnCard('Readiness', m.readiness.ready ? 'healthy' : 'unhealthy',
-        m.readiness.ready ? 'Ready' : m.readiness.count + ' missing ' + (m.readiness.count === 1 ? 'variable' : 'variables'),
-        m.readiness.ready ? 'Required variables have values'
-          : 'A deployment would fail on configuration',
+      const rd = m.readiness;
+      // Three states, not two. A template with no value is a question, and what
+      // answers it is whether anything has actually deployed without it.
+      const tone = rd.ready ? 'healthy' : (rd.proven ? 'disabled' : 'unhealthy');
+      const headline = rd.ready ? 'Ready'
+        : rd.count + ' unset ' + (rd.count === 1 ? 'variable' : 'variables');
+      const detail = rd.ready ? 'Every template the projects ask for has a value'
+        : (rd.proven
+            ? 'Deployments have succeeded with these unset, so the process may not use them'
+            : rd.unprovenCount + ' of them on project-environment pairs that have never deployed successfully');
+      readyCard = _tnCard('Readiness', tone, headline, detail,
         link('/app#/' + escHtml(IP.spaceId || '') + '/tenants/' + escHtml(m.id) + '/variables', 'Open tenant variables'));
     }
 
@@ -1848,6 +1855,20 @@ const Views = (function () {
       +   (tagGroups ? '<div class="ip-tn-taggroups">' + tagGroups + '</div>' : '')
       + '</header>'
       + '<div class="ip-tn-cards">' + connCard + readyCard + outcomeCard + '</div>'
+      + (m.readiness && m.readiness.missing.length
+          ? '<section class="ip-tn-panel"><h3>Unset variables'
+            + '<span class="ip-tn-age">' + m.readiness.count + ' of the templates these projects ask for</span></h3>'
+            + '<ul class="ip-tn-targets">' + m.readiness.missing.map(v =>
+                '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(v.name) + '</span>'
+                + '<span class="ip-tn-age">' + escHtml(v.scope) + '</span>'
+                + '<span class="ip-tn-age">' + escHtml(v.environments.join(', ')) + '</span>'
+                + (v.proven ? '<span class="ip-pill ip-pill-disabled">deployed without it</span>'
+                            : '<span class="ip-pill ip-pill-unhealthy">unproven</span>') + '</li>').join('')
+            + '</ul>'
+            + '<p class="ip-tn-legend">A template is a request for a value, not a guarantee the process uses one. '
+            + 'Where a deployment has already succeeded with the value unset, that is recorded rather than called a failure.</p>'
+            + '</section>'
+          : '')
       + '<section class="ip-tn-panel"><h3>Deployment matrix</h3>' + matrix + '</section>'
       + '<div class="ip-tn-split">'
       +   '<section class="ip-tn-panel"><h3>Infrastructure'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1903,12 +1903,12 @@ const Views = (function () {
               + escHtml(st.envName) + ' <span class="ip-tn-age">' + escHtml(text) + '</span></span>';
           }).join('')
         + '</span></li>').join('');
-      return '<section class="ip-tn-panel"><h3>Feature flags'
+      return '<section class="ip-tn-panel ip-tn-flagpanel"><h3>Feature flags'
         + '<span class="ip-tn-age">' + fl.model.total + ' across this tenant\'s projects</span></h3>'
         + '<div class="ip-tn-stats">'
-        +   stat(sm.fullyOn, 'fully on', 'healthy')
-        +   stat(sm.fullyOff, 'fully off', 'disabled')
-        +   stat(sm.betweenCount, 'in between', sm.betweenCount ? 'warning' : 'disabled')
+        +   stat(sm.fullyOn, 'on', 'healthy')
+        +   stat(sm.fullyOff, 'off', 'disabled')
+        +   stat(sm.betweenCount, 'rolling out', sm.betweenCount ? 'warning' : 'disabled')
         + '</div>'
         + (rows
             ? '<ul class="ip-tn-targets">' + rows + '</ul>'
@@ -1919,8 +1919,10 @@ const Views = (function () {
         + '</section>';
     })();
 
-    const overviewTab = '<section class="ip-tn-panel"><h3>Deployment matrix</h3>' + matrix + '</section>'
-      + flagSummary
+    const overviewTab = '<div class="ip-tn-matrixrow">'
+      +   '<section class="ip-tn-panel ip-tn-matrixpanel"><h3>Deployment matrix</h3>' + matrix + '</section>'
+      +   flagSummary
+      + '</div>'
       + '<div class="ip-tn-split">'
       +   '<section class="ip-tn-panel"><h3>Infrastructure'
       +     (m.infrastructure && !m.infrastructure.orphaned

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1705,6 +1705,161 @@ const Views = (function () {
     });
   }
 
+  // ─── Tenant detail ─────────────────────────────────────────────────────────
+  // Four independent facts across the top, then the matrix that answers "what
+  // is on it", then what it deploys to and what it has been doing. The four
+  // cards are never combined into one badge: a tenant that is disconnected and
+  // a tenant whose last deployment failed are different problems.
+  function _tnCard(title, tone, headline, detail, link) {
+    return '<div class="ip-tn-card">'
+      + '<p class="ip-tn-cardtitle">' + escHtml(title) + '</p>'
+      + '<p class="ip-tn-cardhead"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone) + '"></span>'
+      +   escHtml(headline) + '</p>'
+      + (detail ? '<p class="ip-tn-carddetail">' + escHtml(detail) + '</p>' : '')
+      + (link ? '<p class="ip-tn-cardlink">' + link + '</p>' : '')
+      + '</div>';
+  }
+
+  function _tnMatrixCell(c) {
+    // Three different absences, drawn three different ways. Not connected is
+    // structural, never deployed is a fact about history, and neither is a
+    // failure.
+    if (!c.connected) return '<td class="ip-tn-mcell is-absent"><span class="ip-tn-muted">not connected</span></td>';
+    if (!c.deployed) return '<td class="ip-tn-mcell"><span class="ip-tn-muted">never deployed</span></td>';
+    const tone = c.stateKey === 'success' ? 'healthy'
+      : (c.stateKey === 'running' ? 'running' : (c.stateKey === 'cancelled' ? 'disabled' : 'unhealthy'));
+    return '<td class="ip-tn-mcell">'
+      + '<span class="ip-tn-mver">' + escHtml(c.version) + '</span>'
+      + '<span class="ip-tn-mmeta"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone) + '"></span>'
+      +   escHtml(c.stateLabel) + '<span class="ip-tn-age">' + escHtml(_tenantWhen(c.when)) + '</span></span>'
+      + '</td>';
+  }
+
+  function _tnTargets(list, kind, caption) {
+    if (!list.length) return '';
+    const rows = list.slice(0, 20).map(t => {
+      const key = Data.healthKeyLabel ? Data.healthKeyLabel(_tnHealthKey(t)) : '';
+      return '<li class="ip-tn-target">'
+        + '<span class="ip-tn-tname">' + escHtml(t.name) + '</span>'
+        + (t.via ? '<span class="ip-tn-age">via ' + escHtml(t.via) + '</span>' : '')
+        + '<span class="ip-pill ip-pill-' + escHtml(_tnHealthKey(t)) + '">' + escHtml(key) + '</span>'
+        + '</li>';
+    }).join('');
+    const rest = list.length - Math.min(list.length, 20);
+    return '<div class="ip-tn-targetgroup">'
+      + '<p class="ip-tn-targethead">' + escHtml(kind) + '<span class="ip-tn-age">' + escHtml(caption) + '</span>'
+      +   '<span class="ip-tn-age">' + list.length + (list.length === 1 ? ' target' : ' targets') + '</span></p>'
+      + '<ul class="ip-tn-targets">' + rows + '</ul>'
+      + (rest ? '<p class="ip-tn-age">+' + rest + ' more</p>' : '')
+      + '</div>';
+  }
+  function _tnHealthKey(t) {
+    return Data.healthKeyLabel ? (t.disabled ? 'disabled'
+      : (t.health === 'Healthy' || t.health === 'HealthyWithWarnings' ? 'healthy' : 'unhealthy')) : 'healthy';
+  }
+
+  function renderTenantDetail(IP) {
+    const st = IP.tenantDetail || { status: 'loading' };
+    const back = '<p class="ip-tn-back"><a href="#tenants">← All tenants</a></p>';
+    if (st.status === 'loading' || !st.status) {
+      return back + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading tenant…</p></div>';
+    }
+    if (st.status === 'error') {
+      return back + '<div class="ip-state"><h3>Couldn\'t load this tenant</h3><p>'
+        + escHtml(st.error || 'Unknown error') + '</p></div>';
+    }
+    const m = st.model;
+    const serverUrl = (IP.serverUrl || '').replace(/\/$/, '');
+    const link = (path, label) => serverUrl
+      ? '<a href="' + escHtml(serverUrl + path) + '" target="_blank" rel="noopener">' + escHtml(label) + ' ↗</a>' : '';
+
+    const tagsBySet = {};
+    m.tags.forEach(t => { (tagsBySet[t.set || 'Tags'] || (tagsBySet[t.set || 'Tags'] = [])).push(t.name); });
+    const tagGroups = Object.keys(tagsBySet).map(setName =>
+      '<span class="ip-tn-taggroup"><span class="ip-tn-tagset">' + escHtml(setName) + '</span>'
+      + tagsBySet[setName].map(n => '<span class="ip-chipx ip-chipx-tag">' + escHtml(n) + '</span>').join('')
+      + '</span>').join('');
+
+    const conn = m.connection;
+    const connCard = _tnCard('Connection', conn.connected ? 'healthy' : 'unhealthy',
+      conn.connected ? 'Connected' : 'Not connected',
+      conn.connected ? conn.pairCount + ' project-environment ' + (conn.pairCount === 1 ? 'pair' : 'pairs')
+        + ' across ' + conn.projectCount + (conn.projectCount === 1 ? ' project' : ' projects')
+        : 'No project is scoped to this tenant, so nothing can deploy to it.',
+      link('/app#/' + escHtml(IP.spaceId || '') + '/tenants/' + escHtml(m.id) + '/overview', 'Open connections'));
+
+    let readyCard;
+    if (m.readinessError) {
+      readyCard = _tnCard('Readiness', 'disabled', 'Unknown', m.readinessError, '');
+    } else if (!m.readiness) {
+      readyCard = _tnCard('Readiness', 'disabled', 'Loading…', '', '');
+    } else {
+      readyCard = _tnCard('Readiness', m.readiness.ready ? 'healthy' : 'unhealthy',
+        m.readiness.ready ? 'Ready' : m.readiness.count + ' missing ' + (m.readiness.count === 1 ? 'variable' : 'variables'),
+        m.readiness.ready ? 'Required variables have values'
+          : 'A deployment would fail on configuration',
+        link('/app#/' + escHtml(IP.spaceId || '') + '/tenants/' + escHtml(m.id) + '/variables', 'Open tenant variables'));
+    }
+
+    const lo = m.lastOutcome;
+    const loTone = !lo ? 'disabled'
+      : (lo.key === 'success' ? 'healthy' : (lo.key === 'running' ? 'running' : 'unhealthy'));
+    const outcomeCard = _tnCard('Last outcome', loTone,
+      lo ? lo.label : 'Never deployed',
+      lo ? _tenantWhen(lo.when) + (lo.projectName ? ' · ' + lo.projectName : '')
+        : 'Connected, but nothing has been deployed here yet', '');
+
+    const matrix = m.matrix.length
+      ? '<table class="ip-table ip-tn-matrix"><thead><tr><th>Project</th>'
+        + m.environments.map(e => '<th>' + escHtml(e.name) + '</th>').join('') + '</tr></thead><tbody>'
+        + m.matrix.map(row => '<tr><td class="ip-tn-mproj">' + escHtml(row.projectName) + '</td>'
+          + row.cells.map(_tnMatrixCell).join('') + '</tr>').join('')
+        + '</tbody></table>'
+        + '<p class="ip-tn-legend"><span class="ip-tn-muted">not connected</span> is structural — the pair does not exist. '
+        + '<span class="ip-tn-muted">never deployed</span> means it does, and nothing has gone to it. Neither is a failure.</p>'
+      : '<p class="ip-tn-muted">No project is scoped to this tenant.</p>';
+
+    let infra;
+    if (m.infrastructureError) {
+      infra = '<p class="ip-tn-muted">' + escHtml(m.infrastructureError) + '</p>';
+    } else if (!m.infrastructure) {
+      infra = '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading targets…</span></div>';
+    } else if (m.infrastructure.orphaned) {
+      infra = '<p class="ip-tn-warn">No deployment target matches this tenant. Its deployments resolve to nothing.</p>';
+    } else {
+      infra = _tnTargets(m.infrastructure.dedicated, 'Dedicated', 'targets that name this tenant directly')
+        + _tnTargets(m.infrastructure.shared, 'Shared', 'matched by tag');
+    }
+
+    const activity = m.activity.length
+      ? '<ul class="ip-tn-activity">' + m.activity.map(a => {
+          const tone = a.stateKey === 'success' ? 'healthy'
+            : (a.stateKey === 'running' ? 'running' : (a.stateKey === 'cancelled' ? 'disabled' : 'unhealthy'));
+          return '<li><span class="ip-tn-dot ip-rel-node-' + escHtml(tone) + '"></span>'
+            + '<span class="ip-tn-actmain">' + escHtml(a.projectName + ' ' + a.version + ' → ' + a.envName) + '</span>'
+            + '<span class="ip-tn-age">' + escHtml(a.stateLabel) + ' · ' + escHtml(_tenantWhen(a.when)) + '</span></li>';
+        }).join('') + '</ul>'
+      : '<p class="ip-tn-muted">Nothing has been deployed to this tenant.</p>';
+
+    return back
+      + '<header class="ip-head"><h2>' + escHtml(m.name) + (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
+      +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
+      +   (m.description ? '<p class="ip-sub">' + escHtml(m.description) + '</p>' : '')
+      +   (tagGroups ? '<div class="ip-tn-taggroups">' + tagGroups + '</div>' : '')
+      + '</header>'
+      + '<div class="ip-tn-cards">' + connCard + readyCard + outcomeCard + '</div>'
+      + '<section class="ip-tn-panel"><h3>Deployment matrix</h3>' + matrix + '</section>'
+      + '<div class="ip-tn-split">'
+      +   '<section class="ip-tn-panel"><h3>Infrastructure'
+      +     (m.infrastructure && !m.infrastructure.orphaned
+            ? '<span class="ip-tn-age">' + m.infrastructure.healthy + ' of ' + m.infrastructure.total + ' healthy</span>' : '')
+      +     '</h3>' + infra + '</section>'
+      +   '<section class="ip-tn-panel"><h3>Activity</h3>' + activity + '</section>'
+      + '</div>'
+      + '<p class="ip-rel-hnote-inline">Currency against each project\'s latest release, and feature flags scoped to this '
+      +   'tenant, are not shown yet — both need a request per connected project.</p>';
+  }
+
   function renderThemeToggle(IP) {
     const dark = IP.theme === 'dark';
     const icon = dark ? _sunSvg : _moonSvg;
@@ -1755,7 +1910,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1016,7 +1016,32 @@ const Views = (function () {
     return Math.round(hours / 24) + 'd ago';
   }
 
-  function _relCell(cell, link) {
+  // An environment holding several releases is a tenant rollout part-way
+  // through. Each entry carries a share bar so the split reads at a glance, and
+  // the cell shows a few of them contracted and every one of them expanded —
+  // the detail lives with the environment it describes rather than in a
+  // separate panel that repeats the column headings.
+  function _relEntry(e, cell, withBar) {
+    const share = cell.tenantTotal ? (e.tenantCount / cell.tenantTotal * 100) : 0;
+    return '<span class="ip-rel-entry">'
+      + '<span class="ip-rel-entry-head">'
+      +   '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
+      +   '<span class="ip-rel-age">' + escHtml(_relWhen(e.when)) + '</span>'
+      + '</span>'
+      + (withBar
+          ? '<span class="ip-rel-tsbar" title="' + escHtml(e.tenantCount.toLocaleString() + ' of '
+              + cell.tenantTotal.toLocaleString() + ' tenants')
+            + '"><span style="width:' + share.toFixed(1) + '%"></span></span>'
+            + '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString()
+            + (e.tenantCount === 1 ? ' tenant' : ' tenants') + '</span>'
+          : (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml('· ' + e.tenantCount
+              + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : ''))
+      + (e.stateKey !== 'success'
+          ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '')
+      + '</span>';
+  }
+
+  function _relCell(cell, link, expanded) {
     const seg = link && link !== 'none' ? '<span class="ip-rel-seg ip-rel-seg-' + escHtml(link) + '"></span>' : '';
     if (!cell.entries.length) {
       return '<div class="ip-rel-cell">' + seg
@@ -1025,27 +1050,33 @@ const Views = (function () {
     }
     const head = cell.entries[0];
     const split = cell.entries.length > 1;
+    const withBar = split && cell.tenantTotal > 0;
     const node = '<span class="ip-rel-node ip-rel-node-' + escHtml(REL_STATE_TONE[head.stateKey] || 'disabled')
       + (split ? ' ip-rel-node-split' : '') + '" title="' + escHtml(head.stateLabel + ' in ' + cell.envName) + '"></span>';
-    const MAX = 3;
-    const shown = cell.entries.slice(0, MAX);
+
+    // Contracted shows the leading few. Expanded shows the lot, capped only
+    // where a list would stop being readable at all.
+    const CAP = expanded ? 25 : 3;
+    const shown = cell.entries.slice(0, CAP);
     const hidden = cell.entries.length - shown.length;
-    const labels = shown.map(e =>
-      '<span class="ip-rel-entry">'
-      + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
-      + '<span class="ip-rel-age">' + escHtml(_relWhen(e.when)) + '</span>'
-      + (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml('· ' + e.tenantCount + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : '')
-      + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '')
-      + '</span>').join('');
+    const hiddenTenants = cell.entries.slice(CAP).reduce((n, e) => n + e.tenantCount, 0);
+
+    const labels = shown.map(e => _relEntry(e, cell, withBar)).join('');
+    const summary = withBar && expanded
+      ? '<span class="ip-rel-tssum">' + cell.versionCount + ' releases · '
+        + cell.tenantTotal.toLocaleString() + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') + '</span>'
+      : '';
     const more = hidden > 0
       ? '<span class="ip-rel-more">+' + hidden + ' more ' + (hidden === 1 ? 'release' : 'releases')
-        + (cell.tenantTotal ? ' across ' + cell.tenantTotal + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') : '') + '</span>'
+        + (hiddenTenants ? ' on ' + hiddenTenants.toLocaleString() + (hiddenTenants === 1 ? ' tenant' : ' tenants') : '')
+        + '</span>'
       : '';
-    return '<div class="ip-rel-cell">' + seg + node + '<div class="ip-rel-labels">' + labels + more + '</div></div>';
+    return '<div class="ip-rel-cell' + (withBar ? ' has-split' : '') + '">' + seg + node
+      + '<div class="ip-rel-labels">' + summary + labels + more + '</div></div>';
   }
 
   function _relRow(proj, cols, expanded, history, windowLabel) {
-    const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i])).join('');
+    const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i], expanded)).join('');
     const row = '<div class="ip-rel-row' + (expanded ? ' expanded' : '') + '" role="button" tabindex="0"'
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
       + '<div class="ip-rel-proj">'
@@ -1090,62 +1121,13 @@ const Views = (function () {
     return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">' + _relTrack(cells, cols) + '</div>';
   }
 
-  // Where a tenant rollout is part-way through, an environment holds several
-  // releases at once. The collapsed cell can only say how many; this names them,
-  // in the environment's own column so it reads against the row above rather
-  // than as a separate list.
-  //
-  // The counts come from the dashboard payload — /progression returns one
-  // deployment per environment and carries no tenant detail at all.
-  function _relTenantSpread(proj, cols) {
-    const cells = proj.cells || [];
-    if (!cells.some(c => c.versionCount > 1 && c.tenantTotal > 0)) return '';
-    const MAX = 6;
-
-    const body = cells.map(c => {
-      if (!c.tenantTotal) return '<div class="ip-rel-tscell"></div>';
-      if (c.versionCount <= 1) {
-        return '<div class="ip-rel-tscell"><span class="ip-rel-tsall">All '
-          + c.tenantTotal.toLocaleString() + (c.tenantTotal === 1 ? ' tenant' : ' tenants')
-          + ' on one release</span></div>';
-      }
-      const shown = c.entries.slice(0, MAX);
-      const rest = c.entries.length - shown.length;
-      const restTenants = c.entries.slice(MAX).reduce((n, e) => n + e.tenantCount, 0);
-      const rows = shown.map(e => {
-        const share = c.tenantTotal ? (e.tenantCount / c.tenantTotal * 100) : 0;
-        return '<div class="ip-rel-tsentry">'
-          + '<span class="ip-rel-tshead">'
-          +   '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
-          +   '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString() + '</span>'
-          + '</span>'
-          + '<span class="ip-rel-tsbar" title="' + escHtml(e.tenantCount + ' of ' + c.tenantTotal + ' tenants')
-          +   '"><span style="width:' + share.toFixed(1) + '%"></span></span>'
-          + '</div>';
-      }).join('');
-      const more = rest > 0
-        ? '<span class="ip-rel-tsmore">+' + rest + ' more on ' + restTenants.toLocaleString()
-          + (restTenants === 1 ? ' tenant' : ' tenants') + '</span>' : '';
-      return '<div class="ip-rel-tscell">'
-        + '<span class="ip-rel-tssum">' + c.versionCount + ' releases · '
-        +   c.tenantTotal.toLocaleString() + (c.tenantTotal === 1 ? ' tenant' : ' tenants') + '</span>'
-        + rows + more + '</div>';
-    }).join('');
-
-    return '<div class="ip-rel-tsblock">'
-      + '<p class="ip-rel-tscaption">Tenant split</p>'
-      + _relTrack(body, cols)
-      + '</div>';
-  }
-
   function _relHistory(proj, cols, history, windowLabel) {
     const st = history || { status: 'loading' };
-    const spread = _relTenantSpread(proj, cols);
     // Mirrors the row structure — a label-width gutter, then the track — so an
     // expanded row starts on exactly the same x as the row it opened from.
     const wrap = body => '<div class="ip-rel-history">'
       + '<div class="ip-rel-proj ip-rel-history-gutter" aria-hidden="true"></div>'
-      + '<div class="ip-rel-history-body">' + spread + body + '</div></div>';
+      + '<div class="ip-rel-history-body">' + body + '</div></div>';
 
     if (st.status === 'loading' || !st.status) {
       return wrap('<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>');

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1758,6 +1758,18 @@ const Views = (function () {
       : (t.health === 'Healthy' || t.health === 'HealthyWithWarnings' ? 'healthy' : 'unhealthy')) : 'healthy';
   }
 
+  function bindTenantDetail(IP) {
+    const root = document.getElementById('main-content');
+    if (!root) return;
+    root.querySelectorAll('[data-tenanttab]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        IP.tenantTab = btn.getAttribute('data-tenanttab');
+        root.innerHTML = renderTenantDetail(IP);
+        bindTenantDetail(IP);
+      });
+    });
+  }
+
   function renderTenantDetail(IP) {
     const st = IP.tenantDetail || { status: 'loading' };
     const back = '<p class="ip-tn-back"><a href="#tenants">← All tenants</a></p>';
@@ -1797,7 +1809,7 @@ const Views = (function () {
       const rd = m.readiness;
       // Three states, not two. A template with no value is a question, and what
       // answers it is whether anything has actually deployed without it.
-      const tone = rd.ready ? 'healthy' : (rd.proven ? 'disabled' : 'unhealthy');
+      const tone = rd.ready ? 'healthy' : (rd.proven ? 'disabled' : 'warning');
       const headline = rd.ready ? 'Ready'
         : rd.count + ' unset ' + (rd.count === 1 ? 'variable' : 'variables');
       const detail = rd.ready ? 'Every template the projects ask for has a value'
@@ -1848,6 +1860,46 @@ const Views = (function () {
         }).join('') + '</ul>'
       : '<p class="ip-tn-muted">Nothing has been deployed to this tenant.</p>';
 
+    // The unset variables sit behind a tab rather than in the flow: they are a
+    // thing to go and look at, not part of the answer to "what is on this
+    // tenant right now".
+    const unsetCount = m.readiness ? m.readiness.count : 0;
+    const tab = (unsetCount && IP.tenantTab === 'Variables') ? 'Variables' : 'Overview';
+    const tabDefs = [{ key: 'Overview', label: 'Overview' }];
+    if (unsetCount) tabDefs.push({ key: 'Variables', label: 'Unset variables', count: unsetCount });
+    const tabs = tabDefs.length > 1
+      ? '<nav class="ip-tabs ip-section-tabs" aria-label="Tenant sections">'
+        + tabDefs.map(d => '<button type="button" class="ip-tab ip-section-tab'
+          + (d.key === tab ? ' ip-tab-active' : '') + '" data-tenanttab="' + escHtml(d.key) + '"'
+          + (d.key === tab ? ' aria-current="page"' : '') + '>' + escHtml(d.label)
+          + (d.count ? '<span class="ip-tn-tabcount">' + d.count + '</span>' : '') + '</button>').join('')
+        + '</nav>'
+      : '';
+
+    const overviewTab = '<section class="ip-tn-panel"><h3>Deployment matrix</h3>' + matrix + '</section>'
+      + '<div class="ip-tn-split">'
+      +   '<section class="ip-tn-panel"><h3>Infrastructure'
+      +     (m.infrastructure && !m.infrastructure.orphaned
+            ? '<span class="ip-tn-age">' + m.infrastructure.healthy + ' of ' + m.infrastructure.total + ' healthy</span>' : '')
+      +     '</h3>' + infra + '</section>'
+      +   '<section class="ip-tn-panel"><h3>Activity</h3>' + activity + '</section>'
+      + '</div>';
+
+    const variablesTab = m.readiness && m.readiness.missing.length
+      ? '<section class="ip-tn-panel"><h3>Unset variables'
+        + '<span class="ip-tn-age">' + m.readiness.count + ' of the templates these projects ask for</span></h3>'
+        + '<ul class="ip-tn-targets">' + m.readiness.missing.map(v =>
+            '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(v.name) + '</span>'
+            + '<span class="ip-tn-age">' + escHtml(v.scope) + '</span>'
+            + '<span class="ip-tn-age">' + escHtml(v.environments.join(', ')) + '</span>'
+            + (v.proven ? '<span class="ip-pill ip-pill-disabled">deployed without it</span>'
+                        : '<span class="ip-pill ip-pill-warning">unproven</span>') + '</li>').join('')
+        + '</ul>'
+        + '<p class="ip-tn-legend">A template is a request for a value, not a guarantee the process uses one. '
+        + 'Where a deployment has already succeeded with the value unset, that is recorded rather than called a failure.</p>'
+        + '</section>'
+      : '';
+
     return back
       + '<header class="ip-head"><h2>' + escHtml(m.name) + (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
       +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
@@ -1855,28 +1907,8 @@ const Views = (function () {
       +   (tagGroups ? '<div class="ip-tn-taggroups">' + tagGroups + '</div>' : '')
       + '</header>'
       + '<div class="ip-tn-cards">' + connCard + readyCard + outcomeCard + '</div>'
-      + (m.readiness && m.readiness.missing.length
-          ? '<section class="ip-tn-panel"><h3>Unset variables'
-            + '<span class="ip-tn-age">' + m.readiness.count + ' of the templates these projects ask for</span></h3>'
-            + '<ul class="ip-tn-targets">' + m.readiness.missing.map(v =>
-                '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(v.name) + '</span>'
-                + '<span class="ip-tn-age">' + escHtml(v.scope) + '</span>'
-                + '<span class="ip-tn-age">' + escHtml(v.environments.join(', ')) + '</span>'
-                + (v.proven ? '<span class="ip-pill ip-pill-disabled">deployed without it</span>'
-                            : '<span class="ip-pill ip-pill-unhealthy">unproven</span>') + '</li>').join('')
-            + '</ul>'
-            + '<p class="ip-tn-legend">A template is a request for a value, not a guarantee the process uses one. '
-            + 'Where a deployment has already succeeded with the value unset, that is recorded rather than called a failure.</p>'
-            + '</section>'
-          : '')
-      + '<section class="ip-tn-panel"><h3>Deployment matrix</h3>' + matrix + '</section>'
-      + '<div class="ip-tn-split">'
-      +   '<section class="ip-tn-panel"><h3>Infrastructure'
-      +     (m.infrastructure && !m.infrastructure.orphaned
-            ? '<span class="ip-tn-age">' + m.infrastructure.healthy + ' of ' + m.infrastructure.total + ' healthy</span>' : '')
-      +     '</h3>' + infra + '</section>'
-      +   '<section class="ip-tn-panel"><h3>Activity</h3>' + activity + '</section>'
-      + '</div>'
+      + tabs
+      + (tab === 'Variables' ? variablesTab : overviewTab)
       + '<p class="ip-rel-hnote-inline">Currency against each project\'s latest release, and feature flags scoped to this '
       +   'tenant, are not shown yet — both need a request per connected project.</p>';
   }
@@ -1931,7 +1963,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2114,7 +2114,7 @@ const Views = (function () {
     const hidden = group.hiddenEnvironments.length
       ? '<p class="ip-rel-hidden">Not shown, because this project group has never deployed to them: '
         + escHtml(group.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
-    return _relControls(IP) + _relLegend()
+    return _relLegend()
       + '<div class="ip-rel-groups" style="--ip-rel-cols:' + cols + '">'
       +   '<section class="ip-rel-group"><div class="ip-rel-grid">'
       +     '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>'
@@ -2381,12 +2381,19 @@ const Views = (function () {
     // Two questions about one project: what is running right now, and how the
     // project is put together. They are different enough to be different tabs.
     const tab = IP.projectTab === 'Overview' ? 'Overview' : 'Status';
-    const tabs = '<nav class="ip-tabs ip-section-tabs" aria-label="Project sections">'
+    // Status's window and grouping controls ride the tab row, right-aligned, the
+    // way they sit against the heading on the projects list. Below the tabs they
+    // read as page content rather than as controls.
+    const ready = IP.releases && IP.releases.status === 'ready';
+    const tabs = '<div class="ip-pm-tabbar">'
+      + '<nav class="ip-tabs ip-section-tabs" aria-label="Project sections">'
       + [{ key: 'Status', label: 'Status' }, { key: 'Overview', label: 'Overview' }].map(d =>
           '<button type="button" class="ip-tab ip-section-tab' + (d.key === tab ? ' ip-tab-active' : '')
           + '" data-projecttab="' + escHtml(d.key) + '"'
           + (d.key === tab ? ' aria-current="page"' : '') + '>' + escHtml(d.label) + '</button>').join('')
-      + '</nav>';
+      + '</nav>'
+      + (tab === 'Status' && ready ? _relControls(IP) : '')
+      + '</div>';
 
     const header = back
       + '<header class="ip-head"><h2>' + escHtml(m.name)

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1001,7 +1001,7 @@ const Views = (function () {
     // group, so every group lines up. The width itself is a share of the
     // available space, so a wide window spreads and a narrow one tightens.
     return '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols
-      + ',calc(100% / var(--ip-rel-cols)))">' + inner + '</div>';
+      + ',calc((100% - var(--ip-rel-endgutter)) / var(--ip-rel-cols)))">' + inner + '</div>';
   }
 
   function _relWhen(iso) {
@@ -1082,20 +1082,55 @@ const Views = (function () {
           + '" title="' + escHtml(c.stateLabel + ' in ' + c.envName) + '"></span>'
         : (r.frontier === -1 && i === 0 ? '<span class="ip-rel-hnode ip-rel-node-empty"></span>' : '');
       const age = c.deployed && i !== r.frontier
-        ? '<span class="ip-rel-hcellage">' + escHtml(_relWhen(c.when)) + '</span>' : '';
+        ? '<span class="ip-rel-hcellage">' + escHtml(_relWhen(c.when))
+          + (c.tenantCount ? ' · ' + c.tenantCount + 't' : '') + '</span>' : '';
       return '<div class="ip-rel-hcell">' + seg + node + age + (atHead ? meta : '') + '</div>';
     }).join('');
 
     return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">' + _relTrack(cells, cols) + '</div>';
   }
 
+  // Where a tenant rollout is part-way through, an environment holds several
+  // releases at once. The collapsed cell can only say how many; this names them.
+  // The counts come from the dashboard payload — progression returns one
+  // deployment per environment and no tenant detail at all.
+  function _relTenantSpread(proj) {
+    const split = (proj.cells || []).filter(c => c.versionCount > 1 && c.tenantTotal > 0);
+    if (!split.length) return '';
+    const MAX_ROWS = 12;
+    const blocks = split.map(c => {
+      const rows = c.entries.slice(0, MAX_ROWS).map(e => {
+        const share = c.tenantTotal ? Math.round(e.tenantCount / c.tenantTotal * 100) : 0;
+        return '<li class="ip-rel-tsrow">'
+          + '<span class="ip-rel-tsbar"><span style="width:' + share + '%"></span></span>'
+          + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
+          + '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString()
+          +   (e.tenantCount === 1 ? ' tenant' : ' tenants') + '</span>'
+          + '<span class="ip-rel-hage">' + escHtml(_relWhen(e.when)) + '</span>'
+          + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">'
+              + escHtml(e.stateLabel) + '</span>' : '')
+          + '</li>';
+      }).join('');
+      const rest = c.entries.length - Math.min(c.entries.length, MAX_ROWS);
+      return '<div class="ip-rel-tsenv">'
+        + '<p class="ip-rel-tstitle">' + escHtml(c.envName) + ' — '
+        +   c.versionCount + (c.versionCount === 1 ? ' release' : ' releases') + ' across '
+        +   c.tenantTotal.toLocaleString() + (c.tenantTotal === 1 ? ' tenant' : ' tenants') + '</p>'
+        + '<ul class="ip-rel-tslist">' + rows + '</ul>'
+        + (rest > 0 ? '<p class="ip-rel-tsmore">+' + rest + ' further ' + (rest === 1 ? 'release' : 'releases') + '</p>' : '')
+        + '</div>';
+    }).join('');
+    return '<div class="ip-rel-tenants-block">' + blocks + '</div>';
+  }
+
   function _relHistory(proj, cols, history, windowLabel) {
     const st = history || { status: 'loading' };
+    const spread = _relTenantSpread(proj);
     // Mirrors the row structure — a label-width gutter, then the track — so an
     // expanded row starts on exactly the same x as the row it opened from.
     const wrap = body => '<div class="ip-rel-history">'
       + '<div class="ip-rel-proj ip-rel-history-gutter" aria-hidden="true"></div>'
-      + '<div class="ip-rel-history-body">' + body + '</div></div>';
+      + '<div class="ip-rel-history-body">' + spread + body + '</div></div>';
 
     if (st.status === 'loading' || !st.status) {
       return wrap('<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>');

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1388,6 +1388,7 @@ const Views = (function () {
     }
 
     const notes = [];
+    if (IP.spaceError) notes.push('Infrastructure cannot be read in this space, so the other sections are unavailable. Projects reads the project dashboard, which you do have access to.');
     if (m.truncated.capped) notes.push('Showing ' + m.truncated.shown + ' projects — the server caps the dashboard at ' + m.truncated.projectLimit + '. Projects beyond the cap are missing from this view.');
     if (m.truncated.isFiltered) notes.push('The dashboard is filtered on this instance, so this is a subset of its projects.');
     const note = notes.length ? '<div class="ip-rel-note">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '';

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -997,8 +997,11 @@ const Views = (function () {
   const REL_STATE_TONE = { success:'healthy', failed:'unhealthy', timedout:'unhealthy', cancelled:'disabled', running:'running', unknown:'disabled' };
 
   function _relTrack(inner, cols) {
-    return '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols + ',var(--ip-rel-col))">'
-      + inner + '</div>';
+    // Columns are one page-wide width, set on the wrapper from the widest
+    // group, so every group lines up. The width itself is a share of the
+    // available space, so a wide window spreads and a narrow one tightens.
+    return '<div class="ip-rel-track" style="grid-template-columns:repeat(' + cols
+      + ',calc(100% / var(--ip-rel-cols)))">' + inner + '</div>';
   }
 
   function _relWhen(iso) {
@@ -1047,26 +1050,27 @@ const Views = (function () {
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
       + '<div class="ip-rel-proj">'
       +   '<span class="ip-rel-caret" aria-hidden="true"></span>'
-      +   '<span class="ip-rel-proj-text">'
-      +     '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
-      +   '</span>'
+      +   '<span class="ip-rel-proj-name">' + escHtml(proj.name) + '</span>'
       + '</div>'
       + _relTrack(cells, cols)
       + '</div>';
     return row + (expanded ? _relHistory(proj, cols, history, windowLabel) : '');
   }
 
-  // The version rides the line at the furthest environment the release reached,
-  // rather than sitting in a column on the left. Where a release stops is then
-  // the same thing as where its name is.
+  // The version rides the line at the furthest environment the release reached.
+  // The age beside it is when it ARRIVED there, not when the release was cut —
+  // a release assembled weeks ago and promoted this morning is this morning's
+  // event, and showing its birthday made the window look broken.
   function _relHistoryRow(r, cols, multiChannel) {
+    const headCell = r.frontier >= 0 ? r.cells[r.frontier] : null;
+    const headAge = headCell && headCell.when ? headCell.when : r.assembled;
     const meta = '<span class="ip-rel-hlabel">'
       + '<span class="ip-rel-hver">' + escHtml(r.version) + '</span>'
       + (multiChannel && r.channelName ? '<span class="ip-rel-hchan">' + escHtml(r.channelName) + '</span>' : '')
-      + '<span class="ip-rel-hage">' + escHtml(_relWhen(r.assembled)) + '</span>'
+      + '<span class="ip-rel-hage">' + escHtml(_relWhen(headAge)) + '</span>'
       + (r.lag > 0 ? '<span class="ip-rel-hlag">' + r.lag + ' behind'
           + (multiChannel ? ' in ' + escHtml(r.channelName) : '') + '</span>' : '')
-      + (!r.everDeployed ? '<span class="ip-rel-hnever">created, never deployed</span>' : '')
+      + (!r.everDeployed ? '<span class="ip-rel-hnever">created ' + escHtml(_relWhen(r.assembled)) + ', never deployed</span>' : '')
       + '</span>';
 
     const cells = r.cells.map((c, i) => {
@@ -1087,7 +1091,11 @@ const Views = (function () {
 
   function _relHistory(proj, cols, history, windowLabel) {
     const st = history || { status: 'loading' };
-    const wrap = body => '<div class="ip-rel-history">' + body + '</div>';
+    // Mirrors the row structure — a label-width gutter, then the track — so an
+    // expanded row starts on exactly the same x as the row it opened from.
+    const wrap = body => '<div class="ip-rel-history">'
+      + '<div class="ip-rel-proj ip-rel-history-gutter" aria-hidden="true"></div>'
+      + '<div class="ip-rel-history-body">' + body + '</div></div>';
 
     if (st.status === 'loading' || !st.status) {
       return wrap('<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading releases…</span></div>');
@@ -1150,6 +1158,7 @@ const Views = (function () {
     const open = IP.projectOpen || {};
     const hist = IP.projectHistory || {};
 
+    const maxCols = (m.groups || []).reduce((n, g) => Math.max(n, g.environments.length), 1);
     const blocks = (m.groups || []).map(g => {
       const cols = g.environments.length;
       if (!cols) {
@@ -1178,7 +1187,8 @@ const Views = (function () {
       +   '<span><i class="ip-rel-key ip-rel-key-split"></i>Split across tenants</span>'
       +   '<span><i class="ip-rel-key ip-rel-key-strong"></i>Same release both sides</span>'
       +   '<span><i class="ip-rel-key ip-rel-key-pale"></i>Drifted</span>'
-      + '</div>' + blocks;
+      + '</div>'
+      + '<div class="ip-rel-groups" style="--ip-rel-cols:' + maxCols + '">' + blocks + '</div>';
   }
 
   function bindProjects(IP) {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1091,41 +1091,56 @@ const Views = (function () {
   }
 
   // Where a tenant rollout is part-way through, an environment holds several
-  // releases at once. The collapsed cell can only say how many; this names them.
-  // The counts come from the dashboard payload — progression returns one
-  // deployment per environment and no tenant detail at all.
-  function _relTenantSpread(proj) {
-    const split = (proj.cells || []).filter(c => c.versionCount > 1 && c.tenantTotal > 0);
-    if (!split.length) return '';
-    const MAX_ROWS = 12;
-    const blocks = split.map(c => {
-      const rows = c.entries.slice(0, MAX_ROWS).map(e => {
-        const share = c.tenantTotal ? Math.round(e.tenantCount / c.tenantTotal * 100) : 0;
-        return '<li class="ip-rel-tsrow">'
-          + '<span class="ip-rel-tsbar"><span style="width:' + share + '%"></span></span>'
-          + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
-          + '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString()
-          +   (e.tenantCount === 1 ? ' tenant' : ' tenants') + '</span>'
-          + '<span class="ip-rel-hage">' + escHtml(_relWhen(e.when)) + '</span>'
-          + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">'
-              + escHtml(e.stateLabel) + '</span>' : '')
-          + '</li>';
+  // releases at once. The collapsed cell can only say how many; this names them,
+  // in the environment's own column so it reads against the row above rather
+  // than as a separate list.
+  //
+  // The counts come from the dashboard payload — /progression returns one
+  // deployment per environment and carries no tenant detail at all.
+  function _relTenantSpread(proj, cols) {
+    const cells = proj.cells || [];
+    if (!cells.some(c => c.versionCount > 1 && c.tenantTotal > 0)) return '';
+    const MAX = 6;
+
+    const body = cells.map(c => {
+      if (!c.tenantTotal) return '<div class="ip-rel-tscell"></div>';
+      if (c.versionCount <= 1) {
+        return '<div class="ip-rel-tscell"><span class="ip-rel-tsall">All '
+          + c.tenantTotal.toLocaleString() + (c.tenantTotal === 1 ? ' tenant' : ' tenants')
+          + ' on one release</span></div>';
+      }
+      const shown = c.entries.slice(0, MAX);
+      const rest = c.entries.length - shown.length;
+      const restTenants = c.entries.slice(MAX).reduce((n, e) => n + e.tenantCount, 0);
+      const rows = shown.map(e => {
+        const share = c.tenantTotal ? (e.tenantCount / c.tenantTotal * 100) : 0;
+        return '<div class="ip-rel-tsentry">'
+          + '<span class="ip-rel-tshead">'
+          +   '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
+          +   '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString() + '</span>'
+          + '</span>'
+          + '<span class="ip-rel-tsbar" title="' + escHtml(e.tenantCount + ' of ' + c.tenantTotal + ' tenants')
+          +   '"><span style="width:' + share.toFixed(1) + '%"></span></span>'
+          + '</div>';
       }).join('');
-      const rest = c.entries.length - Math.min(c.entries.length, MAX_ROWS);
-      return '<div class="ip-rel-tsenv">'
-        + '<p class="ip-rel-tstitle">' + escHtml(c.envName) + ' — '
-        +   c.versionCount + (c.versionCount === 1 ? ' release' : ' releases') + ' across '
-        +   c.tenantTotal.toLocaleString() + (c.tenantTotal === 1 ? ' tenant' : ' tenants') + '</p>'
-        + '<ul class="ip-rel-tslist">' + rows + '</ul>'
-        + (rest > 0 ? '<p class="ip-rel-tsmore">+' + rest + ' further ' + (rest === 1 ? 'release' : 'releases') + '</p>' : '')
-        + '</div>';
+      const more = rest > 0
+        ? '<span class="ip-rel-tsmore">+' + rest + ' more on ' + restTenants.toLocaleString()
+          + (restTenants === 1 ? ' tenant' : ' tenants') + '</span>' : '';
+      return '<div class="ip-rel-tscell">'
+        + '<span class="ip-rel-tssum">' + c.versionCount + ' releases · '
+        +   c.tenantTotal.toLocaleString() + (c.tenantTotal === 1 ? ' tenant' : ' tenants') + '</span>'
+        + rows + more + '</div>';
     }).join('');
-    return '<div class="ip-rel-tenants-block">' + blocks + '</div>';
+
+    return '<div class="ip-rel-tsblock">'
+      + '<p class="ip-rel-tscaption">Tenant split</p>'
+      + _relTrack(body, cols)
+      + '</div>';
   }
 
   function _relHistory(proj, cols, history, windowLabel) {
     const st = history || { status: 'loading' };
-    const spread = _relTenantSpread(proj);
+    const spread = _relTenantSpread(proj, cols);
     // Mirrors the row structure — a label-width gutter, then the track — so an
     // expanded row starts on exactly the same x as the row it opened from.
     const wrap = body => '<div class="ip-rel-history">'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -90,6 +90,13 @@ const Views = (function () {
     return String(base).replace(/\/$/, '') + '/app#/infrastructure/machines';
   }
   function renderOverview(ov, estate) {
+    // Every number below is derived from deployment targets. If they could not
+    // be read, say so above them rather than presenting zeros as findings.
+    const blind = estate && estate.failed && estate.failed.machines
+      ? '<div class="ip-rel-note"><p>Deployment targets can\'t be read in this space, so every '
+        + 'target-derived figure below is missing rather than zero. Environments, worker pools and '
+        + 'tenants are unaffected.</p></div>'
+      : '';
     const ab = (ov.agents && ov.agents.behind) || 0;
     const agentsPillText = ab === 0 ? 'all up to date' : ab + ' behind';
     const typeRows = ov.byType.map(r =>
@@ -110,7 +117,7 @@ const Views = (function () {
       + '<td>' + r.disabled + '</td></tr>').join('');
     const pools = ov.workers.pools.map(p =>
       '<li><span>' + escHtml(p.name) + '</span><b>' + p.count + '</b></li>').join('');
-    return ''
+    return blind + ''
       + '<header class="ip-head ip-head-actions">'
       +   '<div class="ip-head-text"><h2>Infrastructure overview</h2>'
       +     '<p class="ip-sub">A diagnostic snapshot of your deployment estate.</p></div>'
@@ -218,6 +225,12 @@ const Views = (function () {
       + '<td>' + escHtml(t.version) + '</td></tr>';
   }
   function renderTargets(IP) {
+    // A space where targets cannot be read must not render as a space with no
+    // targets — the zero would be a claim we cannot make.
+    if (IP.estate && IP.estate.failed && IP.estate.failed.machines) {
+      return '<header class="ip-head"><h2>Deployment targets</h2></header>'
+        + _unreadable('deployment targets');
+    }
     const all = IP.estate.targets;
     // Nothing to filter, so the facet rail and toolbar would be furniture around a void.
     if (!all.length) return renderTargetsZero(IP);

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1373,8 +1373,9 @@ const Views = (function () {
       + changeBand + varBand);
   }
 
-  function renderProjects(IP) {
-    const st = IP.releases || { status: 'idle' };
+  // The window/grouping controls, the legend and the environment header are the
+  // same on the projects list and on one project's Status tab. One copy each.
+  function _relControls(IP) {
     const windows = (typeof Data !== 'undefined' && Data.HISTORY_WINDOWS) || [{ label: '24 hours' }, { label: '7 days' }, { label: 'All' }];
     const active = IP.historyWindow || windows[0].label;
     const segs = windows.map(w => '<button class="ip-seg' + (w.label === active ? ' active' : '')
@@ -1383,12 +1384,49 @@ const Views = (function () {
     const grouping = IP.grouping || groupings[0];
     const gsegs = groupings.map(gname => '<button class="ip-seg' + (gname === grouping ? ' active' : '')
       + '" data-grouping="' + escHtml(gname) + '">' + escHtml(gname) + '</button>').join('');
+    return '<div class="ip-rel-controls">'
+      + '<div class="ip-rel-window"><span class="ip-caption">History</span><div class="ip-segs">' + segs + '</div></div>'
+      + '<div class="ip-rel-window"><span class="ip-caption">Group by</span><div class="ip-segs">' + gsegs + '</div></div>'
+      + '</div>';
+  }
+
+  function _relWindowLabel(IP) {
+    const windows = (typeof Data !== 'undefined' && Data.HISTORY_WINDOWS) || [{ label: '24 hours' }];
+    return IP.historyWindow || windows[0].label;
+  }
+
+  function _relLegend() {
+    return '<div class="ip-rel-legend">'
+      + '<span><i class="ip-rel-key ip-rel-key-healthy"></i>Deployed</span>'
+      + '<span><i class="ip-rel-key ip-rel-key-running"></i>In progress</span>'
+      + '<span><i class="ip-rel-key ip-rel-key-unhealthy"></i>Failed or timed out</span>'
+      + '<span><i class="ip-rel-key ip-rel-key-split"></i>Split across tenants</span>'
+      + '<span><i class="ip-rel-key ip-rel-key-strong"></i>Same release both sides</span>'
+      + '<span><i class="ip-rel-key ip-rel-key-pale"></i>Drifted</span>'
+      + '</div>';
+  }
+
+  function _relEnvHeads(groupId, environments, off) {
+    return environments.map(e => {
+      const isOff = !!(off || {})[e.id];
+      return '<div class="ip-rel-envhead' + (isOff ? ' is-off' : '') + '">'
+        + '<span class="ip-rel-envname">' + escHtml(e.name) + '</span>'
+        + '<button type="button" class="ip-rel-envtoggle" role="switch"'
+        +   ' aria-checked="' + (isOff ? 'false' : 'true') + '"'
+        +   ' data-envtoggle="' + escHtml(groupId) + '|' + escHtml(e.id) + '"'
+        +   ' title="' + escHtml((isOff ? 'Show ' : 'Hide ') + e.name + ' in expanded history') + '">'
+        +   '<span class="ip-rel-envtoggle-track"><span class="ip-rel-envtoggle-knob"></span></span>'
+        + '</button></div>';
+    }).join('');
+  }
+
+  function renderProjects(IP) {
+    const st = IP.releases || { status: 'idle' };
+    const active = _relWindowLabel(IP);
+    const grouping = IP.grouping || ((typeof Data !== 'undefined' && Data.GROUPINGS) || ['Time'])[0];
     const head = '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Projects</h2>'
       + '<p class="ip-sub">What each project is running in each environment, and where a release has stopped moving.</p></div>'
-      + '<div class="ip-rel-controls">'
-      +   '<div class="ip-rel-window"><span class="ip-caption">History</span><div class="ip-segs">' + segs + '</div></div>'
-      +   '<div class="ip-rel-window"><span class="ip-caption">Group by</span><div class="ip-segs">' + gsegs + '</div></div>'
-      + '</div></header>';
+      + _relControls(IP) + '</header>';
 
     if (st.status === 'loading' || st.status === 'idle') {
       return head + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading the project dashboard…</p></div>';
@@ -1423,17 +1461,7 @@ const Views = (function () {
           + '<p class="ip-rel-hempty">Nothing in this group has been deployed yet.</p></section>';
       }
       const off = (IP.envOff && IP.envOff[g.id]) || {};
-      const heads = g.environments.map(e => {
-        const isOff = !!off[e.id];
-        return '<div class="ip-rel-envhead' + (isOff ? ' is-off' : '') + '">'
-          + '<span class="ip-rel-envname">' + escHtml(e.name) + '</span>'
-          + '<button type="button" class="ip-rel-envtoggle" role="switch"'
-          +   ' aria-checked="' + (isOff ? 'false' : 'true') + '"'
-          +   ' data-envtoggle="' + escHtml(g.id) + '|' + escHtml(e.id) + '"'
-          +   ' title="' + escHtml((isOff ? 'Show ' : 'Hide ') + e.name + ' in expanded history') + '">'
-          +   '<span class="ip-rel-envtoggle-track"><span class="ip-rel-envtoggle-knob"></span></span>'
-          + '</button></div>';
-      }).join('');
+      const heads = _relEnvHeads(g.id, g.environments, off);
       const flg = IP.projectFlags || {};
       const rows = g.projects.map(p =>
         '<div class="ip-rel-card' + (open[p.id] ? ' is-open' : '') + '">'
@@ -1451,22 +1479,19 @@ const Views = (function () {
         + '</div>' + hiddenNote + '</section>';
     }).join('');
 
-    return head + note
-      + '<div class="ip-rel-legend">'
-      +   '<span><i class="ip-rel-key ip-rel-key-healthy"></i>Deployed</span>'
-      +   '<span><i class="ip-rel-key ip-rel-key-running"></i>In progress</span>'
-      +   '<span><i class="ip-rel-key ip-rel-key-unhealthy"></i>Failed or timed out</span>'
-      +   '<span><i class="ip-rel-key ip-rel-key-split"></i>Split across tenants</span>'
-      +   '<span><i class="ip-rel-key ip-rel-key-strong"></i>Same release both sides</span>'
-      +   '<span><i class="ip-rel-key ip-rel-key-pale"></i>Drifted</span>'
-      + '</div>'
+    return head + note + _relLegend()
       + '<div class="ip-rel-groups" style="--ip-rel-cols:' + maxCols + '">' + blocks + '</div>';
   }
 
   function bindProjects(IP) {
     const root = document.getElementById('main-content');
     if (!root) return;
-    const redraw = () => { root.innerHTML = renderProjects(IP); bindProjects(IP); };
+    _bindRelRows(IP, root, () => { root.innerHTML = renderProjects(IP); bindProjects(IP); });
+  }
+
+  // Expanding a row, hiding an environment, changing the window or the grouping
+  // behave the same wherever the row is drawn, so only the redraw differs.
+  function _bindRelRows(IP, root, redraw) {
     const toggle = el => {
       const id = el.getAttribute('data-project');
       if (!id) return;
@@ -2053,6 +2078,72 @@ const Views = (function () {
   // What goes in, what starts it, what it does, where it lands. Panels rather
   // than a flow diagram: the same facts, without asking anyone to trust a
   // layout before they trust the data.
+  // The projects list draws one row per project; a project's own page draws that
+  // same row for one project. Same builders, same interactions — the only
+  // difference is that this one opens expanded, because a page about one project
+  // should not make you click to see it.
+  function _projectStatus(IP, projectId) {
+    const st = IP.releases || { status: 'idle' };
+    if (st.status === 'loading' || st.status === 'idle') {
+      return '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading the project dashboard…</span></div>';
+    }
+    if (st.status === 'error') {
+      return '<p class="ip-tn-muted">' + escHtml(st.error || 'The project dashboard could not be read.') + '</p>';
+    }
+    const m = st.model;
+    const group = (m.groups || []).find(g => g.projects.some(pr => pr.id === projectId));
+    const proj = group && group.projects.find(pr => pr.id === projectId);
+    if (!proj) {
+      // Two different reasons, and the dashboard cap is the one worth naming.
+      return '<p class="ip-tn-muted">'
+        + (m.truncated && m.truncated.capped
+            ? 'This project is beyond the ' + m.truncated.projectLimit + ' the dashboard returns, so its releases are not on it.'
+            : 'This project has no releases on the dashboard yet.')
+        + '</p>';
+    }
+    const cols = group.environments.length;
+    if (!cols) return '<p class="ip-tn-muted">Nothing in this project group has been deployed yet.</p>';
+
+    const off = (IP.envOff && IP.envOff[group.id]) || {};
+    const open = !!(IP.projectOpen || {})[projectId];
+    const grouping = IP.grouping || ((typeof Data !== 'undefined' && Data.GROUPINGS) || ['Time'])[0];
+    const card = '<div class="ip-rel-card' + (open ? ' is-open' : '') + '">'
+      + _relRow(proj, cols, open, (IP.projectHistory || {})[projectId], _relWindowLabel(IP), off,
+          (IP.projectFlags || {})[projectId], grouping)
+      + '</div>';
+    const hidden = group.hiddenEnvironments.length
+      ? '<p class="ip-rel-hidden">Not shown, because this project group has never deployed to them: '
+        + escHtml(group.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
+    return _relControls(IP) + _relLegend()
+      + '<div class="ip-rel-groups" style="--ip-rel-cols:' + cols + '">'
+      +   '<section class="ip-rel-group"><div class="ip-rel-grid">'
+      +     '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>'
+      +       _relTrack(_relEnvHeads(group.id, group.environments, off), cols) + '</div>'
+      +     '<div class="ip-rel-cards">' + card + '</div>'
+      +   '</div>' + hidden + '</section>'
+      + '</div>';
+  }
+
+  function bindProjectMap(IP) {
+    const root = document.getElementById('main-content');
+    if (!root) return;
+    const redraw = () => { root.innerHTML = renderProjectMap(IP); bindProjectMap(IP); };
+    root.querySelectorAll('[data-projecttab]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        IP.projectTab = btn.getAttribute('data-projecttab');
+        redraw();
+        // Opening Status for the first time is when its history is first wanted.
+        const id = IP.projectMap && IP.projectMap.projectId;
+        if (IP.projectTab === 'Status' && id && (IP.projectOpen || {})[id]
+            && IP.releases && IP.releases.status === 'ready') {
+          if (IP.loadProjectHistory) IP.loadProjectHistory(id);
+          if (IP.loadProjectFlags) IP.loadProjectFlags(id);
+        }
+      });
+    });
+    _bindRelRows(IP, root, redraw);
+  }
+
   function renderProjectMap(IP) {
     const st = IP.projectMap || { status: 'loading' };
     const back = '<p class="ip-tn-back"><a href="#projects">← All projects</a></p>';
@@ -2287,12 +2378,26 @@ const Views = (function () {
         + '<p class="ip-tn-legend">' + notes.map(escHtml).join(' ') + '</p>';
     })();
 
-    return back
+    // Two questions about one project: what is running right now, and how the
+    // project is put together. They are different enough to be different tabs.
+    const tab = IP.projectTab === 'Overview' ? 'Overview' : 'Status';
+    const tabs = '<nav class="ip-tabs ip-section-tabs" aria-label="Project sections">'
+      + [{ key: 'Status', label: 'Status' }, { key: 'Overview', label: 'Overview' }].map(d =>
+          '<button type="button" class="ip-tab ip-section-tab' + (d.key === tab ? ' ip-tab-active' : '')
+          + '" data-projecttab="' + escHtml(d.key) + '"'
+          + (d.key === tab ? ' aria-current="page"' : '') + '>' + escHtml(d.label) + '</button>').join('')
+      + '</nav>';
+
+    const header = back
       + '<header class="ip-head"><h2>' + escHtml(m.name)
       +   (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
       +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
       +   _tnDescription(m.description)
-      + '</header>'
+      + '</header>' + tabs;
+
+    if (tab === 'Status') return header + _projectStatus(IP, m.id);
+
+    return header
       + panel('Lifecycles', m.lifecycles && m.lifecycles.length > 1
           ? m.lifecycles.length + ' in use' : m.lifecycle, lifecycles)
       + '<div class="ip-pm-grid">'
@@ -2362,7 +2467,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderProjectMap, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderProjectMap, bindProjectMap, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1319,7 +1319,11 @@ const Views = (function () {
     // Grouping by time interleaves flag changes with the releases, so a flip
     // that shipped alongside a deployment reads as one moment rather than as
     // two facts in two sections.
-    const changes = (grouping === 'Time' && flags && flags.status === 'ready' && flags.changes) ? flags.changes : [];
+    const changesAll = (flags && flags.status === 'ready' && flags.changes) ? flags.changes : [];
+    // Same treatment as variable changes: a change scoped outside this grid has
+    // no column to sit in, so it is counted in the note rather than drawn.
+    const changesShown = changesAll.filter(c => !c.scopedElsewhere);
+    const changes = grouping === 'Time' ? changesShown : [];
     const varsAll = (flags && flags.status === 'ready' && flags.variables) ? flags.variables : [];
     const varsShown = varsAll.filter(c => !c.scopedElsewhere);
     const varChanges = grouping === 'Time' ? varsShown : [];
@@ -1344,13 +1348,16 @@ const Views = (function () {
     if (m.hiddenByWindow) notes.push(m.hiddenByWindow + ' older ' + (m.hiddenByWindow === 1 ? 'release is' : 'releases are') + ' outside this window.');
     if (m.windowed) notes.push('History reaches back ' + m.historyCount + ' releases per channel.');
     if (m.neverDeployedCount) notes.push(m.neverDeployedCount + ' of these were created and never deployed anywhere.');
+    const flagElsewhere = changesAll.length - changesShown.length;
+    if (flagElsewhere) notes.push(flagElsewhere + ' flag ' + (flagElsewhere === 1 ? 'change is' : 'changes are')
+      + ' scoped to environments this project does not deploy to.');
 
     // Grouped by type, the changes get their own band rather than being mixed
     // into the releases; grouped by time they are already interleaved above.
     let changeBand = '';
-    if (grouping === 'Type' && flags && flags.status === 'ready' && (flags.changes || []).length) {
+    if (grouping === 'Type' && changesShown.length) {
       const envIds = (m.environments || []).map(e => e.id);
-      const changeRows = flags.changes.map(c => _relFlagChangeRow(c, cols, off, envIds)).filter(Boolean).join('');
+      const changeRows = changesShown.map(c => _relFlagChangeRow(c, cols, off, envIds)).filter(Boolean).join('');
       if (changeRows) {
         changeBand = '<div class="ip-rel-band"><p class="ip-rel-bandhead">Flag changes'
           + '<span class="ip-rel-bandcount">last ' + escHtml(String(windowLabel).toLowerCase()) + '</span></p>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2035,37 +2035,6 @@ const Views = (function () {
     // Feature flags, on the same terms as the tenant page: on and off are
     // counts, and the ones in between are named, because "4 in between" is not
     // something anyone can act on without knowing which four.
-    const flagPanel = (function () {
-      if (m.flagsError) return none(m.flagsError);
-      const fm = m.flags;
-      if (!fm) return '<div class="ip-rel-loading"><div class="ip-spinner"></div><span>Loading flags…</span></div>';
-      if (!fm.total) return none('This project has no feature flags.');
-      if (!fm.scoped) return none(fm.total + ' flags, but no lifecycle environments to place them in.');
-      const stat = (n, lbl, tone) => '<span class="ip-tn-stat">'
-        + '<span class="ip-tn-statnum ip-tn-stat-' + escHtml(tone) + '">' + n + '</span>'
-        + '<span class="ip-tn-statlabel">' + escHtml(lbl) + '</span></span>';
-      const tone = k => k === 'on' ? 'healthy' : (k === 'partial' ? 'warning' : 'disabled');
-      const text = c => c.key === 'partial' ? c.percent + '%'
-        : c.key === 'on' ? (c.tenantCount ? 'on · ' + c.tenantCount + ' targeted' : 'on')
-        : 'off';
-      const rows = fm.between.map(f =>
-        '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(f.name) + '</span>'
-        + '<span class="ip-tn-flagstates">' + f.cells.map(c =>
-            '<span class="ip-tn-flagstate"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone(c.key)) + '"></span>'
-            + escHtml(c.envName) + ' <span class="ip-tn-age">' + escHtml(text(c)) + '</span></span>').join('')
-        + '</span></li>').join('');
-      const notes = [];
-      notes.push('A flag with no setting for an environment falls back to its default, and is counted that way.');
-      if (fm.truncated) notes.push('Only the first ' + fm.flags.length + ' of ' + fm.total + ' flags were read.');
-      return '<div class="ip-tn-stats">'
-        +   stat(fm.fullyOn, 'on', 'healthy')
-        +   stat(fm.fullyOff, 'off', 'disabled')
-        +   stat(fm.betweenCount, 'rolling out', fm.betweenCount ? 'warning' : 'disabled')
-        + '</div>'
-        + (rows ? '<ul class="ip-tn-targets">' + rows + '</ul>'
-                : '<p class="ip-tn-muted">Every flag is on or off across all of these environments.</p>')
-        + '<p class="ip-tn-legend">' + notes.map(escHtml).join(' ') + '</p>';
-    })();
 
     return back
       + '<header class="ip-head"><h2>' + escHtml(m.name) + (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
@@ -2282,16 +2251,30 @@ const Views = (function () {
       const stat = (n, lbl, tone) => '<span class="ip-tn-stat">'
         + '<span class="ip-tn-statnum ip-tn-stat-' + escHtml(tone) + '">' + n + '</span>'
         + '<span class="ip-tn-statlabel">' + escHtml(lbl) + '</span></span>';
-      const tone = k => k === 'on' ? 'healthy' : (k === 'partial' ? 'warning' : 'disabled');
-      const text = c => c.key === 'partial' ? c.percent + '%'
-        : c.key === 'on' ? (c.tenantCount ? 'on · ' + c.tenantCount + ' targeted' : 'on')
-        : 'off';
-      const rows = fm.between.map(f =>
-        '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(f.name) + '</span>'
-        + '<span class="ip-tn-flagstates">' + f.cells.map(c =>
-            '<span class="ip-tn-flagstate"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone(c.key)) + '"></span>'
-            + escHtml(c.envName) + ' <span class="ip-tn-age">' + escHtml(text(c)) + '</span></span>').join('')
-        + '</span></li>').join('');
+      // Environments named once across the top, the same way the lifecycle
+      // panel does it. Repeating them per flag cost more room than the states
+      // themselves.
+      const cell = c => {
+        const title = c.envName + ': ' + (c.key === 'partial' ? c.percent + '% rollout'
+          : c.key === 'on' ? (c.tenantCount ? 'on, ' + c.tenantCount + ' targeted' : 'on') : 'off')
+          + (c.viaDefault ? ' (by default)' : '');
+        const body = c.key === 'partial'
+          ? '<span class="ip-pm-fpct">' + c.percent + '</span>'
+          : '<span class="ip-pm-fdot is-' + escHtml(c.key) + (c.viaDefault ? ' is-default' : '') + '"></span>';
+        return '<div class="ip-pm-cell" title="' + escHtml(title) + '">' + body + '</div>';
+      };
+      const grid = fm.between.length
+        ? '<div class="ip-pm-lc ip-pm-fg" style="--ip-pm-cols:' + fm.environments.length + '">'
+          + '<div class="ip-pm-lcrow ip-pm-lchead"><div class="ip-pm-lclabel"></div>'
+          +   '<div class="ip-pm-lctrack">' + fm.environments.map(e =>
+                '<div class="ip-pm-colhead" title="' + escHtml(e) + '">' + escHtml(e) + '</div>').join('')
+          + '</div></div>'
+          + fm.between.map(f =>
+              '<div class="ip-pm-lcrow"><div class="ip-pm-lclabel">'
+              + '<span class="ip-tn-tname" title="' + escHtml(f.name) + '">' + escHtml(f.name) + '</span></div>'
+              + '<div class="ip-pm-lctrack">' + f.cells.map(cell).join('') + '</div></div>').join('')
+          + '</div>'
+        : '';
       const notes = [];
       notes.push('A flag with no setting for an environment falls back to its default, and is counted that way.');
       if (fm.truncated) notes.push('Only the first ' + fm.flags.length + ' of ' + fm.total + ' flags were read.');
@@ -2300,8 +2283,7 @@ const Views = (function () {
         +   stat(fm.fullyOff, 'off', 'disabled')
         +   stat(fm.betweenCount, 'rolling out', fm.betweenCount ? 'warning' : 'disabled')
         + '</div>'
-        + (rows ? '<ul class="ip-tn-targets">' + rows + '</ul>'
-                : '<p class="ip-tn-muted">Every flag is on or off across all of these environments.</p>')
+        + (grid || '<p class="ip-tn-muted">Every flag is on or off across all of these environments.</p>')
         + '<p class="ip-tn-legend">' + notes.map(escHtml).join(' ') + '</p>';
     })();
 

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1497,6 +1497,182 @@ const Views = (function () {
     });
   }
 
+  // ─── Tenants ───────────────────────────────────────────────────────────────
+  // A tenant has no health of its own, so the row reports four independent
+  // facts side by side and never merges them into a score.
+  const TENANT_PAGE_SIZE = 100;
+
+  function _tenantWhen(at) {
+    if (!at) return '';
+    return _relWhen(new Date(at).toISOString());
+  }
+
+  function _tenantOutcomeCell(t) {
+    if (!t.connected) return '<span class="ip-tn-muted">Not connected</span>';
+    if (!t.deployed) return '<span class="ip-tn-muted">Never deployed</span>';
+    const tone = t.outcome === 'success' ? 'healthy'
+      : (t.outcome === 'running' ? 'running' : (t.outcome === 'cancelled' ? 'disabled' : 'unhealthy'));
+    return '<span class="ip-tn-outcome">'
+      + '<span class="ip-tn-dot ip-rel-node-' + escHtml(tone) + '"></span>'
+      + '<span>' + escHtml(t.outcomeLabel) + '</span>'
+      + '<span class="ip-tn-age">' + escHtml(_tenantWhen(t.outcomeAt)) + '</span>'
+      + (t.outcomeProject ? '<span class="ip-tn-age">· ' + escHtml(t.outcomeProject) + '</span>' : '')
+      + '</span>';
+  }
+
+  function _tenantFacetGroup(title, entries, key, selected) {
+    if (!entries.length) return '';
+    const sel = (selected && selected[key]) || {};
+    const rows = entries.map(e =>
+      '<label class="ip-tn-facet' + (sel[e.value] ? ' is-on' : '') + '">'
+      + '<input type="checkbox" data-facet="' + escHtml(key) + '" data-value="' + escHtml(e.value) + '"'
+      +   (sel[e.value] ? ' checked' : '') + '>'
+      + '<span class="ip-tn-facet-name">' + escHtml(e.label) + '</span>'
+      + '<span class="ip-tn-facet-count">' + e.count + '</span></label>').join('');
+    return '<div class="ip-tn-facetgroup"><p class="ip-tn-facettitle">' + escHtml(title) + '</p>' + rows + '</div>';
+  }
+
+  function renderTenants(IP) {
+    const st = IP.tenants || { status: 'idle' };
+    const head = '<header class="ip-head"><h2>Tenants</h2>'
+      + '<p class="ip-sub">Customers, sites and regions deployed through one shared process. '
+      + 'State is four independent facts — connection, last outcome, currency and readiness — never one score.</p></header>';
+
+    if (st.status === 'loading' || st.status === 'idle') {
+      return head + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading tenants…</p></div>';
+    }
+    if (st.status === 'error') {
+      return head + '<div class="ip-state"><h3>Couldn\'t load tenants</h3><p>' + escHtml(st.error || 'Unknown error') + '</p></div>';
+    }
+    const m = st.model;
+    if (!m.tenants.length) {
+      return head + '<div class="ip-empty"><h3>No tenants in this space</h3>'
+        + '<p>A tenant is a customer, site or region that a project deploys to separately, through one shared process.</p></div>';
+    }
+
+    IP.tenantQuery = IP.tenantQuery || '';
+    IP.tenantSort = IP.tenantSort || 'Actionability';
+    IP.tenantSel = IP.tenantSel || {};
+    IP.tenantPage = IP.tenantPage || 0;
+
+    const filtered = Data.filterTenants(m.tenants, IP.tenantQuery, IP.tenantSel);
+    const sorted = Data.sortTenants(filtered, IP.tenantSort);
+    const pages = Math.max(1, Math.ceil(sorted.length / TENANT_PAGE_SIZE));
+    const page = Math.min(IP.tenantPage, pages - 1);
+    const slice = sorted.slice(page * TENANT_PAGE_SIZE, (page + 1) * TENANT_PAGE_SIZE);
+
+    const facets = Data.tenantFacets(m.tenants, IP.tenantQuery, IP.tenantSel);
+    // Tag sets come from the instance, not from a fixed list — an instance with
+    // no tag sets simply has no tag facets.
+    const tagGroups = m.tagSets.map(ts => _tenantFacetGroup(ts.name,
+      ts.tags.map(tag => ({ label: tag.name, value: ts.name + '/' + tag.name,
+        count: facets.count('tags', ts.name + '/' + tag.name) }))
+        .filter(e => e.count > 0), 'tags', IP.tenantSel)).join('');
+
+    const envGroup = _tenantFacetGroup('Environment',
+      m.environments.map(e => ({ label: e.name, value: e.name, count: facets.count('environments', e.name) }))
+        .filter(e => e.count > 0), 'environments', IP.tenantSel);
+
+    const stateGroup = _tenantFacetGroup('State', [
+      { label: 'Needs attention', value: 'needs-attention', count: facets.count('state', 'needs-attention') },
+      { label: 'Never deployed', value: 'never-deployed', count: facets.count('state', 'never-deployed') },
+      { label: 'Not connected', value: 'not-connected', count: facets.count('state', 'not-connected') }
+    ].filter(e => e.count > 0), 'state', IP.tenantSel);
+
+    const projGroup = _tenantFacetGroup('Connected project',
+      m.projects.map(p => ({ label: p.name, value: p.id, count: facets.count('projects', p.id) }))
+        .filter(e => e.count > 0), 'projects', IP.tenantSel);
+
+    const sorts = Data.TENANT_SORTS.map(x => '<option' + (x === IP.tenantSort ? ' selected' : '') + '>'
+      + escHtml(x) + '</option>').join('');
+
+    const rows = slice.map(t =>
+      '<tr class="ip-tn-row">'
+      + '<td><a class="ip-tn-name" href="#tenants/' + escHtml(t.id) + '">' + escHtml(t.name) + '</a>'
+      +   '<span class="ip-tn-id">' + escHtml(t.id) + '</span></td>'
+      + '<td>' + (t.tags.length
+          ? t.tags.slice(0, 3).map(tag => '<span class="ip-chipx ip-chipx-tag">' + escHtml(tag.name) + '</span>').join('')
+            + (t.tags.length > 3 ? '<span class="ip-tn-age">+' + (t.tags.length - 3) + '</span>' : '')
+          : '<span class="ip-tn-muted">—</span>') + '</td>'
+      + '<td>' + t.connectedProjectIds.length + '</td>'
+      + '<td>' + (t.environmentsOn.length ? escHtml(t.environmentsOn.slice(0, 2).join(', '))
+          + (t.environmentsOn.length > 2 ? ' +' + (t.environmentsOn.length - 2) : '')
+          : '<span class="ip-tn-muted">—</span>') + '</td>'
+      + '<td>' + _tenantOutcomeCell(t) + '</td>'
+      + '</tr>').join('');
+
+    const activeChips = [];
+    Object.keys(IP.tenantSel).forEach(k => Object.keys(IP.tenantSel[k] || {}).forEach(v => {
+      if (IP.tenantSel[k][v]) activeChips.push('<button class="ip-tn-chip" data-clear="' + escHtml(k) + '|' + escHtml(v) + '">'
+        + escHtml(v) + ' ×</button>');
+    }));
+
+    return head
+      + '<div class="ip-tn-toolbar">'
+      +   '<input class="ip-search ip-tn-search" type="search" placeholder="Search tenants…" value="' + escHtml(IP.tenantQuery) + '">'
+      +   '<label class="ip-tn-sort"><span class="ip-caption">Sort</span><select class="ip-tn-sortsel">' + sorts + '</select></label>'
+      +   '<span class="ip-count">' + sorted.length.toLocaleString()
+      +     (sorted.length === m.tenants.length ? '' : ' of ' + m.tenants.length.toLocaleString())
+      +     (sorted.length === 1 ? ' tenant' : ' tenants') + '</span>'
+      + '</div>'
+      + (activeChips.length ? '<div class="ip-tn-chips">' + activeChips.join('')
+          + '<button class="ip-tn-chip is-clear" data-clear="all">Clear all</button></div>' : '')
+      + '<p class="ip-rel-hnote-inline">Pick a release scope to see currency. Versions from different projects don\'t add up, '
+      +   'so there is no cross-project figure to show. Readiness needs a request per tenant, so it lives on the tenant page.</p>'
+      + '<div class="ip-tn-body">'
+      +   '<aside class="ip-tn-facets"><p class="ip-tn-facethead">Filters</p>'
+      +     tagGroups + envGroup + stateGroup + projGroup + '</aside>'
+      +   '<div class="ip-tn-table-wrap">'
+      +     (slice.length
+          ? '<table class="ip-table ip-tn-table"><thead><tr>'
+            + '<th>Tenant</th><th>Tags</th><th>Projects</th><th>Environments</th><th>Last outcome</th>'
+            + '</tr></thead><tbody>' + rows + '</tbody></table>'
+          : '<div class="ip-empty"><h3>No tenants match these filters</h3>'
+            + '<p>Clear a filter or search for a different name.</p></div>')
+      +     (pages > 1 ? '<div class="ip-tn-pager">'
+            + '<button class="ip-btn ip-btn-secondary" data-page="' + (page - 1) + '"' + (page === 0 ? ' disabled' : '') + '>Previous</button>'
+            + '<span class="ip-tn-age">Page ' + (page + 1) + ' of ' + pages + '</span>'
+            + '<button class="ip-btn ip-btn-secondary" data-page="' + (page + 1) + '"' + (page >= pages - 1 ? ' disabled' : '') + '>Next</button>'
+            + '</div>' : '')
+      +   '</div>'
+      + '</div>'
+      + (m.truncated ? '<p class="ip-rel-hnote-inline">More than ' + m.total + ' tenants — this reads the first pages only.</p>' : '');
+  }
+
+  function bindTenants(IP) {
+    const root = document.getElementById('main-content');
+    if (!root) return;
+    const redraw = () => { root.innerHTML = renderTenants(IP); bindTenants(IP); };
+    const search = root.querySelector('.ip-tn-search');
+    if (search) search.addEventListener('input', () => {
+      IP.tenantQuery = search.value; IP.tenantPage = 0;
+      redraw();
+      const again = root.querySelector('.ip-tn-search');
+      if (again) { again.focus(); again.setSelectionRange(again.value.length, again.value.length); }
+    });
+    const sort = root.querySelector('.ip-tn-sortsel');
+    if (sort) sort.addEventListener('change', () => { IP.tenantSort = sort.value; redraw(); });
+    root.querySelectorAll('[data-facet]').forEach(box => {
+      box.addEventListener('change', () => {
+        const key = box.getAttribute('data-facet'), value = box.getAttribute('data-value');
+        IP.tenantSel[key] = IP.tenantSel[key] || {};
+        if (IP.tenantSel[key][value]) delete IP.tenantSel[key][value]; else IP.tenantSel[key][value] = true;
+        IP.tenantPage = 0; redraw();
+      });
+    });
+    root.querySelectorAll('[data-clear]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const spec = btn.getAttribute('data-clear');
+        if (spec === 'all') IP.tenantSel = {};
+        else { const parts = spec.split('|'); if (IP.tenantSel[parts[0]]) delete IP.tenantSel[parts[0]][parts[1]]; }
+        IP.tenantPage = 0; redraw();
+      });
+    });
+    root.querySelectorAll('[data-page]').forEach(btn => {
+      btn.addEventListener('click', () => { IP.tenantPage = Number(btn.getAttribute('data-page')); redraw(); });
+    });
+  }
+
   function renderThemeToggle(IP) {
     const dark = IP.theme === 'dark';
     const icon = dark ? _sunSvg : _moonSvg;
@@ -1547,7 +1723,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderProjects, bindProjects, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1192,6 +1192,43 @@ const Views = (function () {
     return '<div class="ip-rel-hrow ip-rel-frow">' + _relTrack(cells, cols) + '</div>';
   }
 
+  // A variable change is a point event like a flag change, but it can land in
+  // several environments at once — one edit, scoped to two environments, marks
+  // two columns rather than becoming two rows. An unscoped variable applies
+  // everywhere, so it marks every column.
+  function _relVarChangeRow(change, cols, envOff, envIds) {
+    const off = envOff || {};
+    const scoped = change.envIds && change.envIds.length ? change.envIds : null;
+    const marks = envIds.filter(id => !off[id] && (!scoped || scoped.indexOf(id) !== -1));
+    if (!marks.length) return '';
+    const firstCol = envIds.indexOf(marks[0]);
+
+    const label = '<span class="ip-rel-hlabel">'
+      + '<span class="ip-rel-varname">' + escHtml(change.name) + '</span>'
+      + '<span class="ip-rel-vardelta' + (change.sensitive ? ' is-secret' : '') + '">'
+      +   escHtml(Data.variableChangeLabel(change)) + '</span>'
+      + (scoped ? '' : '<span class="ip-rel-flagscope">all environments</span>')
+      + '<span class="ip-rel-hage">' + escHtml(_relWhen(new Date(change.occurred).toISOString())) + '</span>'
+      + '</span>';
+
+    const cells = envIds.map((eid, i) => {
+      if (off[eid]) return '<div class="ip-rel-hcell is-off"></div>';
+      if (marks.indexOf(eid) === -1) return '<div class="ip-rel-hcell"></div>';
+      return '<div class="ip-rel-hcell ip-rel-fcell">'
+        + '<span class="ip-rel-vnode" title="' + escHtml(change.name) + '"></span>'
+        + (i === firstCol ? label : '') + '</div>';
+    }).join('');
+    return '<div class="ip-rel-hrow ip-rel-vrow">' + _relTrack(cells, cols) + '</div>';
+  }
+
+  function _relVarNote(vars) {
+    const elsewhere = (vars || []).filter(c => c.scopedElsewhere).length;
+    const parts = ['A variable change alters nothing already deployed — variables are snapshotted into a release when it is created, so an edit lands with the next one.'];
+    if (elsewhere) parts.push(elsewhere + ' ' + (elsewhere === 1 ? 'change is' : 'changes are')
+      + ' scoped to environments this project does not deploy to.');
+    return '<p class="ip-rel-hnote-inline">' + parts.map(escHtml).join(' ') + '</p>';
+  }
+
   function _relFlags(proj, cols, flags, envOff) {
     const st = flags || { status: 'loading' };
     if (st.status === 'loading' || !st.status) {
@@ -1242,41 +1279,46 @@ const Views = (function () {
       return wrap('<p class="ip-rel-err">' + escHtml(st.error || 'Could not load this project\'s releases.') + '</p>');
     }
     const m = st.model;
-    if (!m.totalReleases) {
-      return wrap('<p class="ip-rel-hempty">No releases have been created for this project.</p>');
-    }
-    if (!m.releases.length) {
-      return wrap('<p class="ip-rel-hempty">Nothing moved in the last ' + escHtml(String(windowLabel).toLowerCase())
-        + '. ' + m.totalReleases + ' older ' + (m.totalReleases === 1 ? 'release' : 'releases')
-        + ' — widen the window to see ' + (m.totalReleases === 1 ? 'it' : 'them') + '.</p>');
-    }
-
     const off = envOff || {};
     const anyOff = Object.keys(off).some(k => off[k]);
+    // A project can have nothing released in the window and still have a flag
+    // flip or a variable edit worth seeing, so an empty release list is a
+    // message inside the panel rather than the end of it.
+    const releaseEmpty = !m.totalReleases
+      ? '<p class="ip-rel-hempty">No releases have been created for this project.</p>'
+      : (!m.releases.length
+          ? '<p class="ip-rel-hempty">Nothing moved in the last ' + escHtml(String(windowLabel).toLowerCase())
+            + '. ' + m.totalReleases + ' older ' + (m.totalReleases === 1 ? 'release' : 'releases')
+            + ' — widen the window to see ' + (m.totalReleases === 1 ? 'it' : 'them') + '.</p>'
+          : '');
     const visible = anyOff
       ? m.releases.filter(r => r.cells.some((c, i) => c.deployed && !off[c.envId]))
       : m.releases;
     const mutedOut = m.releases.length - visible.length;
-    if (anyOff && !visible.length) {
-      return wrap('<p class="ip-rel-hempty">Every release in this window only reached environments you have muted.</p>');
-    }
+    const mutedAll = anyOff && m.releases.length && !visible.length;
     const multiChannel = m.channels.length > 1;
     // Grouping by time interleaves flag changes with the releases, so a flip
     // that shipped alongside a deployment reads as one moment rather than as
     // two facts in two sections.
     const changes = (grouping === 'Time' && flags && flags.status === 'ready' && flags.changes) ? flags.changes : [];
+    const varsAll = (flags && flags.status === 'ready' && flags.variables) ? flags.variables : [];
+    const varsShown = varsAll.filter(c => !c.scopedElsewhere);
+    const varChanges = grouping === 'Time' ? varsShown : [];
     let rows;
-    if (grouping === 'Time' && changes.length) {
+    if (grouping === 'Time' && (changes.length || varChanges.length)) {
       const envIds = (m.environments || []).map(e => e.id);
       const items = visible.map(r => {
         const head = r.frontier >= 0 ? r.cells[r.frontier] : null;
         const at = head && head.when ? Date.parse(head.when) : (r.assembled ? Date.parse(r.assembled) : 0);
         return { at: at, html: _relHistoryRow(r, cols, multiChannel, off) };
-      }).concat(changes.map(c => ({ at: c.occurred, html: _relFlagChangeRow(c, cols, off, envIds) })));
+      }).concat(changes.map(c => ({ at: c.occurred, html: _relFlagChangeRow(c, cols, off, envIds) })))
+        .concat(varChanges.map(c => ({ at: c.occurred, html: _relVarChangeRow(c, cols, off, envIds) })));
       rows = items.filter(i => i.html).sort((a, b) => b.at - a.at).map(i => i.html).join('');
     } else {
       rows = visible.map(r => _relHistoryRow(r, cols, multiChannel, off)).join('');
     }
+    if (mutedAll) rows = '<p class="ip-rel-hempty">Every release in this window only reached environments you have muted.</p>';
+    else if (releaseEmpty) rows = releaseEmpty + rows;
     const notes = [];
     if (mutedOut) notes.push(mutedOut + ' ' + (mutedOut === 1 ? 'release' : 'releases')
       + ' only reached muted environments.');
@@ -1296,9 +1338,20 @@ const Views = (function () {
           + changeRows + '</div>';
       }
     }
-    return wrap(rows + (notes.length
+    let varBand = '';
+    if (grouping === 'Type' && varsShown.length) {
+      const envIds2 = (m.environments || []).map(e => e.id);
+      const varRows = varsShown.map(c => _relVarChangeRow(c, cols, off, envIds2)).filter(Boolean).join('');
+      if (varRows) {
+        varBand = '<div class="ip-rel-band"><p class="ip-rel-bandhead">Variable changes'
+          + '<span class="ip-rel-bandcount">last ' + escHtml(String(windowLabel).toLowerCase()) + '</span></p>'
+          + varRows + _relVarNote(varsAll) + '</div>';
+      }
+    }
+    const varInline = (grouping === 'Time' && varsShown.length) ? _relVarNote(varsAll) : '';
+    return wrap(rows + varInline + (notes.length
       ? '<div class="ip-rel-hnote">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '')
-      + changeBand);
+      + changeBand + varBand);
   }
 
   function renderProjects(IP) {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1434,7 +1434,10 @@ const Views = (function () {
           + '</button></div>';
       }).join('');
       const flg = IP.projectFlags || {};
-      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active, off, flg[p.id], grouping)).join('');
+      const rows = g.projects.map(p =>
+        '<div class="ip-rel-card' + (open[p.id] ? ' is-open' : '') + '">'
+        + _relRow(p, cols, !!open[p.id], hist[p.id], active, off, flg[p.id], grouping)
+        + '</div>').join('');
       const hiddenNote = g.hiddenEnvironments.length
         ? '<p class="ip-rel-hidden">Not shown, because this group has never deployed to them: '
           + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
@@ -1443,7 +1446,7 @@ const Views = (function () {
         +   '<span class="ip-rel-group-count">' + g.projects.length + (g.projects.length === 1 ? ' project' : ' projects') + '</span></h3>'
         + '<div class="ip-rel-grid">'
         +   '<div class="ip-rel-head"><div class="ip-rel-proj">Project</div>' + _relTrack(heads, cols) + '</div>'
-        +   rows
+        +   '<div class="ip-rel-cards">' + rows + '</div>'
         + '</div>' + hiddenNote + '</section>';
     }).join('');
 

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1080,7 +1080,7 @@ const Views = (function () {
       + '<div class="ip-rel-labels">' + summary + labels + more + '</div></div>';
   }
 
-  function _relRow(proj, cols, expanded, history, windowLabel, envOff, flags) {
+  function _relRow(proj, cols, expanded, history, windowLabel, envOff, flags, grouping) {
     const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i], expanded)).join('');
     const row = '<div class="ip-rel-row' + (expanded ? ' expanded' : '') + '" role="button" tabindex="0"'
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
@@ -1090,7 +1090,7 @@ const Views = (function () {
       + '</div>'
       + _relTrack(cells, cols)
       + '</div>';
-    return row + (expanded ? _relHistory(proj, cols, history, windowLabel, envOff || {}, flags) : '');
+    return row + (expanded ? _relHistory(proj, cols, history, windowLabel, envOff || {}, flags, grouping) : '');
   }
 
   // The version rides the line at the furthest environment the release reached.
@@ -1170,6 +1170,28 @@ const Views = (function () {
     return '<div class="ip-rel-hrow ip-rel-frow">' + _relTrack(cells, cols) + '</div>';
   }
 
+  // A flag change is a point event: it happened in one environment, at one
+  // moment. No line — it did not travel anywhere, it landed.
+  function _relFlagChangeRow(change, cols, envOff, envIds) {
+    const off = envOff || {};
+    const col = change.scope === 'environment' ? envIds.indexOf(change.envId) : 0;
+    if (change.scope === 'environment' && (col < 0 || off[change.envId])) return '';
+    const label = '<span class="ip-rel-hlabel">'
+      + '<span class="ip-rel-flagname">' + escHtml(change.flagName) + '</span>'
+      + '<span class="ip-rel-flagdelta">' + escHtml(Data.flagChangeLabel(change)) + '</span>'
+      + (change.scope === 'default' ? '<span class="ip-rel-flagscope">default</span>' : '')
+      + '<span class="ip-rel-hage">' + escHtml(_relWhen(new Date(change.occurred).toISOString())) + '</span>'
+      + '</span>';
+    const cells = envIds.map((eid, i) => {
+      if (off[eid]) return '<div class="ip-rel-hcell is-off"></div>';
+      if (i !== col) return '<div class="ip-rel-hcell"></div>';
+      return '<div class="ip-rel-hcell ip-rel-fcell">'
+        + '<span class="ip-rel-fnode is-change" title="' + escHtml(change.flagName) + '"></span>'
+        + label + '</div>';
+    }).join('');
+    return '<div class="ip-rel-hrow ip-rel-frow">' + _relTrack(cells, cols) + '</div>';
+  }
+
   function _relFlags(proj, cols, flags, envOff) {
     const st = flags || { status: 'loading' };
     if (st.status === 'loading' || !st.status) {
@@ -1205,7 +1227,7 @@ const Views = (function () {
       + '</div>';
   }
 
-  function _relHistory(proj, cols, history, windowLabel, envOff, flags) {
+  function _relHistory(proj, cols, history, windowLabel, envOff, flags, grouping) {
     const st = history || { status: 'loading' };
     // Mirrors the row structure — a label-width gutter, then the track — so an
     // expanded row starts on exactly the same x as the row it opened from.
@@ -1239,7 +1261,22 @@ const Views = (function () {
       return wrap('<p class="ip-rel-hempty">Every release in this window only reached environments you have muted.</p>');
     }
     const multiChannel = m.channels.length > 1;
-    const rows = visible.map(r => _relHistoryRow(r, cols, multiChannel, off)).join('');
+    // Grouping by time interleaves flag changes with the releases, so a flip
+    // that shipped alongside a deployment reads as one moment rather than as
+    // two facts in two sections.
+    const changes = (grouping === 'Time' && flags && flags.status === 'ready' && flags.changes) ? flags.changes : [];
+    let rows;
+    if (grouping === 'Time' && changes.length) {
+      const envIds = (m.environments || []).map(e => e.id);
+      const items = visible.map(r => {
+        const head = r.frontier >= 0 ? r.cells[r.frontier] : null;
+        const at = head && head.when ? Date.parse(head.when) : (r.assembled ? Date.parse(r.assembled) : 0);
+        return { at: at, html: _relHistoryRow(r, cols, multiChannel, off) };
+      }).concat(changes.map(c => ({ at: c.occurred, html: _relFlagChangeRow(c, cols, off, envIds) })));
+      rows = items.filter(i => i.html).sort((a, b) => b.at - a.at).map(i => i.html).join('');
+    } else {
+      rows = visible.map(r => _relHistoryRow(r, cols, multiChannel, off)).join('');
+    }
     const notes = [];
     if (mutedOut) notes.push(mutedOut + ' ' + (mutedOut === 1 ? 'release' : 'releases')
       + ' only reached muted environments.');
@@ -1247,8 +1284,21 @@ const Views = (function () {
     if (m.windowed) notes.push('History reaches back ' + m.historyCount + ' releases per channel.');
     if (m.neverDeployedCount) notes.push(m.neverDeployedCount + ' of these were created and never deployed anywhere.');
 
+    // Grouped by type, the changes get their own band rather than being mixed
+    // into the releases; grouped by time they are already interleaved above.
+    let changeBand = '';
+    if (grouping === 'Type' && flags && flags.status === 'ready' && (flags.changes || []).length) {
+      const envIds = (m.environments || []).map(e => e.id);
+      const changeRows = flags.changes.map(c => _relFlagChangeRow(c, cols, off, envIds)).filter(Boolean).join('');
+      if (changeRows) {
+        changeBand = '<div class="ip-rel-band"><p class="ip-rel-bandhead">Flag changes'
+          + '<span class="ip-rel-bandcount">last ' + escHtml(String(windowLabel).toLowerCase()) + '</span></p>'
+          + changeRows + '</div>';
+      }
+    }
     return wrap(rows + (notes.length
-      ? '<div class="ip-rel-hnote">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : ''));
+      ? '<div class="ip-rel-hnote">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '')
+      + changeBand);
   }
 
   function renderProjects(IP) {
@@ -1257,9 +1307,16 @@ const Views = (function () {
     const active = IP.historyWindow || windows[0].label;
     const segs = windows.map(w => '<button class="ip-seg' + (w.label === active ? ' active' : '')
       + '" data-window="' + escHtml(w.label) + '">' + escHtml(w.label) + '</button>').join('');
+    const groupings = (typeof Data !== 'undefined' && Data.GROUPINGS) || ['Time', 'Type'];
+    const grouping = IP.grouping || groupings[0];
+    const gsegs = groupings.map(gname => '<button class="ip-seg' + (gname === grouping ? ' active' : '')
+      + '" data-grouping="' + escHtml(gname) + '">' + escHtml(gname) + '</button>').join('');
     const head = '<header class="ip-head ip-head-actions"><div class="ip-head-text"><h2>Projects</h2>'
       + '<p class="ip-sub">What each project is running in each environment, and where a release has stopped moving.</p></div>'
-      + '<div class="ip-rel-window"><span class="ip-caption">History</span><div class="ip-segs">' + segs + '</div></div></header>';
+      + '<div class="ip-rel-controls">'
+      +   '<div class="ip-rel-window"><span class="ip-caption">History</span><div class="ip-segs">' + segs + '</div></div>'
+      +   '<div class="ip-rel-window"><span class="ip-caption">Group by</span><div class="ip-segs">' + gsegs + '</div></div>'
+      + '</div></header>';
 
     if (st.status === 'loading' || st.status === 'idle') {
       return head + '<div class="ip-state"><div class="ip-spinner"></div><p>Loading the project dashboard…</p></div>';
@@ -1305,7 +1362,7 @@ const Views = (function () {
           + '</button></div>';
       }).join('');
       const flg = IP.projectFlags || {};
-      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active, off, flg[p.id])).join('');
+      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active, off, flg[p.id], grouping)).join('');
       const hiddenNote = g.hiddenEnvironments.length
         ? '<p class="ip-rel-hidden">Not shown, because this group has never deployed to them: '
           + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
@@ -1349,6 +1406,13 @@ const Views = (function () {
       el.addEventListener('click', () => toggle(el));
       el.addEventListener('keydown', ev => {
         if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); toggle(el); }
+      });
+    });
+    root.querySelectorAll('[data-grouping]').forEach(btn => {
+      btn.addEventListener('click', ev => {
+        ev.stopPropagation();
+        IP.grouping = btn.getAttribute('data-grouping');
+        redraw();
       });
     });
     root.querySelectorAll('[data-envtoggle]').forEach(btn => {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2109,17 +2109,34 @@ const Views = (function () {
               + '</li>').join('') + '</ol>'
           : none('This project has no deployment steps.'));
 
-    // Destinations: where it lands, in lifecycle order.
-    const destinations = (m.phases.length
-        ? '<ol class="ip-pm-phases">' + m.phases.map(ph =>
-            '<li class="ip-pm-phase"><span class="ip-tn-tname">' + escHtml(ph.name) + '</span>'
-            + '<span class="ip-pm-envs">'
-            +   ph.automatic.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
-            +   ph.optional.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
-            + '</span>'
-            + (ph.automatic.length ? '<span class="ip-tn-age">automatic</span>' : '')
-            + '</li>').join('') + '</ol>'
-        : none('This project has no lifecycle phases.'))
+    const lifecycles = (m.lifecycles && m.lifecycles.length)
+      ? '<div class="ip-pm-lifecycles">' + m.lifecycles.map(lc =>
+          '<div class="ip-pm-lifecycle">'
+          + '<div class="ip-pm-lchead">'
+          +   '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
+          +   (lc.isDefault ? '<span class="ip-chipx ip-chipx-tag">project default</span>' : '')
+          +   (lc.channels.length
+                ? '<span class="ip-tn-age">' + escHtml(lc.channels.join(', ')) + '</span>'
+                : '<span class="ip-tn-age">no channel uses this</span>')
+          + '</div>'
+          + (lc.phases.length
+              ? '<ol class="ip-pm-flow">' + lc.phases.map(ph =>
+                  '<li class="ip-pm-phasebox">'
+                  + '<span class="ip-pm-phasename">' + escHtml(ph.name) + '</span>'
+                  + '<span class="ip-pm-envs">'
+                  +   ph.automatic.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e)
+                        + '<span class="ip-pm-auto" title="Deploys automatically">auto</span></span>').join('')
+                  +   ph.optional.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
+                  + '</span></li>').join('')
+                + '</ol>'
+              : '<p class="ip-tn-muted">No phases.</p>')
+          + '</div>').join('')
+        + '</div>'
+      : none('This project has no lifecycle phases.');
+
+    // Destinations keeps what the lifecycle panel does not say: how targets are
+    // chosen, and whether tenants are involved.
+    const destinations = ''
       + (m.roles.length
           ? '<p class="ip-tn-legend">Targets are selected by role: '
             + m.roles.map(r => escHtml(r)).join(', ') + '.</p>' : '')
@@ -2143,16 +2160,18 @@ const Views = (function () {
       +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
       +   _tnDescription(m.description)
       + '</header>'
+      + panel('Lifecycles', m.lifecycles && m.lifecycles.length > 1
+          ? m.lifecycles.length + ' in use' : m.lifecycle, lifecycles)
       + '<div class="ip-pm-grid">'
-      // What feeds the project and what starts it are the same question asked
-      // twice, so they share a column and read together.
+      // What feeds the project, what starts it, and what it ships through are
+      // the same question asked three ways, so they share a column.
       +   '<div class="ip-pm-col">'
       +     panel('Inputs', m.git ? 'version controlled' : '', inputs)
       +     panel('Triggers', m.triggers.length ? m.triggers.length + ' configured' : '', triggers)
+      +     panel('Channels', m.channels.length ? String(m.channels.length) : '', channels)
       +   '</div>'
       +   panel('Process', m.process.length ? m.process.length + (m.process.length === 1 ? ' step' : ' steps') : '', process)
-      +   panel('Destinations', m.lifecycle, destinations)
-      +   panel('Channels', '', channels)
+      +   panel('Destinations', '', destinations)
       + '</div>'
       + '<p class="ip-rel-hnote-inline">The activity timeline and the project\'s variables are not on this page yet.</p>';
   }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2443,6 +2443,16 @@ const Views = (function () {
     return '<label class="ip-space-lbl">Space</label>'
       + '<select id="ip-space-select" class="ip-space-select">' + opts.join('') + '</select>';
   }
+  // Switching space changes what every id on screen means, so staying put is
+  // rarely right: a target, tenant or project detail page belongs to the space
+  // you just left. Projects is where a space switch lands.
+  function spaceSwitchNav(currentHash) {
+    const target = '#projects';
+    const now = String(currentHash || '');
+    // An identical hash fires no hashchange, so that case has to re-render itself.
+    return { hash: target, rerender: now === target || now === '' };
+  }
+
   function bindSpaceSwitch(IP) {
     const el = document.getElementById('ip-space-select');
     if (!el) return;
@@ -2459,7 +2469,9 @@ const Views = (function () {
       el.disabled = true;
       try {
         if (typeof IP.rescope === 'function') await IP.rescope();
-        Router.render();
+        const nav = spaceSwitchNav(window.location.hash);
+        if (nav.rerender) Router.render();
+        else window.location.hash = nav.hash;
       } catch (err) {
         if (main) main.innerHTML = stateView('error', (err && err.message) || 'Could not load that space');
       } finally {
@@ -2470,7 +2482,7 @@ const Views = (function () {
   return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderProjectMap, bindProjectMap, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
-    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,
+    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch, spaceSwitchNav,
     renderThemeToggle, bindThemeToggle };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1556,7 +1556,7 @@ const Views = (function () {
     IP.tenantPage = IP.tenantPage || 0;
 
     const filtered = Data.filterTenants(m.tenants, IP.tenantQuery, IP.tenantSel);
-    const sorted = Data.sortTenants(filtered, IP.tenantSort);
+    const sorted = Data.sortTenants(filtered, IP.tenantSort, IP.tenantDir);
     const pages = Math.max(1, Math.ceil(sorted.length / TENANT_PAGE_SIZE));
     const page = Math.min(IP.tenantPage, pages - 1);
     const slice = sorted.slice(page * TENANT_PAGE_SIZE, (page + 1) * TENANT_PAGE_SIZE);
@@ -1583,8 +1583,24 @@ const Views = (function () {
       m.projects.map(p => ({ label: p.name, value: p.id, count: facets.count('projects', p.id) }))
         .filter(e => e.count > 0), 'projects', IP.tenantSel);
 
+    IP.tenantDir = IP.tenantDir || Data.tenantSortDir(IP.tenantSort);
     const sorts = Data.TENANT_SORTS.map(x => '<option' + (x === IP.tenantSort ? ' selected' : '') + '>'
       + escHtml(x) + '</option>').join('');
+
+    // Headers and the dropdown drive one piece of state, so a column arrow and
+    // the dropdown can never contradict each other. Tags is not sortable —
+    // ordering by a list of labels answers no question anyone has.
+    const th = (label, key) => {
+      if (!key) return '<th>' + escHtml(label) + '</th>';
+      const active = IP.tenantSort === key;
+      const dir = active ? IP.tenantDir : null;
+      const aria = active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none';
+      return '<th aria-sort="' + aria + '" class="ip-tn-th' + (active ? ' is-sorted' : '') + '">'
+        + '<button type="button" class="ip-tn-sortbtn" data-sort="' + escHtml(key) + '">'
+        +   escHtml(label)
+        +   '<span class="ip-tn-arrow" aria-hidden="true">' + (active ? (dir === 'asc' ? '↑' : '↓') : '↕') + '</span>'
+        + '</button></th>';
+    };
 
     const rows = slice.map(t =>
       '<tr class="ip-tn-row">'
@@ -1625,7 +1641,8 @@ const Views = (function () {
       +   '<div class="ip-tn-table-wrap">'
       +     (slice.length
           ? '<table class="ip-table ip-tn-table"><thead><tr>'
-            + '<th>Tenant</th><th>Tags</th><th>Projects</th><th>Environments</th><th>Last outcome</th>'
+            + th('Tenant', 'Name') + th('Tags', null) + th('Projects', 'Projects')
+            + th('Environments', 'Environments') + th('Last outcome', 'Last outcome')
             + '</tr></thead><tbody>' + rows + '</tbody></table>'
           : '<div class="ip-empty"><h3>No tenants match these filters</h3>'
             + '<p>Clear a filter or search for a different name.</p></div>')
@@ -1651,7 +1668,22 @@ const Views = (function () {
       if (again) { again.focus(); again.setSelectionRange(again.value.length, again.value.length); }
     });
     const sort = root.querySelector('.ip-tn-sortsel');
-    if (sort) sort.addEventListener('change', () => { IP.tenantSort = sort.value; redraw(); });
+    if (sort) sort.addEventListener('change', () => {
+      IP.tenantSort = sort.value;
+      IP.tenantDir = Data.tenantSortDir(sort.value);
+      redraw();
+    });
+    root.querySelectorAll('[data-sort]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const key = btn.getAttribute('data-sort');
+        // Same column again reverses; a new column starts in its natural
+        // direction rather than inheriting the last one's.
+        if (IP.tenantSort === key) IP.tenantDir = IP.tenantDir === 'asc' ? 'desc' : 'asc';
+        else { IP.tenantSort = key; IP.tenantDir = Data.tenantSortDir(key); }
+        IP.tenantPage = 0;
+        redraw();
+      });
+    });
     root.querySelectorAll('[data-facet]').forEach(box => {
       box.addEventListener('change', () => {
         const key = box.getAttribute('data-facet'), value = box.getAttribute('data-value');

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1029,7 +1029,7 @@ const Views = (function () {
       '<span class="ip-rel-entry">'
       + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
       + '<span class="ip-rel-age">' + escHtml(_relWhen(e.when)) + '</span>'
-      + (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml(e.tenantCount + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : '')
+      + (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml('· ' + e.tenantCount + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : '')
       + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '')
       + '</span>').join('');
     const more = hidden > 0
@@ -1052,9 +1052,9 @@ const Views = (function () {
       + '</div>';
   }
 
-  function renderReleases(IP) {
+  function renderProjects(IP) {
     const st = IP.releases || { status: 'idle' };
-    const head = '<header class="ip-head"><h2>Releases</h2>'
+    const head = '<header class="ip-head"><h2>Projects</h2>'
       + '<p class="ip-sub">What each project is running in each environment, and where a release has stopped moving.</p></header>';
 
     if (st.status === 'loading' || st.status === 'idle') {
@@ -1079,6 +1079,9 @@ const Views = (function () {
     const notes = [];
     if (m.truncated.capped) notes.push('Showing ' + m.truncated.shown + ' projects — the server caps the dashboard at ' + m.truncated.projectLimit + '. Projects beyond the cap are missing from this view.');
     if (m.truncated.isFiltered) notes.push('The dashboard is filtered on this instance, so this is a subset of its projects.');
+    const hidden = m.hiddenEnvironments || [];
+    if (hidden.length) notes.push('Not shown, because nothing has been deployed to them: '
+      + hidden.map(e => e.name).join(', ') + '.');
     const note = notes.length
       ? '<div class="ip-rel-note">' + notes.map(n => '<p>' + escHtml(n) + '</p>').join('') + '</div>' : '';
 
@@ -1152,7 +1155,7 @@ const Views = (function () {
       }
     });
   }
-  return { escHtml, stateView, renderReleases, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
+  return { escHtml, stateView, renderProjects, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
     pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch,

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -2109,29 +2109,29 @@ const Views = (function () {
               + '</li>').join('') + '</ol>'
           : none('This project has no deployment steps.'));
 
-    const lifecycles = (m.lifecycles && m.lifecycles.length)
-      ? '<div class="ip-pm-lifecycles">' + m.lifecycles.map(lc =>
-          '<div class="ip-pm-lifecycle">'
-          + '<div class="ip-pm-lchead">'
-          +   '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
-          +   (lc.isDefault ? '<span class="ip-chipx ip-chipx-tag">project default</span>' : '')
-          +   (lc.channels.length
-                ? '<span class="ip-tn-age">' + escHtml(lc.channels.join(', ')) + '</span>'
-                : '<span class="ip-tn-age">no channel uses this</span>')
-          + '</div>'
-          + (lc.phases.length
-              ? '<ol class="ip-pm-flow">' + lc.phases.map(ph =>
-                  '<li class="ip-pm-phasebox">'
-                  + '<span class="ip-pm-phasename">' + escHtml(ph.name) + '</span>'
-                  + '<span class="ip-pm-envs">'
-                  +   ph.automatic.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e)
-                        + '<span class="ip-pm-auto" title="Deploys automatically">auto</span></span>').join('')
-                  +   ph.optional.map(e => '<span class="ip-chipx ip-chipx-env">' + escHtml(e) + '</span>').join('')
-                  + '</span></li>').join('')
-                + '</ol>'
-              : '<p class="ip-tn-muted">No phases.</p>')
-          + '</div>').join('')
-        + '</div>'
+    // Environments are named once, across the top, and each lifecycle is a row
+    // across them — the same grammar the rest of the dashboard uses. Repeating
+    // the environments per lifecycle made two routes to production look like
+    // two different productions.
+    const cols = m.lifecycleEnvironments || [];
+    const lifecycles = (m.lifecycles && m.lifecycles.length && cols.length)
+      ? '<table class="ip-table ip-pm-lctable"><thead><tr><th>Lifecycle</th>'
+        + cols.map(e => '<th>' + escHtml(e) + '</th>').join('') + '</tr></thead><tbody>'
+        + m.lifecycles.map(lc =>
+            '<tr><td class="ip-pm-lcname">'
+            + '<span class="ip-tn-tname">' + escHtml(lc.name) + '</span>'
+            + (lc.isDefault ? '<span class="ip-chipx ip-chipx-tag">default</span>' : '')
+            + '<span class="ip-tn-age">' + escHtml(lc.channels.length
+                ? lc.channels.join(', ') : 'no channel uses this') + '</span>'
+            + '</td>'
+            + lc.cells.map(c => c.reached
+                ? '<td class="ip-pm-lccell"><span class="ip-pm-phasename">' + escHtml(c.phase) + '</span>'
+                  + (c.automatic ? '<span class="ip-pm-auto">auto</span>' : '') + '</td>'
+                : '<td class="ip-pm-lccell is-absent"></td>').join('')
+            + '</tr>').join('')
+        + '</tbody></table>'
+        + '<p class="ip-tn-legend">A blank cell means that lifecycle never reaches that environment. '
+        + '<em>auto</em> marks a phase that deploys without being asked.</p>'
       : none('This project has no lifecycle phases.');
 
     // Destinations keeps what the lifecycle panel does not say: how targets are

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1774,6 +1774,32 @@ const Views = (function () {
       : (t.health === 'Healthy' || t.health === 'HealthyWithWarnings' ? 'healthy' : 'unhealthy')) : 'healthy';
   }
 
+  // A tenant's description is free text the instance owns, and on Octopus Cloud
+  // it is licence boilerplate — a markdown link to a subscription page on every
+  // one of thousands of tenants. Printed raw under the title it read as broken
+  // markup and buried the tenant's own name.
+  //
+  // Markdown links are turned into real links, and nothing else about the field
+  // is trusted: both halves are escaped, and only http and https are allowed
+  // through, so the field cannot inject markup or a javascript: URL.
+  function _tnDescription(text) {
+    const raw = String(text == null ? '' : text).trim();
+    if (!raw) return '';
+    const oneLine = raw.replace(/\s*[\r\n]+\s*/g, ' · ');
+    const linked = oneLine.replace(/\[([^\]\n]{1,120})\]\((https?:\/\/[^\s)]{1,300})\)/g,
+      (whole, label, url) => '<a href="' + escHtml(url) + '" target="_blank" rel="noopener">'
+        + escHtml(label) + '</a>');
+    // Anything that was not a link is escaped by the split, so the only markup
+    // here is the anchors built above.
+    const safe = linked === oneLine ? escHtml(oneLine)
+      : oneLine.split(/(\[[^\]\n]{1,120}\]\(https?:\/\/[^\s)]{1,300}\))/g).map(part => {
+          const m = /^\[([^\]\n]{1,120})\]\((https?:\/\/[^\s)]{1,300})\)$/.exec(part);
+          return m ? '<a href="' + escHtml(m[2]) + '" target="_blank" rel="noopener">'
+            + escHtml(m[1]) + '</a>' : escHtml(part);
+        }).join('');
+    return '<p class="ip-tn-desc" title="' + escHtml(raw) + '">' + safe + '</p>';
+  }
+
   function bindTenantDetail(IP) {
     const root = document.getElementById('main-content');
     if (!root) return;
@@ -2005,7 +2031,7 @@ const Views = (function () {
     return back
       + '<header class="ip-head"><h2>' + escHtml(m.name) + (m.disabled ? ' <span class="ip-pill ip-pill-disabled">Disabled</span>' : '') + '</h2>'
       +   '<p class="ip-tn-id">' + escHtml(m.id) + '</p>'
-      +   (m.description ? '<p class="ip-sub">' + escHtml(m.description) + '</p>' : '')
+      +   _tnDescription(m.description)
       +   (tagGroups ? '<div class="ip-tn-taggroups">' + tagGroups + '</div>' : '')
       + '</header>'
       + '<div class="ip-tn-cards">' + connCard + readyCard + outcomeCard + '</div>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1066,12 +1066,17 @@ const Views = (function () {
     const hidden = cell.entries.length - shown.length;
     const hiddenTenants = cell.entries.slice(CAP).reduce((n, e) => n + e.tenantCount, 0);
 
-    const labels = shown.map(e => _relEntry(e, cell, withBar)).join('');
+    // Name a release where it stops, not in every environment it passed
+    // through. A split still names each entry, because its tenant counts are a
+    // per-environment fact, and anything that did not succeed is named where it
+    // happened — a failure is not repetition.
+    const named = shown.filter(e => withBar || e.isFurthest !== false || e.stateKey !== 'success');
+    const labels = named.map(e => _relEntry(e, cell, withBar)).join('');
     const summary = withBar
       ? '<span class="ip-rel-tssum">' + cell.versionCount + ' releases · '
         + cell.tenantTotal.toLocaleString() + (cell.tenantTotal === 1 ? ' tenant' : ' tenants') + '</span>'
       : '';
-    const more = hidden > 0
+    const more = hidden > 0 && named.length
       ? '<span class="ip-rel-more">+' + hidden + ' more ' + (hidden === 1 ? 'release' : 'releases')
         + (hiddenTenants ? ' on ' + hiddenTenants.toLocaleString() + (hiddenTenants === 1 ? ' tenant' : ' tenants') : '')
         + '</span>'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1879,7 +1879,48 @@ const Views = (function () {
         + '</nav>'
       : '';
 
+    const fl = IP.flags;
+    // A summary of where this tenant's flags stand, on the tab you land on.
+    // Fully on and fully off are counts because that is all they are; the ones
+    // in between are named, because "3 in between" is not something you can act
+    // on without knowing which three.
+    const flagSummary = (function () {
+      if (!fl || fl.status !== 'ready') return '';
+      const sm = fl.model.summary;
+      if (!fl.model.total) return '';
+      const stat = (n, label, tone) => '<span class="ip-tn-stat">'
+        + '<span class="ip-tn-statnum ip-tn-stat-' + escHtml(tone) + '">' + n + '</span>'
+        + '<span class="ip-tn-statlabel">' + escHtml(label) + '</span></span>';
+      const rows = sm.between.map(b =>
+        '<li class="ip-tn-target"><span class="ip-tn-tname">' + escHtml(b.name) + '</span>'
+        + '<span class="ip-tn-age">' + escHtml(b.projectName) + '</span>'
+        + '<span class="ip-tn-flagstates">' + b.states.map(st => {
+            const tone = st.key === 'on' ? 'healthy' : (st.key === 'partial' || st.key === 'segment' ? 'warning' : 'disabled');
+            const text = st.key === 'partial' ? st.percent + '%'
+              : st.key === 'segment' ? 'segment'
+              : st.key === 'excluded' ? 'excluded' : st.key;
+            return '<span class="ip-tn-flagstate"><span class="ip-tn-dot ip-rel-node-' + escHtml(tone) + '"></span>'
+              + escHtml(st.envName) + ' <span class="ip-tn-age">' + escHtml(text) + '</span></span>';
+          }).join('')
+        + '</span></li>').join('');
+      return '<section class="ip-tn-panel"><h3>Feature flags'
+        + '<span class="ip-tn-age">' + fl.model.total + ' across this tenant\'s projects</span></h3>'
+        + '<div class="ip-tn-stats">'
+        +   stat(sm.fullyOn, 'fully on', 'healthy')
+        +   stat(sm.fullyOff, 'fully off', 'disabled')
+        +   stat(sm.betweenCount, 'in between', sm.betweenCount ? 'warning' : 'disabled')
+        + '</div>'
+        + (rows
+            ? '<ul class="ip-tn-targets">' + rows + '</ul>'
+              + '<p class="ip-tn-legend">A flag is in between when it is on in one environment and not another, '
+              + 'or part-way through a rollout. A percentage is decided when the flag is evaluated, so the number '
+              + 'is the rollout, not a verdict for this tenant.</p>'
+            : '<p class="ip-tn-muted">Every flag is settled one way or the other for this tenant.</p>')
+        + '</section>';
+    })();
+
     const overviewTab = '<section class="ip-tn-panel"><h3>Deployment matrix</h3>' + matrix + '</section>'
+      + flagSummary
       + '<div class="ip-tn-split">'
       +   '<section class="ip-tn-panel"><h3>Infrastructure'
       +     (m.infrastructure && !m.infrastructure.orphaned
@@ -1888,7 +1929,6 @@ const Views = (function () {
       +   '<section class="ip-tn-panel"><h3>Activity</h3>' + activity + '</section>'
       + '</div>';
 
-    const fl = IP.flags;
     const flagsTab = (function () {
       if (!fl) return '';
       if (fl.status === 'loading') {

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1023,24 +1023,25 @@ const Views = (function () {
   // separate panel that repeats the column headings.
   function _relEntry(e, cell, withBar) {
     const age = _relWhen(e.when);
-    const state = e.stateKey !== 'success'
-      ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">' + escHtml(e.stateLabel) + '</span>' : '';
     if (!withBar) {
       return '<span class="ip-rel-entry">'
         + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
         + '<span class="ip-rel-age">' + escHtml(age) + '</span>'
         + (e.tenantCount ? '<span class="ip-rel-tenants">' + escHtml('· ' + e.tenantCount
             + (e.tenantCount === 1 ? ' tenant' : ' tenants')) + '</span>' : '')
-        + state + '</span>';
+        + (e.stateKey !== 'success' ? '<span class="ip-rel-state ip-rel-state-' + escHtml(e.stateKey) + '">'
+            + escHtml(e.stateLabel) + '</span>' : '')
+        + '</span>';
     }
-    // One line per release: the share is the row's own fill rather than a
-    // separate bar, so a twelve-way split stays readable in a column.
+    // One line per release: version, the share as a small bar, then the count.
+    // No status here — a rollout row is answering "how much of the estate", and
+    // the node above already carries the environment's state.
     const share = cell.tenantTotal ? (e.tenantCount / cell.tenantTotal * 100) : 0;
-    return '<span class="ip-rel-entry ip-rel-entry-share" style="--ip-rel-share:' + share.toFixed(1) + '%"'
+    return '<span class="ip-rel-entry ip-rel-entry-share"'
       + ' title="' + escHtml(e.version + ' — ' + e.tenantCount.toLocaleString() + ' of '
           + cell.tenantTotal.toLocaleString() + ' tenants' + (age ? ', ' + age : '')) + '">'
       + '<span class="ip-rel-ver">' + escHtml(e.version) + '</span>'
-      + state
+      + '<span class="ip-rel-tsbar"><span style="width:' + share.toFixed(1) + '%"></span></span>'
       + '<span class="ip-rel-tscount">' + e.tenantCount.toLocaleString() + '</span>'
       + '</span>';
   }
@@ -1079,7 +1080,7 @@ const Views = (function () {
       + '<div class="ip-rel-labels">' + summary + labels + more + '</div></div>';
   }
 
-  function _relRow(proj, cols, expanded, history, windowLabel) {
+  function _relRow(proj, cols, expanded, history, windowLabel, envOff) {
     const cells = proj.cells.map((c, i) => _relCell(c, proj.links[i], expanded)).join('');
     const row = '<div class="ip-rel-row' + (expanded ? ' expanded' : '') + '" role="button" tabindex="0"'
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
@@ -1089,15 +1090,20 @@ const Views = (function () {
       + '</div>'
       + _relTrack(cells, cols)
       + '</div>';
-    return row + (expanded ? _relHistory(proj, cols, history, windowLabel) : '');
+    return row + (expanded ? _relHistory(proj, cols, history, windowLabel, envOff || {}) : '');
   }
 
   // The version rides the line at the furthest environment the release reached.
   // The age beside it is when it ARRIVED there, not when the release was cut —
   // a release assembled weeks ago and promoted this morning is this morning's
   // event, and showing its birthday made the window look broken.
-  function _relHistoryRow(r, cols, multiChannel) {
-    const headCell = r.frontier >= 0 ? r.cells[r.frontier] : null;
+  function _relHistoryRow(r, cols, multiChannel, envOff) {
+    const off = envOff || {};
+    // The label rides the furthest environment still showing, so muting the
+    // noisiest one doesn't strand a release's name in a blank column.
+    let frontier = -1;
+    r.cells.forEach((c, i) => { if (c.deployed && !off[c.envId]) frontier = i; });
+    const headCell = frontier >= 0 ? r.cells[frontier] : null;
     const headAge = headCell && headCell.when ? headCell.when : r.assembled;
     const meta = '<span class="ip-rel-hlabel">'
       + '<span class="ip-rel-hver">' + escHtml(r.version) + '</span>'
@@ -1109,14 +1115,15 @@ const Views = (function () {
       + '</span>';
 
     const cells = r.cells.map((c, i) => {
-      const seg = (i > 0 && i <= r.frontier)
-        ? '<span class="ip-rel-seg ip-rel-seg-' + (i === r.frontier ? 'strong' : 'pale') + '"></span>' : '';
-      const atHead = (r.frontier === -1 && i === 0) || i === r.frontier;
+      if (off[c.envId]) return '<div class="ip-rel-hcell is-off"></div>';
+      const seg = (i > 0 && i <= frontier)
+        ? '<span class="ip-rel-seg ip-rel-seg-' + (i === frontier ? 'strong' : 'pale') + '"></span>' : '';
+      const atHead = (frontier === -1 && i === 0) || i === frontier;
       const node = c.deployed
         ? '<span class="ip-rel-hnode ip-rel-node-' + escHtml(REL_STATE_TONE[c.stateKey] || 'disabled')
           + '" title="' + escHtml(c.stateLabel + ' in ' + c.envName) + '"></span>'
-        : (r.frontier === -1 && i === 0 ? '<span class="ip-rel-hnode ip-rel-node-empty"></span>' : '');
-      const age = c.deployed && i !== r.frontier
+        : (frontier === -1 && i === 0 ? '<span class="ip-rel-hnode ip-rel-node-empty"></span>' : '');
+      const age = c.deployed && i !== frontier
         ? '<span class="ip-rel-hcellage">' + escHtml(_relWhen(c.when))
           + (c.tenantCount ? ' · ' + c.tenantCount + 't' : '') + '</span>' : '';
       return '<div class="ip-rel-hcell">' + seg + node + age + (atHead ? meta : '') + '</div>';
@@ -1125,7 +1132,7 @@ const Views = (function () {
     return '<div class="ip-rel-hrow' + (r.everDeployed ? '' : ' undeployed') + '">' + _relTrack(cells, cols) + '</div>';
   }
 
-  function _relHistory(proj, cols, history, windowLabel) {
+  function _relHistory(proj, cols, history, windowLabel, envOff) {
     const st = history || { status: 'loading' };
     // Mirrors the row structure — a label-width gutter, then the track — so an
     // expanded row starts on exactly the same x as the row it opened from.
@@ -1149,9 +1156,20 @@ const Views = (function () {
         + ' — widen the window to see ' + (m.totalReleases === 1 ? 'it' : 'them') + '.</p>');
     }
 
+    const off = envOff || {};
+    const anyOff = Object.keys(off).some(k => off[k]);
+    const visible = anyOff
+      ? m.releases.filter(r => r.cells.some((c, i) => c.deployed && !off[c.envId]))
+      : m.releases;
+    const mutedOut = m.releases.length - visible.length;
+    if (anyOff && !visible.length) {
+      return wrap('<p class="ip-rel-hempty">Every release in this window only reached environments you have muted.</p>');
+    }
     const multiChannel = m.channels.length > 1;
-    const rows = m.releases.map(r => _relHistoryRow(r, cols, multiChannel)).join('');
+    const rows = visible.map(r => _relHistoryRow(r, cols, multiChannel, off)).join('');
     const notes = [];
+    if (mutedOut) notes.push(mutedOut + ' ' + (mutedOut === 1 ? 'release' : 'releases')
+      + ' only reached muted environments.');
     if (m.hiddenByWindow) notes.push(m.hiddenByWindow + ' older ' + (m.hiddenByWindow === 1 ? 'release is' : 'releases are') + ' outside this window.');
     if (m.windowed) notes.push('History reaches back ' + m.historyCount + ' releases per channel.');
     if (m.neverDeployedCount) notes.push(m.neverDeployedCount + ' of these were created and never deployed anywhere.');
@@ -1201,8 +1219,19 @@ const Views = (function () {
         return '<section class="ip-rel-group"><h3 class="ip-rel-group-name">' + escHtml(g.name) + '</h3>'
           + '<p class="ip-rel-hempty">Nothing in this group has been deployed yet.</p></section>';
       }
-      const heads = g.environments.map(e => '<div class="ip-rel-envhead">' + escHtml(e.name) + '</div>').join('');
-      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active)).join('');
+      const off = (IP.envOff && IP.envOff[g.id]) || {};
+      const heads = g.environments.map(e => {
+        const isOff = !!off[e.id];
+        return '<div class="ip-rel-envhead' + (isOff ? ' is-off' : '') + '">'
+          + '<span class="ip-rel-envname">' + escHtml(e.name) + '</span>'
+          + '<button type="button" class="ip-rel-envtoggle" role="switch"'
+          +   ' aria-checked="' + (isOff ? 'false' : 'true') + '"'
+          +   ' data-envtoggle="' + escHtml(g.id) + '|' + escHtml(e.id) + '"'
+          +   ' title="' + escHtml((isOff ? 'Show ' : 'Hide ') + e.name + ' in expanded history') + '">'
+          +   '<span class="ip-rel-envtoggle-track"><span class="ip-rel-envtoggle-knob"></span></span>'
+          + '</button></div>';
+      }).join('');
+      const rows = g.projects.map(p => _relRow(p, cols, !!open[p.id], hist[p.id], active, off)).join('');
       const hiddenNote = g.hiddenEnvironments.length
         ? '<p class="ip-rel-hidden">Not shown, because this group has never deployed to them: '
           + escHtml(g.hiddenEnvironments.map(e => e.name).join(', ')) + '.</p>' : '';
@@ -1243,6 +1272,17 @@ const Views = (function () {
       el.addEventListener('click', () => toggle(el));
       el.addEventListener('keydown', ev => {
         if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); toggle(el); }
+      });
+    });
+    root.querySelectorAll('[data-envtoggle]').forEach(btn => {
+      btn.addEventListener('click', ev => {
+        ev.stopPropagation();
+        const parts = String(btn.getAttribute('data-envtoggle')).split('|');
+        const gid = parts[0], eid = parts[1];
+        IP.envOff = IP.envOff || {};
+        IP.envOff[gid] = IP.envOff[gid] || {};
+        if (IP.envOff[gid][eid]) delete IP.envOff[gid][eid]; else IP.envOff[gid][eid] = true;
+        redraw();
       });
     });
     // The window filters what was already fetched, so switching it never


### PR DESCRIPTION
Follow-up to #30. Two new sections in the Infrastructure (PreAlpha) dashboard — **Projects** and **Tenants** — plus a per-project page behind both.

The question behind it: the Octopus project dashboard tells you what is in each environment, but not what moved, when, or what changed alongside it. A release sitting two versions behind production looks the same as one that shipped an hour ago.

## Projects

A new sidebar item above Infrastructure. It is what the estate exists to deliver, and unlike the rest of the dashboard it needs no infrastructure access — a space where `/machines` 403s still gets its projects.

**Collapsed**, one row per project across the environment columns, grouped the way the instance groups projects. Each group gets its own columns: a group that has never deployed to Preprod does not carry an empty column for it. The line between two environments is strong where they hold the same release and pale where they have drifted. A release is named only in the furthest environment it reaches — naming it four times said nothing the line had not already said. Where an environment holds more than one release, the cell splits by tenant.

**Expanded**, the same columns carry the history: releases, feature flag changes and variable changes, grouped by time or by type, over 24 hours / 7 days / all. Grouping by time is what puts a flag change next to the release it shipped with.

Environment columns can be switched off per group, for an instance where two of six environments are the ones you care about.

## Tenants

A list — connection, last outcome, currency and readiness as four independent facts, never merged into one score — with facets from the instance's own tag sets, sortable columns and paging.

A tenant page behind it: deployment matrix, a feature flag panel resolved for that tenant, infrastructure, activity, and unset variables as a tab rather than an alarm.

## A project's own page

`#projects/<id>`, reached from any project name. Two tabs:

**Status** is the projects-list row for that one project, opened expanded. Same builders, same columns from the project's own group, same controls and interactions — anything that changes on the list changes here.

**Overview** is a map of the project for someone who has just inherited it: lifecycles (environments named once across the top, each lifecycle a line of numbered phase nodes, extras folded away), channels, feeds and packages, triggers, the process, destinations, and feature flags.

Destinations resolves how targets are selected — roles, within the lifecycle's environments, and how tenants take part — against the estate: how many match, healthy / unhealthy / disabled counted separately, broken down by role and environment, and for a tenanted project how many targets name a tenant directly or match by tag. Three outcomes that look alike in the data are kept apart: a project with no target roles selects nothing **by design** (Terraform and script projects are common, and "0 targets" reads as something missing), roles that match nothing is a **warning**, and unreadable machines is **unknown**.

The activity timeline and project variables are not on this page yet, and it says so.

## Feature flags

Flags are a preview capability, and the API reference at `/api/experimental/llms.txt` does not cover preview surfaces — searching it for feature flags returns `/featuresconfiguration`, which manages server-wide capabilities and looks like a match. The first version of this analysis concluded on that evidence that flags had no data source. They are at `/api/{spaceId}/projects/{projectId}/featuretoggles`. Worth knowing for anyone else building here with AI assistance: **assume the reference under-reports anything in preview.**

Change history is reconstructed from the audit trail. `ChangeDetails.DocumentContext` holds the document before, `Differences` the JSON Patch after — together, both ends of the arrow.

**Sensitive variables are never rendered.** The audit represents a sensitive value as a constant 45-character placeholder on both sides of a change, so there is no before and no after. Those changes degrade to "SecretKey changed in Production, 2h ago" with no arrow — rendering the placeholder either side gives `••••• → •••••`, which reads as a bug. Note the audit redacts differently from the live API: `/variables/{id}` returns `IsSensitive: true` and a null value, the audit carries a placeholder and no `IsSensitive` field at all, so sensitivity there is signalled only by `Type`.

## Fixes along the way

1. **Permission-limited spaces.** Cloud Platform 403s on `/machines/all` while environments, pools and tenants return 200. Estate hydration treated any machines failure as fatal, so the whole space read as unloadable. A 401/403 now degrades to a space without machine data; other errors still fail. Three related bugs, fixed one at a time as each surfaced.
2. **`viewNeedsEstate` matched the whole hash**, so `tenants/T-1` was not recognised as estate-free and cold-start intercepted a tenant click. It matches the base segment now.
3. **Readiness contradicted itself** — a tenant reported six missing variables and "a deployment would fail on configuration" next to a deployment that had succeeded three days earlier. Two faults: the count multiplied templates by environments, and it asserted an outcome the live data contradicted. It counts distinct templates now and marks a template proven where that project/environment pair has actually deployed.
4. **A history fetched before the dashboard landed** was built against no environment columns and cached that way. The dashboard's arrival now rebuilds from the raw payload.
5. **Switching space** kept you on the current view, which on a detail page meant a target, tenant or project belonging to the space you just left. It lands on Projects.
6. **A stray copy of a render block** left in `renderTenantDetail` by a string-replace edit. It rendered nowhere, which is why nothing caught it. A test now asserts each render block is defined once in the view that uses it.

## Against the review checklist

- **Read-only.** No POST/PUT/DELETE/PATCH anywhere in the diff.
- **No external calls or resources.** Every request goes to the Octopus instance through the existing `fetchJson`; no scripts, stylesheets, fonts or iframes.
- **API loops are all bounded, and each surfaces its own truncation to the user rather than silently capping:** feature toggles 4 pages of 100; tenants 20 pages of 100; tenant machines 10 pages of 100; a tenant's flags 6 projects; a project's extra channel lifecycles 6. `/progression` is capped at `releaseHistoryCount=30` and is fetched once per project, on expand, and kept for the session.
- **Auth failures** are distinguished from other errors throughout (`e.auth` on 401/403) and degrade per-section rather than per-page.
- **`innerHTML`** is only ever assigned the output of the view builders, which escape every interpolated value through `escHtml`. The one field that carries markdown links — a tenant description — is split on the link pattern, every part escaped, and only `http`/`https` reach an `href`.
- **No `eval`, no iframes, no Chrome extension APIs, no cookie reads, no parent-directory loads.** No `manifest.json` change.
- **Local storage** is one key, `iprealpha:theme`, prefixed for this dashboard.
- **429 and rate limiting** are inherited unchanged from the existing `fetchJson` (p-throttle at 200/min, retry with backoff).
- `metadata.json` unchanged.

## Verification

Tests 132 → 421, run on every commit.

Rendered against `deploy.octopus.app` across several spaces during the build, including Octopus Server (191 flags, 3,140 releases, one cell with 41 distinct versions), Cloud Platform (the 403 space), and a space with 4,375 tenants. Live data drove several of the fixes above.

**Not verified in the packaged extension.** Everything here was exercised through the dashboard's own tests and against live API responses; a pass in the loaded extension is still worth doing before this ships to anyone.
