### PR TITLE
Infrastructure (PreAlpha): focus restoration, stale renders, machine caching, and tenancy metrics

### DIFF
--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -4226,3 +4226,85 @@ describe('Incomplete reads say so where the zero used to be', () => {
     expect(r.count).toBe(1);
   });
 });
+
+describe('A redraw keeps focus where the user left it', () => {
+  const Views = require('./views');
+
+  test('a control is identified by what survives the rebuild', () => {
+    const el = (tag, attrs) => ({
+      tagName: tag.toUpperCase(), id: attrs.id || '',
+      hasAttribute: a => Object.prototype.hasOwnProperty.call(attrs, a),
+      getAttribute: a => attrs[a]
+    });
+    expect(Views.focusSelector(el('div', { 'data-project': 'Projects-1' })))
+      .toBe('div[data-project="Projects-1"]');
+    expect(Views.focusSelector(el('button', { 'data-sort': 'Name' })))
+      .toBe('button[data-sort="Name"]');
+    // A facet needs both halves, or it finds the wrong checkbox.
+    expect(Views.focusSelector(el('input', { 'data-facet': 'tags', 'data-value': 'Region/EU' })))
+      .toBe('input[data-facet="tags"][data-value="Region/EU"]');
+    expect(Views.focusSelector(el('input', { id: 'ip-search' }))).toBe('#ip-search');
+  });
+
+  test('an element with nothing stable about it is left alone', () => {
+    expect(Views.focusSelector({ tagName: 'SPAN', id: '', hasAttribute: () => false, getAttribute: () => null }))
+      .toBeNull();
+    expect(Views.focusSelector(null)).toBeNull();
+  });
+
+  test('focus is restored across a redraw, and the caret with it', () => {
+    let focused = null, range = null;
+    const control = { focus: () => { focused = 'again'; },
+      setSelectionRange: (a, b) => { range = [a, b]; } };
+    const active = { tagName: 'INPUT', id: 'ip-search', hasAttribute: () => false,
+      getAttribute: () => null, selectionStart: 3, selectionEnd: 5 };
+    const root = { contains: () => true, querySelector: sel => (sel === '#ip-search' ? control : null) };
+    global.document = { activeElement: active, body: {} };
+    let redrew = false;
+    Views.withFocus(root, () => { redrew = true; });
+    expect(redrew).toBe(true);
+    expect(focused).toBe('again');
+    expect(range).toEqual([3, 5]);
+    delete global.document;
+  });
+
+  test('a control that no longer exists after the redraw does not throw', () => {
+    const active = { tagName: 'BUTTON', id: '', hasAttribute: a => a === 'data-page',
+      getAttribute: () => '4' };
+    const root = { contains: () => true, querySelector: () => null };
+    global.document = { activeElement: active, body: {} };
+    expect(() => Views.withFocus(root, () => {})).not.toThrow();
+    delete global.document;
+  });
+});
+
+describe('The machine list is read once per space, not once per page', () => {
+  const data = require('./data');
+
+  test('a second read inside the window reuses the first', async () => {
+    data.clearMachineCache();
+    const calls = [];
+    global.fetch = async url => { calls.push(url); return {
+      ok: true, status: 200, json: async () => ({ Items: [], TotalResults: 0 }) }; };
+    await data.fetchTenantMachines('Spaces-1');
+    const first = calls.length;
+    await data.fetchTenantMachines('Spaces-1');
+    expect(calls.length).toBe(first);
+    // A different space is a different estate.
+    await data.fetchTenantMachines('Spaces-2');
+    expect(calls.length).toBeGreaterThan(first);
+    data.clearMachineCache();
+    delete global.fetch;
+  });
+
+  test('a failed read is not remembered as the answer', async () => {
+    data.clearMachineCache();
+    let attempts = 0;
+    global.fetch = async () => { attempts++; return { ok: false, status: 500, statusText: 'Server Error' }; };
+    await data.fetchTenantMachines('Spaces-1').catch(() => {});
+    await data.fetchTenantMachines('Spaces-1').catch(() => {});
+    expect(attempts).toBe(2);
+    data.clearMachineCache();
+    delete global.fetch;
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -4431,3 +4431,95 @@ describe('The machine list is read once per space, not once per page', () => {
     expect(calls.length).toBe(n + 1);
   });
 });
+
+describe('Tenancy metrics on the tenants list', () => {
+  const data = require('./data');
+  const Views = require('./views');
+  const dash = { Projects: [], ProjectGroups: [], Environments: [], Tenants: [], Items: [] };
+  const model = (tenants, extra) => data.tenantsModel(Object.assign({
+    tenants: { items: tenants, total: tenants.length, truncated: false },
+    dashboard: dash, tagSets: [] }, extra || {}));
+  const sample = [
+    { Id: 'T1', Name: 'Acme', TenantTags: ['Region/EU', 'Tier/Gold'],
+      ProjectEnvironments: { P1: ['E1', 'E2'], P2: ['E2'] } },     // 2 projects, 2 envs
+    { Id: 'T2', Name: 'Globex', TenantTags: ['Region/EU'],
+      ProjectEnvironments: { P1: ['E1'], P2: ['E1'], P3: ['E3'] } }, // 3 projects, 2 envs
+    { Id: 'T3', Name: 'Initech', TenantTags: [], ProjectEnvironments: {} }
+  ];
+
+  test('tenants in environments counts tenants, and connections separately', () => {
+    const k = model(sample).metrics;
+    expect(k.inEnvironments).toBe(2);            // Initech is connected to none
+    expect(k.environmentConnections).toBe(4);    // Acme E1,E2 + Globex E1,E3
+  });
+
+  test('an environment reached by two projects is one connection, not two', () => {
+    // Acme has three project-environment pairs across two environments.
+    const k = model([sample[0]]).metrics;
+    expect(k.environmentConnections).toBe(2);
+    expect(model([sample[0]]).tenants[0].pairCount).toBe(3);
+  });
+
+  test('tags are counted distinctly, and their sets with them', () => {
+    const k = model(sample).metrics;
+    expect(k.tagValues).toBe(2);      // Region/EU is shared, so it counts once
+    expect(k.tagSetsInUse).toBe(2);   // Region, Tier
+  });
+
+  test('the widest tenant is named, not just counted', () => {
+    const k = model(sample).metrics;
+    expect(k.maxProjects).toBe(3);
+    expect(k.maxProjectsTenant).toBe('Globex');
+  });
+
+  test('a space with no tenancy at all reports zeros without naming anyone', () => {
+    const k = model([]).metrics;
+    expect(k).toMatchObject({ inEnvironments: 0, environmentConnections: 0, tagValues: 0, maxProjects: 0 });
+    expect(k.maxProjectsTenant).toBe('');
+    // A space with no tenants shows the empty state instead of the cards.
+    expect(Views.renderTenants({ tenants: { status: 'ready', model: model([]) } }))
+      .toContain('No tenants in this space');
+  });
+
+  test('tenants that exist but connect to nothing name no tenant', () => {
+    const m = model([{ Id: 'T1', Name: 'Initech', ProjectEnvironments: {} }]);
+    expect(m.metrics.maxProjects).toBe(0);
+    const html = Views.renderTenants({ tenants: { status: 'ready', model: m } });
+    const cards = html.slice(html.indexOf('ip-kpi-3'), html.indexOf('ip-tn-toolbar'));
+    expect(cards).toContain('no tenant is connected to a project');
+    expect(cards).not.toContain('Initech');
+  });
+
+  test('the cards render the numbers and the tenant name', () => {
+    const html = Views.renderTenants({ tenants: { status: 'ready', model: model(sample) } });
+    expect(html).toContain('Tenants in environments');
+    expect(html).toContain('Tenant tags in use');
+    expect(html).toContain('Most projects on one tenant');
+    expect(html).toContain('Globex');
+    expect(html).toContain('4 tenant-environment connections');
+  });
+
+  test('metrics over a truncated list say what they were counted over', () => {
+    const many = [];
+    for (let i = 0; i < 50; i++) many.push({ Id: 'T' + i, Name: 'T' + i, ProjectEnvironments: { P1: ['E1'] } });
+    const m = data.tenantsModel({ tenants: { items: many, total: 4375, truncated: true },
+      dashboard: dash, tagSets: [] });
+    expect(m.metrics.partial).toBe(true);
+    expect(m.metrics.countedOver).toBe(50);
+    const html = Views.renderTenants({ tenants: { status: 'ready', model: m } });
+    expect(html).toContain('first 50 tenants read, not all 4,375');
+  });
+
+  test('a complete list makes no such claim', () => {
+    const html = Views.renderTenants({ tenants: { status: 'ready', model: model(sample) } });
+    expect(html).not.toContain('tenants read, not all');
+  });
+
+  test('the dashboard cap does not touch these — they come from the tenant payload', () => {
+    const capped = data.tenantsModel({ tenants: { items: sample, total: sample.length },
+      dashboard: Object.assign({}, dash, { Projects: [{ Id: 'P1' }], ProjectLimit: 1 }), tagSets: [] });
+    expect(capped.dashboardCap.capped).toBe(true);
+    expect(capped.metrics.maxProjects).toBe(3);   // unchanged by the cap
+    expect(capped.metrics.partial).toBe(false);
+  });
+});

--- a/dashboards/infrastructureprealpha/dashboard.test.js
+++ b/dashboards/infrastructureprealpha/dashboard.test.js
@@ -4229,13 +4229,13 @@ describe('Incomplete reads say so where the zero used to be', () => {
 
 describe('A redraw keeps focus where the user left it', () => {
   const Views = require('./views');
+  const el = (tag, attrs) => ({
+    tagName: tag.toUpperCase(), id: attrs.id || '',
+    hasAttribute: a => Object.prototype.hasOwnProperty.call(attrs, a),
+    getAttribute: a => attrs[a]
+  });
 
   test('a control is identified by what survives the rebuild', () => {
-    const el = (tag, attrs) => ({
-      tagName: tag.toUpperCase(), id: attrs.id || '',
-      hasAttribute: a => Object.prototype.hasOwnProperty.call(attrs, a),
-      getAttribute: a => attrs[a]
-    });
     expect(Views.focusSelector(el('div', { 'data-project': 'Projects-1' })))
       .toBe('div[data-project="Projects-1"]');
     expect(Views.focusSelector(el('button', { 'data-sort': 'Name' })))
@@ -4243,68 +4243,191 @@ describe('A redraw keeps focus where the user left it', () => {
     // A facet needs both halves, or it finds the wrong checkbox.
     expect(Views.focusSelector(el('input', { 'data-facet': 'tags', 'data-value': 'Region/EU' })))
       .toBe('input[data-facet="tags"][data-value="Region/EU"]');
-    expect(Views.focusSelector(el('input', { id: 'ip-search' }))).toBe('#ip-search');
+  });
+
+  test('keys whose value moves with the state are not used to identify anything', () => {
+    // data-page is relative to the current page, so the captured selector could
+    // never match after paging. The pager's role does not move.
+    expect(Views.focusSelector(el('button', { 'data-page': '4' }))).toBeNull();
+    expect(Views.focusSelector(el('button', { 'data-pager': 'next', 'data-page': '4' })))
+      .toBe('button[data-pager="next"]');
+  });
+
+  test('a project link identifies its own project, not the first on the page', () => {
+    const first = Views.focusSelector(el('a', { 'data-projectlink': 'Projects-1' }));
+    const last = Views.focusSelector(el('a', { 'data-projectlink': 'Projects-99' }));
+    expect(first).not.toBe(last);
+    expect(last).toBe('a[data-projectlink="Projects-99"]');
   });
 
   test('an element with nothing stable about it is left alone', () => {
-    expect(Views.focusSelector({ tagName: 'SPAN', id: '', hasAttribute: () => false, getAttribute: () => null }))
-      .toBeNull();
+    expect(Views.focusSelector(el('span', {}))).toBeNull();
     expect(Views.focusSelector(null)).toBeNull();
   });
 
-  test('focus is restored across a redraw, and the caret with it', () => {
+  test('the escaper runs in both worlds and stays inside the quotes', () => {
+    // Chrome always has CSS.escape; jest never does, so the browser branch had
+    // no coverage at all and the assertion pinned the fallback's output.
+    const chrome = Views.focusSelector(el('input', { 'data-ctl': 'a"b' }));
+    expect(chrome).toBe('input[data-ctl="a\\"b"]');
+    global.CSS = { escape: s => String(s).replace(/([^a-zA-Z0-9_-])/g, '\\$1') };
+    try {
+      expect(Views.focusSelector(el('input', { 'data-value': 'Region/EU' })))
+        .toBe('input[data-value="Region\\/EU"]');
+    } finally { delete global.CSS; }
+  });
+
+  test('focus and caret come back on the control production actually renders', () => {
+    // The tenant search box has no id — it is found by data-ctl. The previous
+    // test used an id no element in #main-content carries, so it proved a branch
+    // that never runs.
     let focused = null, range = null;
     const control = { focus: () => { focused = 'again'; },
       setSelectionRange: (a, b) => { range = [a, b]; } };
-    const active = { tagName: 'INPUT', id: 'ip-search', hasAttribute: () => false,
-      getAttribute: () => null, selectionStart: 3, selectionEnd: 5 };
-    const root = { contains: () => true, querySelector: sel => (sel === '#ip-search' ? control : null) };
+    const active = Object.assign(el('input', { 'data-ctl': 'tenant-search' }),
+      { selectionStart: 3, selectionEnd: 5 });
+    const root = { contains: () => true,
+      querySelector: sel => (sel === 'input[data-ctl="tenant-search"]' ? control : null) };
     global.document = { activeElement: active, body: {} };
     let redrew = false;
     Views.withFocus(root, () => { redrew = true; });
+    delete global.document;
     expect(redrew).toBe(true);
     expect(focused).toBe('again');
     expect(range).toEqual([3, 5]);
-    delete global.document;
   });
 
-  test('a control that no longer exists after the redraw does not throw', () => {
-    const active = { tagName: 'BUTTON', id: '', hasAttribute: a => a === 'data-page',
-      getAttribute: () => '4' };
+  test('a control the redraw legitimately removed is left alone', () => {
+    const active = el('button', { 'data-project': 'Projects-1' });
     const root = { contains: () => true, querySelector: () => null };
     global.document = { activeElement: active, body: {} };
     expect(() => Views.withFocus(root, () => {})).not.toThrow();
     delete global.document;
   });
+
+  test('restoring focus does not drag the viewport with it', () => {
+    let opts = 'never called';
+    const control = { focus: o => { opts = o; } };
+    const active = el('div', { 'data-project': 'Projects-1' });
+    const root = { contains: () => true, querySelector: () => control };
+    global.document = { activeElement: active, body: {} };
+    Views.withFocus(root, () => {});
+    delete global.document;
+    expect(opts).toEqual({ preventScroll: true });
+  });
+});
+
+describe('The rendered controls carry the identity the focus fix relies on', () => {
+  const data = require('./data');
+  const Views = require('./views');
+
+  test('each project link is addressed by its own id', () => {
+    const dash = { Projects: [{ Id: 'P1', Name: 'Portal', ProjectGroupId: 'G1' },
+                              { Id: 'P2', Name: 'Admin', ProjectGroupId: 'G1' }],
+      ProjectGroups: [{ Id: 'G1', Name: 'Web' }], Environments: [{ Id: 'E1', Name: 'Dev' }],
+      Tenants: [], Items: [{ ProjectId: 'P1', EnvironmentId: 'E1', ReleaseVersion: '1.0',
+        State: 'Success', IsCurrent: true, CompletedTime: '2026-08-13T09:00:00Z' },
+        { ProjectId: 'P2', EnvironmentId: 'E1', ReleaseVersion: '2.0', State: 'Success',
+          IsCurrent: true, CompletedTime: '2026-08-13T09:00:00Z' }] };
+    const html = Views.renderProjects({ releases: { status: 'ready', model: data.releasesModel(dash) } });
+    expect(html).toContain('data-projectlink="P1"');
+    expect(html).toContain('data-projectlink="P2"');
+    expect(html).not.toContain('data-projectlink="1"');
+  });
+
+  test('the tenant search, sort and pager are addressable', () => {
+    const tenants = [];
+    for (let i = 0; i < 150; i++) tenants.push({ Id: 'T' + i, Name: 'Tenant ' + i, ProjectEnvironments: {} });
+    const model = data.tenantsModel({ tenants: { items: tenants, total: tenants.length },
+      dashboard: { Projects: [], ProjectGroups: [], Environments: [], Tenants: [], Items: [] }, tagSets: [] });
+    const html = Views.renderTenants({ tenants: { status: 'ready', model: model } });
+    expect(html).toContain('data-ctl="tenant-search"');
+    expect(html).toContain('data-ctl="tenant-sort"');
+    // The pager's identity has to be the same on every page.
+    expect(html).toContain('data-pager="prev"');
+    expect(html).toContain('data-pager="next"');
+    const page2 = Views.renderTenants({ tenants: { status: 'ready', model: model }, tenantPage: 1 });
+    expect(page2).toContain('data-pager="next"');
+  });
+});
+
+describe('A hash resolves to the section it belongs to', () => {
+  const data = require('./data');
+
+  test('a detail route is the same section as its list', () => {
+    expect(data.baseView('#projects/Projects-1')).toBe('projects');
+    expect(data.baseView('#projects')).toBe('projects');
+    expect(data.baseView('tenants/Tenants-9')).toBe('tenants');
+  });
+
+  test('an empty or absent hash is the landing view', () => {
+    expect(data.baseView('')).toBe('overview');
+    expect(data.baseView(null)).toBe('overview');
+    expect(data.baseView('#')).toBe('overview');
+  });
 });
 
 describe('The machine list is read once per space, not once per page', () => {
   const data = require('./data');
-
-  test('a second read inside the window reuses the first', async () => {
-    data.clearMachineCache();
+  const stubFetch = pages => {
     const calls = [];
-    global.fetch = async url => { calls.push(url); return {
-      ok: true, status: 200, json: async () => ({ Items: [], TotalResults: 0 }) }; };
-    await data.fetchTenantMachines('Spaces-1');
-    const first = calls.length;
-    await data.fetchTenantMachines('Spaces-1');
-    expect(calls.length).toBe(first);
-    // A different space is a different estate.
+    global.fetch = async url => {
+      calls.push(url);
+      const page = pages[Math.min(calls.length - 1, pages.length - 1)];
+      return { ok: true, status: 200, json: async () => page };
+    };
+    return calls;
+  };
+
+  afterEach(() => { data.clearMachineCache(); delete global.fetch; });
+
+  test('a second read inside the window reuses the first, per space', async () => {
+    const calls = stubFetch([{ Items: [{ Id: 'M1' }], TotalResults: 1 }]);
+    const a = await data.fetchTenantMachines('Spaces-1');
+    const n = calls.length;
+    const b = await data.fetchTenantMachines('Spaces-1');
+    expect(calls.length).toBe(n);
+    expect(b).toBe(a);                       // the same resolved value, not a copy
     await data.fetchTenantMachines('Spaces-2');
-    expect(calls.length).toBeGreaterThan(first);
-    data.clearMachineCache();
-    delete global.fetch;
+    expect(calls.length).toBeGreaterThan(n); // a different space is a different estate
+  });
+
+  test('it pages until the total is reached, and reports what it read', async () => {
+    const full = { Items: new Array(100).fill(0).map((_, i) => ({ Id: 'M' + i })), TotalResults: 150 };
+    const rest = { Items: new Array(50).fill(0).map((_, i) => ({ Id: 'N' + i })), TotalResults: 150 };
+    const calls = stubFetch([full, rest]);
+    const res = await data.fetchTenantMachines('Spaces-1');
+    expect(calls.length).toBe(2);
+    expect(calls[1]).toContain('skip=100');
+    expect(res.items.length).toBe(150);
+    expect(res.truncated).toBe(false);
+  });
+
+  test('concurrent callers join one read rather than starting two', async () => {
+    const calls = stubFetch([{ Items: [], TotalResults: 0 }]);
+    const [x, y] = await Promise.all([
+      data.fetchTenantMachines('Spaces-1'), data.fetchTenantMachines('Spaces-1')]);
+    expect(calls.length).toBe(1);
+    expect(x).toBe(y);
   });
 
   test('a failed read is not remembered as the answer', async () => {
-    data.clearMachineCache();
     let attempts = 0;
     global.fetch = async () => { attempts++; return { ok: false, status: 500, statusText: 'Server Error' }; };
     await data.fetchTenantMachines('Spaces-1').catch(() => {});
     await data.fetchTenantMachines('Spaces-1').catch(() => {});
     expect(attempts).toBe(2);
-    data.clearMachineCache();
-    delete global.fetch;
+  });
+
+  test('clearing names a space, so the one you left is not thrown away too', async () => {
+    const calls = stubFetch([{ Items: [], TotalResults: 0 }]);
+    await data.fetchTenantMachines('Spaces-1');
+    await data.fetchTenantMachines('Spaces-2');
+    const n = calls.length;
+    data.clearMachineCache('Spaces-2');
+    await data.fetchTenantMachines('Spaces-1');   // still cached
+    expect(calls.length).toBe(n);
+    await data.fetchTenantMachines('Spaces-2');   // re-read
+    expect(calls.length).toBe(n + 1);
   });
 });

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1430,7 +1430,26 @@ async function fetchTenantVariables(spaceId, tenantId) {
   return fetchJson('/api/' + spaceId + '/tenants/' + encodeURIComponent(tenantId) + '/variables');
 }
 
-async function fetchTenantMachines(spaceId) {
+// Up to ten paged requests, and both the tenant page and the project map want
+// it. Browsing twenty tenants re-paged the whole estate twenty times. Cached per
+// space for a couple of minutes: long enough to make navigation free, short
+// enough that a target registered while you are looking still turns up.
+const MACHINE_CACHE_MS = 120000;
+const machineCache = {};
+
+function clearMachineCache() { Object.keys(machineCache).forEach(k => { delete machineCache[k]; }); }
+
+function fetchTenantMachines(spaceId) {
+  const hit = machineCache[spaceId];
+  if (hit && (Date.now() - hit.at) < MACHINE_CACHE_MS) return hit.promise;
+  const promise = fetchAllMachines(spaceId);
+  machineCache[spaceId] = { at: Date.now(), promise: promise };
+  // A failed read must not be remembered as the answer for two minutes.
+  promise.catch(() => { if (machineCache[spaceId] && machineCache[spaceId].promise === promise) delete machineCache[spaceId]; });
+  return promise;
+}
+
+async function fetchAllMachines(spaceId) {
   let items = [], total = null, page = 0;
   while (page < TENANT_MACHINE_MAX_PAGES) {
     const res = await fetchJson('/api/' + spaceId + '/machines?skip=' + (page * TENANT_MACHINE_PAGE)
@@ -2114,7 +2133,7 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   viewNeedsEstate,
   fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
   parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
-  fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
+  fetchTenant, fetchTenantVariables, fetchTenantMachines, clearMachineCache, tenantDetailModel, tenantReadiness, matchTenantTargets,
   fetchTenantFlags, tenantFlagModel, flagStateForTenant,
   fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets, projectFlagModel }; }
 
@@ -2132,7 +2151,7 @@ if (typeof module !== 'undefined') {
     viewNeedsEstate,
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
-    fetchTenant, fetchTenantVariables, fetchTenantMachines, tenantDetailModel, tenantReadiness, matchTenantTargets,
+    fetchTenant, fetchTenantVariables, fetchTenantMachines, clearMachineCache, tenantDetailModel, tenantReadiness, matchTenantTargets,
     fetchTenantFlags, tenantFlagModel, flagStateForTenant,
     fetchProjectMap, projectMapModel, actionTypeLabel, triggerLabel, projectTargets, projectFlagModel };
 }

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1287,6 +1287,11 @@ function tenantsModel(payload) {
     const pairs = t.ProjectEnvironments || {};
     const connectedProjects = Object.keys(pairs);
     const pairCount = connectedProjects.reduce((n, pid) => n + ((pairs[pid] || []).length), 0);
+    // Distinct environments this tenant is connected to, across every project.
+    // Deployment history says where it has been; this says where it can go.
+    const connectedEnvs = {};
+    connectedProjects.forEach(pid => (pairs[pid] || []).forEach(eid => { connectedEnvs[eid] = true; }));
+    const connectedEnvIds = Object.keys(connectedEnvs);
 
     let last = null;
     items.forEach(i => {
@@ -1305,6 +1310,7 @@ function tenantsModel(payload) {
       connected: pairCount > 0,
       pairCount: pairCount,
       connectedProjectIds: connectedProjects,
+      connectedEnvironmentIds: connectedEnvIds,
       projectsOn: Object.keys(projectsOn),
       environmentsOn: Object.keys(envsOn).map(id => envName[id] || id),
       deployed: items.length > 0,
@@ -1319,11 +1325,40 @@ function tenantsModel(payload) {
     };
   });
 
+  // Three numbers about the shape of the tenancy, none of which the table shows
+  // and all of which come from the tenant payload rather than the dashboard, so
+  // the dashboard's project cap does not touch them. The tenant list's own page
+  // limit does, and the view says so.
+  const tagValues = {};
+  const tagSetsInUse = {};
+  rows.forEach(r => r.tags.forEach(tag => {
+    tagValues[tag.raw] = true;
+    if (tag.set) tagSetsInUse[tag.set] = true;
+  }));
+  let widest = null;
+  rows.forEach(r => {
+    if (!widest || r.connectedProjectIds.length > widest.count) {
+      widest = { count: r.connectedProjectIds.length, name: r.name, id: r.id };
+    }
+  });
+  const environmentConnections = rows.reduce((n, r) => n + r.connectedEnvironmentIds.length, 0);
+
   return {
     tenants: rows,
     total: (src.tenants && src.tenants.total) || rows.length,
     truncated: !!(src.tenants && src.tenants.truncated),
     dashboardCap: dashboardCap(dash),
+    metrics: {
+      inEnvironments: rows.filter(r => r.connectedEnvironmentIds.length).length,
+      environmentConnections: environmentConnections,
+      tagValues: Object.keys(tagValues).length,
+      tagSetsInUse: Object.keys(tagSetsInUse).length,
+      maxProjects: widest ? widest.count : 0,
+      maxProjectsTenant: widest && widest.count ? widest.name : '',
+      // Every one of these is computed over the tenants that were read.
+      partial: !!(src.tenants && src.tenants.truncated),
+      countedOver: rows.length
+    },
     tagSets: (src.tagSets || []).map(ts => ({
       name: ts.Name,
       tags: (ts.Tags || []).map(tag => ({ name: tag.Name, colour: tag.Color || '' }))

--- a/dashboards/infrastructureprealpha/data.js
+++ b/dashboards/infrastructureprealpha/data.js
@@ -1178,6 +1178,13 @@ function variableChangeLabel(change) {
 // returns 200, which is exactly the case on Cloud Platform.
 const ESTATE_FREE_VIEWS = ['projects', 'tenants'];
 
+/** The section a hash belongs to, ignoring any detail id: 'projects/P-1' and
+ *  'projects' are the same section. */
+function baseView(hash) {
+  const raw = String(hash == null ? '' : hash).replace(/^#/, '');
+  return raw.split('/')[0] || 'overview';
+}
+
 function viewNeedsEstate(view) {
   // Detail routes carry an id — "tenants/Tenants-1" is still the tenants view.
   // Matching the whole hash meant a tenant page counted as an infrastructure
@@ -1437,16 +1444,30 @@ async function fetchTenantVariables(spaceId, tenantId) {
 const MACHINE_CACHE_MS = 120000;
 const machineCache = {};
 
-function clearMachineCache() { Object.keys(machineCache).forEach(k => { delete machineCache[k]; }); }
+/** Clears one space, or all of them when no space is named. Clearing every
+ *  space on a switch was self-defeating: the cache is keyed by space, so going
+ *  A to B and back re-paged A inside its own live window. */
+function clearMachineCache(spaceId) {
+  if (spaceId) { delete machineCache[spaceId]; return; }
+  Object.keys(machineCache).forEach(k => { delete machineCache[k]; });
+}
 
 function fetchTenantMachines(spaceId) {
   const hit = machineCache[spaceId];
-  if (hit && (Date.now() - hit.at) < MACHINE_CACHE_MS) return hit.promise;
-  const promise = fetchAllMachines(spaceId);
-  machineCache[spaceId] = { at: Date.now(), promise: promise };
-  // A failed read must not be remembered as the answer for two minutes.
-  promise.catch(() => { if (machineCache[spaceId] && machineCache[spaceId].promise === promise) delete machineCache[spaceId]; });
-  return promise;
+  // A read still in flight is always worth joining, however long it has taken;
+  // the age only applies once there is an answer that can be stale. Stamping the
+  // clock at the start meant ten paged requests could outlive their own window
+  // and a second caller would start the whole run again.
+  if (hit && (hit.at == null || (Date.now() - hit.at) < MACHINE_CACHE_MS)) return hit.promise;
+  const entry = { at: null, promise: null };
+  entry.promise = fetchAllMachines(spaceId).then(res => {
+    if (machineCache[spaceId] === entry) entry.at = Date.now();
+    return res;
+  });
+  // A failed read must not be remembered as the answer.
+  entry.promise.catch(() => { if (machineCache[spaceId] === entry) delete machineCache[spaceId]; });
+  machineCache[spaceId] = entry;
+  return entry.promise;
 }
 
 async function fetchAllMachines(spaceId) {
@@ -2130,7 +2151,7 @@ if (typeof window !== 'undefined') { window.Data = { setServerUrl, apiUrl, fetch
   fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
   fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
   fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable,
-  viewNeedsEstate,
+  viewNeedsEstate, baseView,
   fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
   parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
   fetchTenant, fetchTenantVariables, fetchTenantMachines, clearMachineCache, tenantDetailModel, tenantReadiness, matchTenantTargets,
@@ -2148,7 +2169,7 @@ if (typeof module !== 'undefined') {
     fetchFeatureToggles, featureFlagModel, flagEnvState, flagIsInFlight,
     fetchFlagEvents, flagChangeModel, flagChangeLabel, GROUPINGS,
     fetchVariableEvents, variableChangeModel, variableChangeLabel, isSensitiveVariable, shortValue, applyVariablePatch,
-    viewNeedsEstate,
+    viewNeedsEstate, baseView,
     fetchTenants, fetchTagSets, tenantsModel, sortTenants, filterTenants, tenantFacets,
     parseTenantTag, tenantOutcomeKey, TENANT_SORTS, tenantSortDir,
     fetchTenant, fetchTenantVariables, fetchTenantMachines, clearMachineCache, tenantDetailModel, tenantReadiness, matchTenantTargets,

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -7,9 +7,27 @@ const Router = (function () {
     document.querySelectorAll('.ip-nav-item').forEach(a =>
       a.classList.toggle('active', a.getAttribute('data-view') === view));
   }
+  // Which section the hash is on, ignoring any detail id. Loaders capture this
+  // when they fire and check it when they resolve: the state they fetched is
+  // always worth keeping, but redrawing over whatever the user is now looking
+  // at is not. Without this, a flag request landing after you navigated to
+  // Tenants replaced the DOM under your cursor mid-keystroke.
+  function currentView() {
+    return String(window.location.hash || '#overview').slice(1).split('/')[0] || 'overview';
+  }
+  /** Redraw only if we are still on the section this work was started for. */
+  function renderIfStill(view) {
+    if (currentView() !== view) return;
+    render();
+  }
+
   function render() {
     const el = document.getElementById('main-content');
     const hash = (window.location.hash || '#overview').slice(1);
+    // The section this pass is drawing. Anything it fires asynchronously checks
+    // this before redrawing, so a slow request cannot replace a page the user
+    // has since navigated to.
+    const startedOn = hash.split('/')[0] || 'overview';
     // A space that failed to hydrate has no estate to route over, and rendering
     // infrastructure views against it would show zeros as though the space were
     // empty. Projects is not one of those views: it reads the project dashboard
@@ -62,7 +80,10 @@ const Router = (function () {
         IP.projectTab = 'Status'; }
       ensureReleases();
       IP.projectOpen = IP.projectOpen || {};
-      if (IP.projectOpen[projectId] === undefined) IP.projectOpen[projectId] = true;
+      // Only on the first render of this project. Defaulting it open on every
+      // render meant collapsing the row and then having an in-flight request
+      // resolve sprang it back open, twice — once per request.
+      if (staleP && IP.projectOpen[projectId] === undefined) IP.projectOpen[projectId] = true;
       el.innerHTML = Views.renderProjectMap(IP);
       Views.bindProjectMap && Views.bindProjectMap(IP);
       // The history and flags are only fetchable once the dashboard has given us
@@ -79,13 +100,13 @@ const Router = (function () {
             if (IP.spaceId !== wantedSpace || !IP.projectMap || IP.projectMap.projectId !== projectId) return;
             IP.projectMap = { status: 'ready', projectId: projectId, spaceId: wantedSpace,
               model: Data.projectMapModel(payload) };
-            render();
+            renderIfStill(startedOn);
           })
           .catch(e => {
             if (IP.spaceId !== wantedSpace || !IP.projectMap || IP.projectMap.projectId !== projectId) return;
             IP.projectMap = { status: 'error', projectId: projectId, spaceId: wantedSpace,
               error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The project request failed.' };
-            render();
+            renderIfStill(startedOn);
           });
       }
       return;
@@ -106,7 +127,12 @@ const Router = (function () {
         // The tenant page reuses the dashboard the list already fetched when it
         // is there, and asks for one when it is not. Variables and machines are
         // separate: either can fail without costing the page.
-        const dashboard = (IP.tenants && IP.tenants.status === 'ready' && IP.tenants.raw)
+        // Reuse the list's dashboard only when it belongs to this space. Without
+        // the space check, viewing tenants in one space and then opening a
+        // tenant in another paired the tenant with the previous space's
+        // deployments: unknown project names, every matrix cell never deployed.
+        const dashboard = (IP.tenants && IP.tenants.status === 'ready' && IP.tenants.raw
+            && IP.tenants.spaceId === wantedSpace)
           ? Promise.resolve(IP.tenants.raw) : Data.fetchDashboard(wantedSpace);
         Promise.all([
           Data.fetchTenant(wantedSpace, tenantId),
@@ -122,7 +148,7 @@ const Router = (function () {
               model: Data.tenantDetailModel({ tenant: res[0], dashboard: res[1],
                 variables: res[2].v, variablesError: res[2].err,
                 machines: res[3].mach, machinesError: res[3].err }) };
-            render();
+            renderIfStill(startedOn);
 
             // Flags are one request per connected project, so they follow the
             // page rather than holding it up. Failing leaves the rest intact.
@@ -138,12 +164,12 @@ const Router = (function () {
                   if (!stillWanted()) return;
                   IP.flags = { status: 'ready',
                     model: Data.tenantFlagModel(payload, tenantDoc, connected, envNames, projNames) };
-                  render();
+                  renderIfStill(startedOn);
                 })
                 .catch(() => {
                   if (!stillWanted()) return;
                   IP.flags = { status: 'error', error: 'Feature flags could not be read for this tenant\'s projects.' };
-                  render();
+                  renderIfStill(startedOn);
                 });
             }
           })
@@ -151,7 +177,7 @@ const Router = (function () {
             if (!stillWanted()) return;
             IP.tenantDetail = { status: 'error', tenantId: tenantId, spaceId: wantedSpace,
               error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The tenant request failed.' };
-            render();
+            renderIfStill(startedOn);
           });
       }
       return;
@@ -188,14 +214,14 @@ const Router = (function () {
             if (IP.spaceId !== wanted) return;
             IP.tenants = { status: 'ready', spaceId: wanted, raw: res[1],
               model: Data.tenantsModel({ tenants: res[0], dashboard: res[1], tagSets: res[2] }) };
-            render();
+            renderIfStill(startedOn);
           })
           .catch(e => {
             if (IP.spaceId !== wanted) return;
             IP.tenants = { status: 'error', spaceId: wanted,
               error: e && e.auth ? 'Your session isn\'t authenticated. Sign in to Octopus and reopen this dashboard.'
                 : (e && e.code) || 'The tenant request failed.' };
-            render();
+            renderIfStill(startedOn);
           });
       }
     }
@@ -211,6 +237,7 @@ const Router = (function () {
   // flags, the window rebuild — are wanted by the projects list and by a single
   // project's Status tab. They are installed once, here, so neither owns them.
   function ensureReleases() {
+    const startedOn = currentView();
     // One request, made the first time someone needs it and re-made when they
     // switch space. Keyed on spaceId so a switch can't leave the previous
     // space's releases on screen.
@@ -282,7 +309,7 @@ const Router = (function () {
             model: Data.featureFlagModel(res[0], gridFor(projectId)),
             changes: Data.flagChangeModel(res[1], gridFor(projectId), windowHours()),
             variables: Data.variableChangeModel(res[2], gridFor(projectId), windowHours()) };
-          render();
+          renderIfStill(startedOn);
         })
         .catch(e => {
           if (IP.spaceId !== wantedSpace) return;
@@ -293,7 +320,7 @@ const Router = (function () {
             ? { status: 'ready', model: { flags: [], total: 0, settled: {}, truncated: false } }
             : { status: 'error', error: e && e.auth ? 'Your session isn\'t authenticated.'
                 : 'Feature flags could not be read for this project.' };
-          render();
+          renderIfStill(startedOn);
         });
     };
     IP.loadProjectHistory = function (projectId) {
@@ -308,13 +335,13 @@ const Router = (function () {
           IP.progressionRaw[projectId] = prog;
           IP.projectHistory[projectId] = { status: 'ready',
             model: Data.progressionModel(prog, gridFor(projectId), windowHours()) };
-          render();
+          renderIfStill(startedOn);
         })
         .catch(e => {
           if (IP.spaceId !== wantedSpace) return;
           IP.projectHistory[projectId] = { status: 'error',
             error: e && e.auth ? 'Your session isn\'t authenticated.' : (e && e.code) || 'The release history request failed.' };
-          render();
+          renderIfStill(startedOn);
         });
     };
     if (needed && Data.fetchDashboard) {
@@ -327,14 +354,14 @@ const Router = (function () {
           // columns at all. Rebuilding from the raw payload costs nothing and is
           // the difference between an aligned row and an empty one.
           IP.rebuildHistories();
-          render();
+          renderIfStill(startedOn);
         })
         .catch(e => {
           if (IP.spaceId !== wanted) return;
           const msg = e && e.auth ? 'Your session isn\'t authenticated. Sign in to Octopus and reopen this dashboard.'
             : (e && e.code) || 'The dashboard request failed.';
           IP.releases = { status: 'error', spaceId: wanted, error: msg };
-          render();
+          renderIfStill(startedOn);
         });
     }
     return needed;

--- a/dashboards/infrastructureprealpha/router.js
+++ b/dashboards/infrastructureprealpha/router.js
@@ -13,7 +13,9 @@ const Router = (function () {
   // at is not. Without this, a flag request landing after you navigated to
   // Tenants replaced the DOM under your cursor mid-keystroke.
   function currentView() {
-    return String(window.location.hash || '#overview').slice(1).split('/')[0] || 'overview';
+    return (typeof Data !== 'undefined' && Data.baseView)
+      ? Data.baseView(window.location.hash || '#overview')
+      : String(window.location.hash || '#overview').slice(1).split('/')[0] || 'overview';
   }
   /** Redraw only if we are still on the section this work was started for. */
   function renderIfStill(view) {
@@ -21,7 +23,16 @@ const Router = (function () {
     render();
   }
 
+  /** Every render replaces #main-content wholesale, which destroys focus. One
+   *  wrapper here covers the routed renders and every async callback that ends
+   *  in one; the views wrap their own local redraws the same way. */
   function render() {
+    const el = document.getElementById('main-content');
+    if (el && typeof Views !== 'undefined' && Views.withFocus) Views.withFocus(el, renderRoute);
+    else renderRoute();
+  }
+
+  function renderRoute() {
     const el = document.getElementById('main-content');
     const hash = (window.location.hash || '#overview').slice(1);
     // The section this pass is drawing. Anything it fires asynchronously checks

--- a/dashboards/infrastructureprealpha/styles.css
+++ b/dashboards/infrastructureprealpha/styles.css
@@ -1059,3 +1059,7 @@ hr, .divider { border: 0; border-top: 1px solid var(--border); margin: var(--spa
   gap: 16px; flex-wrap: wrap; margin-bottom: 20px; border-bottom: 1px solid var(--border); }
 .ip-pm-tabbar > .ip-tabs { margin-bottom: 0; border-bottom: 0; }
 .ip-pm-tabbar > .ip-rel-controls { padding-bottom: 8px; }
+/* Three tenancy metrics share the KPI card treatment; only the column count
+   differs from the four-up grid it borrows from. */
+.ip-kpi-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 720px) { .ip-kpi-3 { grid-template-columns: 1fr; } }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1643,6 +1643,32 @@ const Views = (function () {
     return '<div class="ip-tn-facetgroup"><p class="ip-tn-facettitle">' + escHtml(title) + '</p>' + rows + '</div>';
   }
 
+  // Three facts about the shape of the tenancy that the table cannot show,
+  // because each is a property of the whole list rather than of a row.
+  function _tenantMetrics(m) {
+    const k = m.metrics;
+    if (!k) return '';
+    const card = (label, value, sub) => '<section class="ip-card">'
+      + '<h4>' + escHtml(label) + '</h4>'
+      + '<div class="ip-big">' + value.toLocaleString() + '</div>'
+      + (sub ? '<p class="ip-sub">' + escHtml(sub) + '</p>' : '')
+      + '</section>';
+    return '<div class="ip-grid ip-kpi-grid ip-kpi-3">'
+      + card('Tenants in environments', k.inEnvironments,
+          k.environmentConnections.toLocaleString() + ' tenant-environment '
+          + (k.environmentConnections === 1 ? 'connection' : 'connections')
+          + (k.inEnvironments === k.countedOver ? '' : ', ' + (k.countedOver - k.inEnvironments) + ' connected to none'))
+      + card('Tenant tags in use', k.tagValues,
+          k.tagSetsInUse + (k.tagSetsInUse === 1 ? ' tag set' : ' tag sets'))
+      + card('Most projects on one tenant', k.maxProjects,
+          k.maxProjectsTenant || 'no tenant is connected to a project')
+      + '</div>'
+      // Counted over what was read, which is not always everything.
+      + (k.partial ? '<p class="ip-rel-hnote-inline">These are counted over the first '
+          + k.countedOver.toLocaleString() + ' tenants read, not all ' + m.total.toLocaleString()
+          + '.</p>' : '');
+  }
+
   function renderTenants(IP) {
     const st = IP.tenants || { status: 'idle' };
     const head = '<header class="ip-head"><h2>Tenants</h2>'
@@ -1735,6 +1761,7 @@ const Views = (function () {
     }));
 
     return head
+      + _tenantMetrics(m)
       + '<div class="ip-tn-toolbar">'
       +   '<input class="ip-search ip-tn-search" type="search" data-ctl="tenant-search"'
       +     ' placeholder="Search tenants…" value="' + escHtml(IP.tenantQuery) + '">'

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1380,6 +1380,52 @@ const Views = (function () {
       + changeBand + varBand);
   }
 
+  // Every redraw in this dashboard replaces the whole of #main-content, which
+  // destroys focus. A keyboard user who activates a project row, a sort header
+  // or a tab is returned to document.body, so the next Tab restarts at the top
+  // of the page. These re-find the same control afterwards and put focus back.
+  const FOCUS_KEYS = ['data-project', 'data-sort', 'data-facet', 'data-value', 'data-page',
+    'data-window', 'data-grouping', 'data-envtoggle', 'data-tenanttab', 'data-projecttab',
+    'data-tab', 'data-projectlink'];
+
+  function _cssEscape(value) {
+    const raw = String(value == null ? '' : value);
+    return (typeof CSS !== 'undefined' && CSS && typeof CSS.escape === 'function')
+      ? CSS.escape(raw) : raw.replace(/["\\]/g, '\\$&');
+  }
+
+  /** A selector that finds the same control again after the markup is rebuilt,
+   *  or null when the element has nothing stable to identify it by. */
+  function focusSelector(el) {
+    if (!el || !el.getAttribute || (typeof document !== 'undefined' && el === document.body)) return null;
+    if (el.id) return '#' + _cssEscape(el.id);
+    const parts = FOCUS_KEYS.filter(a => el.hasAttribute(a))
+      .map(a => '[' + a + '="' + _cssEscape(el.getAttribute(a)) + '"]');
+    if (!parts.length) return null;
+    return (el.tagName || '').toLowerCase() + parts.join('');
+  }
+
+  /** Redraws while keeping focus, and the caret, where the user left it. */
+  function withFocus(root, redraw) {
+    const active = document.activeElement;
+    const inside = active && root.contains && root.contains(active);
+    const selector = inside ? focusSelector(active) : null;
+    // Only text fields have a caret worth restoring.
+    let caret = null;
+    try {
+      if (inside && active.selectionStart != null) caret = { start: active.selectionStart, end: active.selectionEnd };
+    } catch (e) { caret = null; }
+    redraw();
+    if (!selector) return;
+    let again = null;
+    try { again = root.querySelector(selector); } catch (e) { again = null; }
+    if (!again) return;
+    again.focus();
+    if (caret && again.setSelectionRange) {
+      try { again.setSelectionRange(caret.start, caret.end); } catch (e) { /* not a text field */ }
+    }
+  }
+
   // The window/grouping controls, the legend and the environment header are the
   // same on the projects list and on one project's Status tab. One copy each.
   function _relControls(IP) {
@@ -1493,7 +1539,9 @@ const Views = (function () {
   function bindProjects(IP) {
     const root = document.getElementById('main-content');
     if (!root) return;
-    _bindRelRows(IP, root, () => { root.innerHTML = renderProjects(IP); bindProjects(IP); });
+    _bindRelRows(IP, root, () => withFocus(root, () => {
+      root.innerHTML = renderProjects(IP); bindProjects(IP);
+    }));
   }
 
   // Expanding a row, hiding an environment, changing the window or the grouping
@@ -1717,7 +1765,7 @@ const Views = (function () {
   function bindTenants(IP) {
     const root = document.getElementById('main-content');
     if (!root) return;
-    const redraw = () => { root.innerHTML = renderTenants(IP); bindTenants(IP); };
+    const redraw = () => withFocus(root, () => { root.innerHTML = renderTenants(IP); bindTenants(IP); });
     const search = root.querySelector('.ip-tn-search');
     if (search) search.addEventListener('input', () => {
       IP.tenantQuery = search.value; IP.tenantPage = 0;
@@ -1848,8 +1896,7 @@ const Views = (function () {
     root.querySelectorAll('[data-tenanttab]').forEach(btn => {
       btn.addEventListener('click', () => {
         IP.tenantTab = btn.getAttribute('data-tenanttab');
-        root.innerHTML = renderTenantDetail(IP);
-        bindTenantDetail(IP);
+        withFocus(root, () => { root.innerHTML = renderTenantDetail(IP); bindTenantDetail(IP); });
       });
     });
   }
@@ -2156,7 +2203,7 @@ const Views = (function () {
   function bindProjectMap(IP) {
     const root = document.getElementById('main-content');
     if (!root) return;
-    const redraw = () => { root.innerHTML = renderProjectMap(IP); bindProjectMap(IP); };
+    const redraw = () => withFocus(root, () => { root.innerHTML = renderProjectMap(IP); bindProjectMap(IP); });
     root.querySelectorAll('[data-projecttab]').forEach(btn => {
       btn.addEventListener('click', () => {
         IP.projectTab = btn.getAttribute('data-projecttab');
@@ -2513,6 +2560,7 @@ const Views = (function () {
     if (!el) return;
     el.addEventListener('change', async e => {
       IP.spaceId = e.target.value;
+      if (typeof Data !== 'undefined' && Data.clearMachineCache) Data.clearMachineCache();
       IP.filters = {}; IP.search = ''; IP.page = 1;
       IP.wFilters = {}; IP.wSearch = ''; IP.wPage = 1;
       IP.envExpanded = {};
@@ -2537,7 +2585,7 @@ const Views = (function () {
   return { escHtml, stateView, renderProjects, bindProjects, renderTenants, bindTenants, renderTenantDetail, bindTenantDetail, renderProjectMap, bindProjectMap, renderOverview, renderTargets, bindTargets, renderTargetDetail, bindTargetDetail, fillTargetDetail, renderTargetsZero, renderWorkersZero, deploymentsCardHtml, runbooksCardHtml, connectivityCardHtml, eventsCardHtml,
     renderEnvironments, bindEnvironments, filterEnvTargets, renderMachinePolicies, renderWorkers, bindWorkers,
     renderAgents, bindAgents, renderArgo, renderAddTarget, bindAddTarget,
-    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch, spaceSwitchNav,
+    pill, chip, healthBar, donut, heatCell, renderSpaceSwitch, bindSpaceSwitch, spaceSwitchNav, focusSelector, withFocus,
     renderThemeToggle, bindThemeToggle };
 })();
 if (typeof module !== 'undefined') { module.exports = Views; }

--- a/dashboards/infrastructureprealpha/views.js
+++ b/dashboards/infrastructureprealpha/views.js
@@ -1104,7 +1104,8 @@ const Views = (function () {
       + ' aria-expanded="' + (expanded ? 'true' : 'false') + '" data-project="' + escHtml(proj.id) + '">'
       + '<div class="ip-rel-proj">'
       +   '<span class="ip-rel-caret" aria-hidden="true"></span>'
-      +   '<a class="ip-rel-proj-name" href="#projects/' + escHtml(proj.id) + '" data-projectlink="1">'
+      +   '<a class="ip-rel-proj-name" href="#projects/' + escHtml(proj.id) + '"'
+      +     ' data-projectlink="' + escHtml(proj.id) + '">'
       +     escHtml(proj.name) + '</a>'
       + '</div>'
       + _relTrack(cells, cols)
@@ -1384,9 +1385,14 @@ const Views = (function () {
   // destroys focus. A keyboard user who activates a project row, a sort header
   // or a tab is returned to document.body, so the next Tab restarts at the top
   // of the page. These re-find the same control afterwards and put focus back.
-  const FOCUS_KEYS = ['data-project', 'data-sort', 'data-facet', 'data-value', 'data-page',
+  // Every key here has to identify one element and keep identifying it after the
+  // rebuild. data-page was in this list and could not: its value is relative to
+  // the current page, so paging always missed. data-projectlink was worse — it
+  // was emitted as a constant, so it matched the first row rather than the
+  // focused one.
+  const FOCUS_KEYS = ['data-project', 'data-sort', 'data-facet', 'data-value', 'data-ctl',
     'data-window', 'data-grouping', 'data-envtoggle', 'data-tenanttab', 'data-projecttab',
-    'data-tab', 'data-projectlink'];
+    'data-tab', 'data-pager', 'data-projectlink'];
 
   function _cssEscape(value) {
     const raw = String(value == null ? '' : value);
@@ -1420,7 +1426,9 @@ const Views = (function () {
     let again = null;
     try { again = root.querySelector(selector); } catch (e) { again = null; }
     if (!again) return;
-    again.focus();
+    // preventScroll where it is supported: restoring focus should not move the
+    // viewport out from under someone.
+    try { again.focus({ preventScroll: true }); } catch (e) { again.focus(); }
     if (caret && again.setSelectionRange) {
       try { again.setSelectionRange(caret.start, caret.end); } catch (e) { /* not a text field */ }
     }
@@ -1564,6 +1572,9 @@ const Views = (function () {
     root.querySelectorAll('.ip-rel-row[data-project]').forEach(el => {
       el.addEventListener('click', () => toggle(el));
       el.addEventListener('keydown', ev => {
+        // The project name is a link inside the row. Enter on it should follow
+        // the link; only the row itself toggles.
+        if (ev.target !== el) return;
         if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); toggle(el); }
       });
     });
@@ -1725,8 +1736,10 @@ const Views = (function () {
 
     return head
       + '<div class="ip-tn-toolbar">'
-      +   '<input class="ip-search ip-tn-search" type="search" placeholder="Search tenants…" value="' + escHtml(IP.tenantQuery) + '">'
-      +   '<label class="ip-tn-sort"><span class="ip-caption">Sort</span><select class="ip-tn-sortsel">' + sorts + '</select></label>'
+      +   '<input class="ip-search ip-tn-search" type="search" data-ctl="tenant-search"'
+      +     ' placeholder="Search tenants…" value="' + escHtml(IP.tenantQuery) + '">'
+      +   '<label class="ip-tn-sort"><span class="ip-caption">Sort</span>'
+      +     '<select class="ip-tn-sortsel" data-ctl="tenant-sort">' + sorts + '</select></label>'
       +   '<span class="ip-count">' + sorted.length.toLocaleString()
       +     (sorted.length === m.tenants.length ? '' : ' of ' + m.tenants.length.toLocaleString())
       +     (sorted.length === 1 ? ' tenant' : ' tenants') + '</span>'
@@ -1747,9 +1760,9 @@ const Views = (function () {
           : '<div class="ip-empty"><h3>No tenants match these filters</h3>'
             + '<p>Clear a filter or search for a different name.</p></div>')
       +     (pages > 1 ? '<div class="ip-tn-pager">'
-            + '<button class="ip-btn ip-btn-secondary" data-page="' + (page - 1) + '"' + (page === 0 ? ' disabled' : '') + '>Previous</button>'
+            + '<button class="ip-btn ip-btn-secondary" data-pager="prev" data-page="' + (page - 1) + '"' + (page === 0 ? ' disabled' : '') + '>Previous</button>'
             + '<span class="ip-tn-age">Page ' + (page + 1) + ' of ' + pages + '</span>'
-            + '<button class="ip-btn ip-btn-secondary" data-page="' + (page + 1) + '"' + (page >= pages - 1 ? ' disabled' : '') + '>Next</button>'
+            + '<button class="ip-btn ip-btn-secondary" data-pager="next" data-page="' + (page + 1) + '"' + (page >= pages - 1 ? ' disabled' : '') + '>Next</button>'
             + '</div>' : '')
       +   '</div>'
       + '</div>'
@@ -1770,8 +1783,6 @@ const Views = (function () {
     if (search) search.addEventListener('input', () => {
       IP.tenantQuery = search.value; IP.tenantPage = 0;
       redraw();
-      const again = root.querySelector('.ip-tn-search');
-      if (again) { again.focus(); again.setSelectionRange(again.value.length, again.value.length); }
     });
     const sort = root.querySelector('.ip-tn-sortsel');
     if (sort) sort.addEventListener('change', () => {
@@ -2560,7 +2571,7 @@ const Views = (function () {
     if (!el) return;
     el.addEventListener('change', async e => {
       IP.spaceId = e.target.value;
-      if (typeof Data !== 'undefined' && Data.clearMachineCache) Data.clearMachineCache();
+      if (typeof Data !== 'undefined' && Data.clearMachineCache) Data.clearMachineCache(IP.spaceId);
       IP.filters = {}; IP.search = ''; IP.page = 1;
       IP.wFilters = {}; IP.wSearch = ''; IP.wPage = 1;
       IP.envExpanded = {};


### PR DESCRIPTION
Follow-up to #34, plus three metrics on the tenants list.

Two cold reviews were run against #34 before it merged — one against `.github/copilot-instructions.md`, one on correctness — with the reviewers told to break the description's claims rather than confirm them. The false-claim findings were fixed in #34; [these five were recorded and left](https://github.com/OctopusSolutionsEngineering/OctoAIChromeExtension/pull/34#issuecomment-5321133446). A third cold review was run against the first attempt at them here, and [found the fix applied at the wrong layer plus one regression](https://github.com/OctopusSolutionsEngineering/OctoAIChromeExtension/pull/35#issuecomment-5323197259). Both rounds are in this branch.

## Focus survives a redraw

Every redraw replaces the whole of `#main-content`, so a keyboard user who activated a project row, a sort header, a facet checkbox or a tab was returned to `document.body` — the next Tab restarted at the top of the page. Only the tenants search box restored itself, and it forced the caret to the end of the value. Since the tab buttons are the primary navigation on both detail pages, this was an operability defect rather than a nit.

`Router.render()` now wraps the routed render in `withFocus`, which identifies the control by the data attribute it is already addressed by, re-finds it after the rebuild, and restores the caret where there is one. The views wrap their own local redraws the same way.

The first attempt wrapped only the four view-internal redraws, which missed the thirteen `innerHTML` writes in the router that every async callback ends in — the case the fix existed for. Three attribute keys also had to change to be usable as identity: `data-projectlink` was emitted as the constant `"1"` (so the selector matched the first project's link, not the focused one), `data-page` moves with the current page, and the tenant search and sort carried nothing at all. A control the redraw legitimately removed is left alone rather than guessed at, and `focus()` asks for `preventScroll`.

Enter on a project-name link also toggled the row behind it: the row's keydown handler had no target check, and `stopPropagation` was bound only for `click`.

## A late callback no longer tears down the page you are on

Every loader guarded on the space but not on the view, and resolved by calling the global `render()`. Expanding a project fires three requests; navigating to Tenants and starting to type meant the DOM was replaced under the cursor when one landed, and the rest of the keystrokes went nowhere.

Loaders now record the section they were fired for and redraw only if you are still on it. The fetched state is stored either way, so coming back finds it ready rather than re-requesting. `baseView` is a pure function in `data.js` so this logic is testable, which it was not when it lived inline in the router.

## Tenant detail could pair a tenant with another space's dashboard

The staleness check on the tenant route included the space id; the check that reuses the tenants list's cached dashboard did not. View tenants in one space, switch, open a tenant in the new space, and the tenant was paired with the previous space's deployments: raw project ids instead of names, every matrix cell reading never deployed, and the readiness card marking every template unproven off the back of it.

## The machine list is cached per space

Ten paged requests at worst, wanted by both the tenant page and the project map, and cached by neither — browsing twenty tenants re-paged the whole estate twenty times. Cached per space for two minutes, stamped on completion rather than on the first request, since the paging can outlive its own window behind the throttle and a second caller would start the run again. A read still in flight is joined whatever its age. A failed read is never remembered as the answer. Clearing takes a space id, because clearing every space on a switch re-paged the one you came from if you went back.

## A collapsed project row stays collapsed

The project route defaulted the row open on every render rather than on the first, so collapsing it and waiting for either in-flight request sprang it back open — twice, once per request.

## Three metrics on the tenants list

The table answers questions about one tenant at a time; these are properties of the whole list, so no row can carry them.

- **Tenants in environments**, with the tenant-environment connection count and how many tenants connect to nothing. A tenant reached by two projects in one environment is one connection, not two — the pair count is a different number and already on the row.
- **Tenant tags in use**, counted distinctly, with the number of tag sets they come from.
- **Most projects on one tenant**, and which tenant that is.

All three come from the tenant payload rather than the project dashboard, so the dashboard's project cap does not distort them. The tenant list's own page limit does, and the cards say what they were counted over whenever the list was truncated. They reuse the KPI card treatment from the agents view; the only new CSS is the column count.

## Against the review checklist

No change to the security surface. Still read-only, still no external calls or resources, no new API loops — the one addition is a cache that removes requests. No `eval`, no iframes, no Chrome APIs, no `manifest.json` change. The new state is an in-memory cache keyed by space id, not local storage.

## Verification

Tests 490 → 517. The third cold review's findings are all addressed, including the test defects it found: the escaping test asserted the fallback branch because `testEnvironment` is node and `CSS.escape` never exists there, while Chrome always has it — both branches are covered now, and the markup is asserted to carry the identities the selectors depend on.

**The focus behaviour still wants a keyboard pass in the loaded extension.** Everything here is exercised against a stubbed `document`, which is what produced the wrong-layer fix in the first place.
